### PR TITLE
docs: Add minimum go version to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,8 @@ To use the `hypersdk`, you must import it into your own `hypervm` and implement 
 required interfaces. Below, we'll cover some of the ones that your
 `hypervm` must implement.
 
+> *Note: hypersdk requires a minimum Go version of 1.19.*
+
 ### Controller
 ```golang
 type Controller interface {


### PR DESCRIPTION
Adds the minimum Go version required for hypersdk to run successfully. Users may need to upgrade their existing Go installation to use hypersdk successfully. 

Signed-off-by: Dan Sover <dan.sover@avalabs.org>
