### PR TITLE
docs: Add BSD-3 license badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 <p align="center">
   <a href="https://github.com/ava-labs/hypersdk/actions/workflows/unit-tests.yml"><img src="https://github.com/ava-labs/hypersdk/actions/workflows/unit-tests.yml/badge.svg" /></a>
   <a href="https://github.com/ava-labs/hypersdk/actions/workflows/static-analysis.yml"><img src="https://github.com/ava-labs/hypersdk/actions/workflows/static-analysis.yml/badge.svg" /></a>
+  <a href="https://github.com/ava-labs/hypersdk/blob/main/LICENSE"><img src="https://img.shields.io/github/license/ava-labs/hypersdk" /></a>
 </p>
 
 The freedom to create your own [Virtual Machine (VM)](https://docs.avax.network/subnets#virtual-machines),


### PR DESCRIPTION
Adds a BSD-3 badge to the README. The badge is both stylish and also let's users know the license of the project right away.

<img width="621" alt="image" src="https://user-images.githubusercontent.com/31546601/220199687-97b575f9-1e28-49de-82f8-131e1fcdceaa.png">

Signed-off-by: Dan Sover <dan.sover@avalabs.org>
