### PR TITLE
Update GH Actions to run on main

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,10 +16,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "main" ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "master" ]
+    branches: [ "main" ]
   schedule:
     - cron: '41 18 * * 3'
 

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -6,7 +6,7 @@ name: Static Analysis
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 
 jobs:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -6,7 +6,7 @@ name: Unit Tests
 on:
   push:
     branches:
-      - master
+      - main
     tags:
       - "*"
   pull_request:


### PR DESCRIPTION
This PR updates GitHub Actions to run on the default main branch instead of master.