### PR TITLE
[mempool] Use generics instead of `mempool.Item`

### DIFF
--- a/chain/dependencies.go
+++ b/chain/dependencies.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ava-labs/avalanchego/x/merkledb"
 
 	"github.com/ava-labs/hypersdk/codec"
-	"github.com/ava-labs/hypersdk/mempool"
 	"github.com/ava-labs/hypersdk/workers"
 )
 
@@ -61,7 +60,7 @@ type VM interface {
 
 type Mempool interface {
 	Len(context.Context) int
-	Add(context.Context, []mempool.Item)
+	Add(context.Context, []*Transaction)
 	Build(
 		context.Context,
 		func(context.Context, *Transaction) (bool /* continue */, bool /* restore */, bool /* remove account */, error),

--- a/chain/transaction.go
+++ b/chain/transaction.go
@@ -17,8 +17,10 @@ import (
 	"github.com/ava-labs/hypersdk/utils"
 )
 
-var _ emap.Item = (*Transaction)(nil)
-var _ mempool.Item = (*Transaction)(nil)
+var (
+	_ emap.Item    = (*Transaction)(nil)
+	_ mempool.Item = (*Transaction)(nil)
+)
 
 type Transaction struct {
 	Base   *Base  `json:"base"`

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -19,8 +19,8 @@ type Mempool[T Item] struct {
 	maxSize      int
 	maxPayerSize int // Maximum items allowed by a single payer
 
-	pm *SortedMempool // Price Mempool
-	tm *SortedMempool // Time Mempool
+	pm *SortedMempool[T] // Price Mempool
+	tm *SortedMempool[T] // Time Mempool
 
 	// [Owned] used to remove all items from an account when the balance is
 	// insufficient
@@ -44,11 +44,11 @@ func New[T Item](
 		maxSize:      maxSize,
 		maxPayerSize: maxPayerSize,
 
-		pm: NewSortedMempool(
+		pm: NewSortedMempool[T](
 			maxSize, /* pre-allocate total size */
 			func(item T) uint64 { return item.UnitPrice() },
 		),
-		tm: NewSortedMempool(
+		tm: NewSortedMempool[T](
 			maxSize, /* pre-allocate total size */
 			func(item T) uint64 { return uint64(item.Expiry()) },
 		),
@@ -121,7 +121,7 @@ func (th *Mempool[T]) Add(ctx context.Context, items []T) {
 		// Remove the lowest paying item if at global max
 		if th.pm.Len() > th.maxSize {
 			// Remove the lowest paying item
-			lowItem := th.pm.PopMin()
+			lowItem, _ := th.pm.PopMin()
 			th.tm.Remove(lowItem.ID())
 			th.removeFromOwned(lowItem)
 		}
@@ -130,7 +130,7 @@ func (th *Mempool[T]) Add(ctx context.Context, items []T) {
 
 // PeekMax returns the highest valued item in th.pm.
 // Assumes there is non-zero items in [Mempool]
-func (th *Mempool[T]) PeekMax(ctx context.Context) T {
+func (th *Mempool[T]) PeekMax(ctx context.Context) (T, bool) {
 	_, span := th.tracer.Start(ctx, "Mempool.PeekMax")
 	defer span.End()
 
@@ -142,7 +142,7 @@ func (th *Mempool[T]) PeekMax(ctx context.Context) T {
 
 // PeekMin returns the lowest valued item in th.pm.
 // Assumes there is non-zero items in [Mempool]
-func (th *Mempool[T]) PeekMin(ctx context.Context) T {
+func (th *Mempool[T]) PeekMin(ctx context.Context) (T, bool) {
 	_, span := th.tracer.Start(ctx, "Mempool.PeekMin")
 	defer span.End()
 
@@ -154,32 +154,36 @@ func (th *Mempool[T]) PeekMin(ctx context.Context) T {
 
 // PopMax removes and returns the highest valued item in th.pm.
 // Assumes there is non-zero items in [Mempool]
-func (th *Mempool[T]) PopMax(ctx context.Context) T { // O(log N)
+func (th *Mempool[T]) PopMax(ctx context.Context) (T, bool) { // O(log N)
 	_, span := th.tracer.Start(ctx, "Mempool.PopMax")
 	defer span.End()
 
 	th.mu.Lock()
 	defer th.mu.Unlock()
 
-	max := th.pm.PopMax()
-	th.tm.Remove(max.ID())
-	th.removeFromOwned(max)
-	return max
+	max, ok := th.pm.PopMax()
+	if ok {
+		th.tm.Remove(max.ID())
+		th.removeFromOwned(max)
+	}
+	return max, ok
 }
 
 // PopMin removes and returns the lowest valued item in th.pm.
 // Assumes there is non-zero items in [Mempool]
-func (th *Mempool[T]) PopMin(ctx context.Context) T { // O(log N)
+func (th *Mempool[T]) PopMin(ctx context.Context) (T, bool) { // O(log N)
 	_, span := th.tracer.Start(ctx, "Mempool.PopMin")
 	defer span.End()
 
 	th.mu.Lock()
 	defer th.mu.Unlock()
 
-	min := th.pm.PopMin()
-	th.tm.Remove(min.ID())
-	th.removeFromOwned(min)
-	return min
+	min, ok := th.pm.PopMin()
+	if ok {
+		th.tm.Remove(min.ID())
+		th.removeFromOwned(min)
+	}
+	return min, ok
 }
 
 // Remove removes [items] from th.
@@ -263,7 +267,7 @@ func (th *Mempool[T]) Build(
 	restorableItems := []T{}
 	var err error
 	for th.pm.Len() > 0 {
-		max := th.pm.PopMax()
+		max, _ := th.pm.PopMax()
 		cont, restore, removeAccount, fErr := f(ctx, max)
 		if restore {
 			// Waiting to restore unused transactions ensures that an account will be

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -11,18 +11,18 @@ import (
 	"github.com/ava-labs/avalanchego/trace"
 )
 
-type Mempool struct {
+type Mempool[T Item] struct {
 	tracer trace.Tracer
 
 	mu sync.RWMutex
 
 	maxSize      int
-	maxPayerSize int // Maximum txs allowed by a single payer
+	maxPayerSize int // Maximum items allowed by a single payer
 
 	pm *SortedMempool // Price Mempool
 	tm *SortedMempool // Time Mempool
 
-	// [Owned] used to remove all txs from an account when the balance is
+	// [Owned] used to remove all items from an account when the balance is
 	// insufficient
 	owned map[string]map[ids.ID]struct{}
 
@@ -32,8 +32,13 @@ type Mempool struct {
 
 // New creates a new [Mempool]. [maxSize] must be > 0 or else the
 // implementation may panic.
-func New(tracer trace.Tracer, maxSize int, maxPayerSize int, exemptPayers [][]byte) *Mempool {
-	m := &Mempool{
+func New[T Item](
+	tracer trace.Tracer,
+	maxSize int,
+	maxPayerSize int,
+	exemptPayers [][]byte,
+) *Mempool[T] {
+	m := &Mempool[T]{
 		tracer: tracer,
 
 		maxSize:      maxSize,
@@ -41,11 +46,11 @@ func New(tracer trace.Tracer, maxSize int, maxPayerSize int, exemptPayers [][]by
 
 		pm: NewSortedMempool(
 			maxSize, /* pre-allocate total size */
-			func(tx Item) uint64 { return tx.UnitPrice() },
+			func(item T) uint64 { return item.UnitPrice() },
 		),
 		tm: NewSortedMempool(
 			maxSize, /* pre-allocate total size */
-			func(tx Item) uint64 { return uint64(tx.Expiry()) },
+			func(item T) uint64 { return uint64(item.Expiry()) },
 		),
 		owned:        map[string]map[ids.ID]struct{}{},
 		exemptPayers: map[string]struct{}{},
@@ -56,45 +61,45 @@ func New(tracer trace.Tracer, maxSize int, maxPayerSize int, exemptPayers [][]by
 	return m
 }
 
-func (th *Mempool) removeFromOwned(tx Item) {
-	sender := tx.Payer()
+func (th *Mempool[T]) removeFromOwned(item T) {
+	sender := item.Payer()
 	acct, ok := th.owned[sender]
 	if !ok {
 		// May no longer be populated
 		return
 	}
-	delete(acct, tx.ID())
+	delete(acct, item.ID())
 	if len(acct) == 0 {
 		delete(th.owned, sender)
 	}
 }
 
-// Has returns if the pm of [th] contains [txID]
-func (th *Mempool) Has(ctx context.Context, txID ids.ID) bool {
+// Has returns if the pm of [th] contains [itemID]
+func (th *Mempool[T]) Has(ctx context.Context, itemID ids.ID) bool {
 	_, span := th.tracer.Start(ctx, "Mempool.Has")
 	defer span.End()
 
 	th.mu.Lock()
 	defer th.mu.Unlock()
-	return th.pm.Has(txID)
+	return th.pm.Has(itemID)
 }
 
-// Add pushes all new txs from [txs] to th. Does not add a tx if
-// the tx payer is not exempt and their txs in the mempool exceed th.maxPayerSize.
+// Add pushes all new items from [items] to th. Does not add a item if
+// the item payer is not exempt and their items in the mempool exceed th.maxPayerSize.
 // If the size of th exceeds th.maxSize, Add pops the lowest value item
 // from th.pm.
-func (th *Mempool) Add(ctx context.Context, txs []Item) {
+func (th *Mempool[T]) Add(ctx context.Context, items []T) {
 	_, span := th.tracer.Start(ctx, "Mempool.Add")
 	defer span.End()
 
 	th.mu.Lock()
 	defer th.mu.Unlock()
 
-	for _, tx := range txs {
-		sender := tx.Payer()
+	for _, item := range items {
+		sender := item.Payer()
 
 		// Ensure no duplicate
-		if th.pm.Has(tx.ID()) {
+		if th.pm.Has(item.ID()) {
 			// Don't drop because already exists
 			continue
 		}
@@ -107,25 +112,25 @@ func (th *Mempool) Add(ctx context.Context, txs []Item) {
 		}
 		_, exempt := th.exemptPayers[sender]
 		if !exempt && len(acct) == th.maxPayerSize {
-			continue // do nothing, wait for txs to expire
+			continue // do nothing, wait for items to expire
 		}
-		th.pm.Add(tx)
-		th.tm.Add(tx)
-		acct[tx.ID()] = struct{}{}
+		th.pm.Add(item)
+		th.tm.Add(item)
+		acct[item.ID()] = struct{}{}
 
-		// Remove the lowest paying tx if at global max
+		// Remove the lowest paying item if at global max
 		if th.pm.Len() > th.maxSize {
-			// Remove the lowest paying tx
-			lowTx := th.pm.PopMin()
-			th.tm.Remove(lowTx.ID())
-			th.removeFromOwned(lowTx)
+			// Remove the lowest paying item
+			lowItem := th.pm.PopMin()
+			th.tm.Remove(lowItem.ID())
+			th.removeFromOwned(lowItem)
 		}
 	}
 }
 
 // PeekMax returns the highest valued item in th.pm.
 // Assumes there is non-zero items in [Mempool]
-func (th *Mempool) PeekMax(ctx context.Context) Item {
+func (th *Mempool[T]) PeekMax(ctx context.Context) T {
 	_, span := th.tracer.Start(ctx, "Mempool.PeekMax")
 	defer span.End()
 
@@ -137,7 +142,7 @@ func (th *Mempool) PeekMax(ctx context.Context) Item {
 
 // PeekMin returns the lowest valued item in th.pm.
 // Assumes there is non-zero items in [Mempool]
-func (th *Mempool) PeekMin(ctx context.Context) Item {
+func (th *Mempool[T]) PeekMin(ctx context.Context) T {
 	_, span := th.tracer.Start(ctx, "Mempool.PeekMin")
 	defer span.End()
 
@@ -149,7 +154,7 @@ func (th *Mempool) PeekMin(ctx context.Context) Item {
 
 // PopMax removes and returns the highest valued item in th.pm.
 // Assumes there is non-zero items in [Mempool]
-func (th *Mempool) PopMax(ctx context.Context) Item { // O(log N)
+func (th *Mempool[T]) PopMax(ctx context.Context) T { // O(log N)
 	_, span := th.tracer.Start(ctx, "Mempool.PopMax")
 	defer span.End()
 
@@ -164,7 +169,7 @@ func (th *Mempool) PopMax(ctx context.Context) Item { // O(log N)
 
 // PopMin removes and returns the lowest valued item in th.pm.
 // Assumes there is non-zero items in [Mempool]
-func (th *Mempool) PopMin(ctx context.Context) Item { // O(log N)
+func (th *Mempool[T]) PopMin(ctx context.Context) T { // O(log N)
 	_, span := th.tracer.Start(ctx, "Mempool.PopMin")
 	defer span.End()
 
@@ -177,25 +182,25 @@ func (th *Mempool) PopMin(ctx context.Context) Item { // O(log N)
 	return min
 }
 
-// Remove removes [txs] from th.
-func (th *Mempool) Remove(ctx context.Context, txs []Item) {
+// Remove removes [items] from th.
+func (th *Mempool[T]) Remove(ctx context.Context, items []T) {
 	_, span := th.tracer.Start(ctx, "Mempool.Remove")
 	defer span.End()
 
 	th.mu.Lock()
 	defer th.mu.Unlock()
 
-	for _, tx := range txs {
-		th.pm.Remove(tx.ID())
-		th.tm.Remove(tx.ID())
-		th.removeFromOwned(tx)
+	for _, item := range items {
+		th.pm.Remove(item.ID())
+		th.tm.Remove(item.ID())
+		th.removeFromOwned(item)
 		// Remove is called when verifying a block. We should not drop transactions at
 		// this time.
 	}
 }
 
-// Len returns the number of txs in th.
-func (th *Mempool) Len(ctx context.Context) int {
+// Len returns the number of items in th.
+func (th *Mempool[T]) Len(ctx context.Context) int {
 	_, span := th.tracer.Start(ctx, "Mempool.Len")
 	defer span.End()
 
@@ -205,8 +210,8 @@ func (th *Mempool) Len(ctx context.Context) int {
 	return th.pm.Len()
 }
 
-// RemoveAccount removes all txs by [sender] from th.
-func (th *Mempool) RemoveAccount(ctx context.Context, sender string) {
+// RemoveAccount removes all items by [sender] from th.
+func (th *Mempool[T]) RemoveAccount(ctx context.Context, sender string) {
 	_, span := th.tracer.Start(ctx, "Mempool.RemoveAccount")
 	defer span.End()
 
@@ -216,21 +221,21 @@ func (th *Mempool) RemoveAccount(ctx context.Context, sender string) {
 	th.removeAccount(sender)
 }
 
-func (th *Mempool) removeAccount(sender string) {
+func (th *Mempool[T]) removeAccount(sender string) {
 	acct, ok := th.owned[sender]
 	if !ok {
 		return
 	}
-	for tx := range acct {
-		th.pm.Remove(tx)
-		th.tm.Remove(tx)
+	for item := range acct {
+		th.pm.Remove(item)
+		th.tm.Remove(item)
 	}
 	delete(th.owned, sender)
 }
 
-// SetMinTimestamp removes all txs with a lower expiry than [t] from th.
-// SetMinTimestamp returns the list of removed txs.
-func (th *Mempool) SetMinTimestamp(ctx context.Context, t int64) []Item {
+// SetMinTimestamp removes all items with a lower expiry than [t] from th.
+// SetMinTimestamp returns the list of removed items.
+func (th *Mempool[T]) SetMinTimestamp(ctx context.Context, t int64) []T {
 	_, span := th.tracer.Start(ctx, "Mempool.SetMinTimesamp")
 	defer span.End()
 
@@ -245,9 +250,9 @@ func (th *Mempool) SetMinTimestamp(ctx context.Context, t int64) []Item {
 	return removed
 }
 
-func (th *Mempool) Build(
+func (th *Mempool[T]) Build(
 	ctx context.Context,
-	f func(context.Context, Item) (cont bool, restore bool, removeAcct bool, err error),
+	f func(context.Context, T) (cont bool, restore bool, removeAcct bool, err error),
 ) error {
 	ctx, span := th.tracer.Start(ctx, "Mempool.Build")
 	defer span.End()
@@ -255,7 +260,7 @@ func (th *Mempool) Build(
 	th.mu.Lock()
 	defer th.mu.Unlock()
 
-	restorableTxs := []Item{}
+	restorableItems := []T{}
 	var err error
 	for th.pm.Len() > 0 {
 		max := th.pm.PopMax()
@@ -263,7 +268,7 @@ func (th *Mempool) Build(
 		if restore {
 			// Waiting to restore unused transactions ensures that an account will be
 			// excluded from future price mempool iterations
-			restorableTxs = append(restorableTxs, max)
+			restorableItems = append(restorableItems, max)
 		} else {
 			th.tm.Remove(max.ID())
 			th.removeFromOwned(max)
@@ -279,9 +284,9 @@ func (th *Mempool) Build(
 		}
 	}
 	//
-	// Restore unused txs
-	for _, tx := range restorableTxs {
-		th.pm.Add(tx)
+	// Restore unused items
+	for _, item := range restorableItems {
+		th.pm.Add(item)
 	}
 	return err
 }

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -29,9 +29,9 @@ func TestMempool(t *testing.T) {
 	max, ok := txm.PeekMax(ctx)
 	require.True(ok)
 	require.Equal(uint64(400), max.UnitPrice())
-	max, ok = txm.PeekMax(ctx)
+	min, ok := txm.PeekMin(ctx)
 	require.True(ok)
-	require.Equal(uint64(200), max.UnitPrice())
+	require.Equal(uint64(200), min.UnitPrice())
 	require.Equal(3, txm.Len(ctx))
 }
 

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -19,15 +19,19 @@ func TestMempool(t *testing.T) {
 
 	ctx := context.TODO()
 	tracer, _ := trace.New(&trace.Config{Enabled: false})
-	txm := New(tracer, 3, 16, nil)
+	txm := New[*MempoolTestItem](tracer, 3, 16, nil)
 
 	for _, i := range []uint64{100, 200, 300, 400} {
 		item := GenerateTestItem(testPayer, 1, i)
-		items := []Item{item}
+		items := []*MempoolTestItem{item}
 		txm.Add(ctx, items)
 	}
-	require.Equal(uint64(400), txm.PeekMax(ctx).UnitPrice())
-	require.Equal(uint64(200), txm.PeekMin(ctx).UnitPrice())
+	max, ok := txm.PeekMax(ctx)
+	require.True(ok)
+	require.Equal(uint64(400), max.UnitPrice())
+	max, ok = txm.PeekMax(ctx)
+	require.True(ok)
+	require.Equal(uint64(200), max.UnitPrice())
 	require.Equal(3, txm.Len(ctx))
 }
 
@@ -37,14 +41,18 @@ func TestMempoolAddDuplicates(t *testing.T) {
 	defer ctrl.Finish()
 	ctx := context.TODO()
 	tracer, _ := trace.New(&trace.Config{Enabled: false})
-	txm := New(tracer, 3, 16, nil)
+	txm := New[*MempoolTestItem](tracer, 3, 16, nil)
 	// Generate item
 	item := GenerateTestItem(testPayer, 1, 300)
-	items := []Item{item}
+	items := []*MempoolTestItem{item}
 	txm.Add(ctx, items)
 	require.Equal(1, txm.Len(ctx), "Item not added.")
-	require.Equal(uint64(300), txm.PeekMax(ctx).UnitPrice())
-	require.Equal(uint64(300), txm.PeekMin(ctx).UnitPrice())
+	max, ok := txm.PeekMax(ctx)
+	require.True(ok)
+	require.Equal(uint64(300), max.UnitPrice())
+	max, ok = txm.PeekMax(ctx)
+	require.True(ok)
+	require.Equal(uint64(300), max.UnitPrice())
 	// Add again
 	txm.Add(ctx, items)
 	require.Equal(1, txm.Len(ctx), "Item not added.")
@@ -62,12 +70,12 @@ func TestMempoolAddExceedMaxPayerSize(t *testing.T) {
 	payer := "notexempt"
 	exemptPayers := []byte(exemptPayer)
 	// Non exempt payers max of 4
-	txm := New(tracer, 20, 4, [][]byte{exemptPayers})
+	txm := New[*MempoolTestItem](tracer, 20, 4, [][]byte{exemptPayers})
 	// Add 6 transactions for each payer
 	for i := uint64(0); i <= 5; i++ {
 		itemPayer := GenerateTestItem(payer, 1, i)
 		itemExempt := GenerateTestItem(exemptPayer, 1, i)
-		items := []Item{itemPayer, itemExempt}
+		items := []*MempoolTestItem{itemPayer, itemExempt}
 		txm.Add(ctx, items)
 	}
 	require.Equal(10, txm.Len(ctx), "Mempool has incorrect txs.")
@@ -82,18 +90,19 @@ func TestMempoolAddExceedMaxSize(t *testing.T) {
 	ctx := context.TODO()
 	tracer, _ := trace.New(&trace.Config{Enabled: false})
 
-	txm := New(tracer, 3, 20, nil)
+	txm := New[*MempoolTestItem](tracer, 3, 20, nil)
 	// Add more tx's than txm.maxSize
 	for i := uint64(0); i <= 9; i++ {
 		item := GenerateTestItem(testPayer, 1, i)
-		items := []Item{item}
+		items := []*MempoolTestItem{item}
 		txm.Add(ctx, items)
 		// Since UnitPrice() is increasing, tx should be included
 		require.True(txm.Has(ctx, item.ID()), "TX not included")
 	}
 	// Pop and check values
 	for i := uint64(7); i <= 9; i++ {
-		popped := txm.PopMin(ctx)
+		popped, ok := txm.PopMin(ctx)
+		require.True(ok)
 		require.Equal(i, popped.UnitPrice(), "Mempool did not pop correct tx.")
 	}
 	_, ok := txm.owned[testPayer]
@@ -108,15 +117,15 @@ func TestMempoolRemoveTxs(t *testing.T) {
 	ctx := context.TODO()
 	tracer, _ := trace.New(&trace.Config{Enabled: false})
 
-	txm := New(tracer, 3, 20, nil)
+	txm := New[*MempoolTestItem](tracer, 3, 20, nil)
 	// Add
 	item := GenerateTestItem(testPayer, 1, 10)
-	items := []Item{item}
+	items := []*MempoolTestItem{item}
 	txm.Add(ctx, items)
 	require.True(txm.Has(ctx, item.ID()), "TX not included")
 	// Remove
 	itemNotIn := GenerateTestItem(testPayer, 1, 10)
-	items = []Item{item, itemNotIn}
+	items = []*MempoolTestItem{item, itemNotIn}
 	txm.Remove(ctx, items)
 	require.Equal(0, txm.Len(ctx), "Mempool has incorrect number of txs.")
 }
@@ -128,12 +137,12 @@ func TestMempoolRemoveAccount(t *testing.T) {
 	ctx := context.TODO()
 	tracer, _ := trace.New(&trace.Config{Enabled: false})
 
-	txm := New(tracer, 3, 20, nil)
+	txm := New[*MempoolTestItem](tracer, 3, 20, nil)
 	// Add
 	item1 := GenerateTestItem(testPayer, 1, 10)
 	item2 := GenerateTestItem(testPayer, 1, 20)
 
-	items := []Item{item1, item2}
+	items := []*MempoolTestItem{item1, item2}
 	txm.Add(ctx, items)
 	require.True(txm.Has(ctx, item1.ID()), "TX not included")
 	require.True(txm.Has(ctx, item2.ID()), "TX not included")
@@ -150,11 +159,11 @@ func TestMempoolSetMinTimestamp(t *testing.T) {
 	ctx := context.TODO()
 	tracer, _ := trace.New(&trace.Config{Enabled: false})
 
-	txm := New(tracer, 20, 20, nil)
+	txm := New[*MempoolTestItem](tracer, 20, 20, nil)
 	// Add more tx's than txm.maxSize
 	for i := int64(0); i <= 9; i++ {
 		item := GenerateTestItem(testPayer, i, 10)
-		items := []Item{item}
+		items := []*MempoolTestItem{item}
 		txm.Add(ctx, items)
 		require.True(txm.Has(ctx, item.ID()), "TX not included")
 	}

--- a/mempool/sorted_mempool.go
+++ b/mempool/sorted_mempool.go
@@ -87,7 +87,7 @@ func (sm *SortedMempool[T]) SetMinVal(val uint64) []T {
 // PeekMin returns the minimum value in sm.
 func (sm *SortedMempool[T]) PeekMin() (T, bool) {
 	if sm.minHeap.Len() == 0 {
-		return *new(T), false
+		return *new(T), false //nolint:gocritic
 	}
 	return sm.minHeap.items[0].item, true
 }
@@ -95,7 +95,7 @@ func (sm *SortedMempool[T]) PeekMin() (T, bool) {
 // PopMin removes the minimum value in sm.
 func (sm *SortedMempool[T]) PopMin() (T, bool) {
 	if sm.minHeap.Len() == 0 {
-		return *new(T), false
+		return *new(T), false //nolint:gocritic
 	}
 	item := sm.minHeap.items[0].item
 	sm.Remove(item.ID())
@@ -105,7 +105,7 @@ func (sm *SortedMempool[T]) PopMin() (T, bool) {
 // PopMin returms the maximum value in sm.
 func (sm *SortedMempool[T]) PeekMax() (T, bool) {
 	if sm.Len() == 0 {
-		return *new(T), false
+		return *new(T), false //nolint:gocritic
 	}
 	return sm.maxHeap.items[0].item, true
 }
@@ -113,7 +113,7 @@ func (sm *SortedMempool[T]) PeekMax() (T, bool) {
 // PopMin removes the maximum value in sm.
 func (sm *SortedMempool[T]) PopMax() (T, bool) {
 	if sm.Len() == 0 {
-		return *new(T), false
+		return *new(T), false //nolint:gocritic
 	}
 	item := sm.maxHeap.items[0].item
 	sm.Remove(item.ID())

--- a/mempool/sorted_mempool.go
+++ b/mempool/sorted_mempool.go
@@ -11,45 +11,45 @@ import (
 
 // SortedMempool contains a max-heap and min-heap. The order within each
 // heap is determined by using GetValue.
-type SortedMempool struct {
+type SortedMempool[T Item] struct {
 	// GetValue informs heaps how to get the an entry's value for ordering.
-	GetValue func(tx Item) uint64
+	GetValue func(item T) uint64
 
-	minHeap *uint64Heap // only includes lowest nonce
-	maxHeap *uint64Heap // only includes lowest nonce
+	minHeap *uint64Heap[T] // only includes lowest nonce
+	maxHeap *uint64Heap[T] // only includes lowest nonce
 }
 
 // NewSortedMempool returns an instance of SortedMempool with minHeap and maxHeap
 // containing [items] and prioritized with [f]
-func NewSortedMempool(items int, f func(tx Item) uint64) *SortedMempool {
-	return &SortedMempool{
+func NewSortedMempool[T Item](items int, f func(item T) uint64) *SortedMempool[T] {
+	return &SortedMempool[T]{
 		GetValue: f,
-		minHeap:  newUint64Heap(items, true),
-		maxHeap:  newUint64Heap(items, false),
+		minHeap:  newUint64Heap[T](items, true),
+		maxHeap:  newUint64Heap[T](items, false),
 	}
 }
 
-// Add pushes [tx] to sm.
-func (sm *SortedMempool) Add(tx Item) {
-	txID := tx.ID()
+// Add pushes [item] to sm.
+func (sm *SortedMempool[T]) Add(item T) {
+	itemID := item.ID()
 	poolLen := sm.maxHeap.Len()
-	val := sm.GetValue(tx)
-	heap.Push(sm.maxHeap, &uint64Entry{
-		id:    txID,
+	val := sm.GetValue(item)
+	heap.Push(sm.maxHeap, &uint64Entry[T]{
+		id:    itemID,
 		val:   val,
-		tx:    tx,
+		item:  item,
 		index: poolLen,
 	})
-	heap.Push(sm.minHeap, &uint64Entry{
-		id:    txID,
+	heap.Push(sm.minHeap, &uint64Entry[T]{
+		id:    itemID,
 		val:   val,
-		tx:    tx,
+		item:  item,
 		index: poolLen,
 	})
 }
 
 // Remove removes [id] from sm. If the id does not exist, Remove returns.
-func (sm *SortedMempool) Remove(id ids.ID) {
+func (sm *SortedMempool[T]) Remove(id ids.ID) {
 	maxEntry, ok := sm.maxHeap.GetID(id) // O(1)
 	if !ok {
 		return
@@ -67,11 +67,11 @@ func (sm *SortedMempool) Remove(id ids.ID) {
 // SetMinVal removes all elements in sm with a value less than [val]. Returns
 // the list of removed elements.
 // TDOD: add lock to prevent concurrent access
-func (sm *SortedMempool) SetMinVal(val uint64) []Item {
-	removed := []Item{}
+func (sm *SortedMempool[T]) SetMinVal(val uint64) []T {
+	removed := []T{}
 	for {
-		min := sm.PeekMin()
-		if min == nil {
+		min, ok := sm.PeekMin()
+		if !ok {
 			break
 		}
 		if sm.GetValue(min) < val {
@@ -84,48 +84,48 @@ func (sm *SortedMempool) SetMinVal(val uint64) []Item {
 	return removed
 }
 
-// PopMin removes the minimum value in sm.
-func (sm *SortedMempool) PeekMin() Item {
+// PeekMin returns the minimum value in sm.
+func (sm *SortedMempool[T]) PeekMin() (T, bool) {
 	if sm.minHeap.Len() == 0 {
-		return nil
+		return *new(T), false
 	}
-	return sm.minHeap.items[0].tx
+	return sm.minHeap.items[0].item, true
 }
 
 // PopMin removes the minimum value in sm.
-func (sm *SortedMempool) PopMin() Item {
+func (sm *SortedMempool[T]) PopMin() (T, bool) {
 	if sm.minHeap.Len() == 0 {
-		return nil
+		return *new(T), false
 	}
-	tx := sm.minHeap.items[0].tx
-	sm.Remove(tx.ID())
-	return tx
+	item := sm.minHeap.items[0].item
+	sm.Remove(item.ID())
+	return item, true
 }
 
 // PopMin returms the maximum value in sm.
-func (sm *SortedMempool) PeekMax() Item {
+func (sm *SortedMempool[T]) PeekMax() (T, bool) {
 	if sm.Len() == 0 {
-		return nil
+		return *new(T), false
 	}
-	return sm.maxHeap.items[0].tx
+	return sm.maxHeap.items[0].item, true
 }
 
 // PopMin removes the maximum value in sm.
-func (sm *SortedMempool) PopMax() Item {
+func (sm *SortedMempool[T]) PopMax() (T, bool) {
 	if sm.Len() == 0 {
-		return nil
+		return *new(T), false
 	}
-	tx := sm.maxHeap.items[0].tx
-	sm.Remove(tx.ID())
-	return tx
+	item := sm.maxHeap.items[0].item
+	sm.Remove(item.ID())
+	return item, true
 }
 
-// Has returns if [tx] is in sm.
-func (sm *SortedMempool) Has(tx ids.ID) bool {
-	return sm.minHeap.HasID(tx)
+// Has returns if [item] is in sm.
+func (sm *SortedMempool[T]) Has(item ids.ID) bool {
+	return sm.minHeap.HasID(item)
 }
 
 // Len returns the number of elements in sm.
-func (sm *SortedMempool) Len() int {
+func (sm *SortedMempool[T]) Len() int {
 	return sm.minHeap.Len()
 }

--- a/mempool/sorted_mempool_test.go
+++ b/mempool/sorted_mempool_test.go
@@ -108,19 +108,27 @@ func TestPeekMin(t *testing.T) {
 	itemMin := GenerateTestItem(testPayer, 1, 1)
 	itemMed := GenerateTestItem(testPayer, 1, 2)
 	itemMax := GenerateTestItem(testPayer, 1, 3)
-	require.Nil(sortedMempool.PeekMin(), "Peek UnitPrice is incorrect")
+	min, ok := sortedMempool.PeekMin()
+	require.False(ok)
+	require.Nil(min, "Peek UnitPrice is incorrect")
 	// Check PeekMin
 	sortedMempool.Add(itemMed)
 	require.True(sortedMempool.Has(itemMed.ID()), "TX not included")
-	require.Equal(itemMed, sortedMempool.PeekMin(), "Peek value is incorrect")
+	min, ok = sortedMempool.PeekMin()
+	require.True(ok)
+	require.Equal(itemMed, min, "Peek value is incorrect")
 
 	sortedMempool.Add(itemMin)
 	require.True(sortedMempool.Has(itemMin.ID()), "TX not included")
-	require.Equal(itemMin, sortedMempool.PeekMin(), "Peek value is incorrect")
+	min, ok = sortedMempool.PeekMin()
+	require.True(ok)
+	require.Equal(itemMin, min, "Peek value is incorrect")
 
 	sortedMempool.Add(itemMax)
 	require.True(sortedMempool.Has(itemMax.ID()), "TX not included")
-	require.Equal(itemMin, sortedMempool.PeekMin(), "Peek value is incorrect")
+	min, ok = sortedMempool.PeekMin()
+	require.True(ok)
+	require.Equal(itemMin, min, "Peek value is incorrect")
 }
 
 func TestPeekMax(t *testing.T) {
@@ -131,19 +139,27 @@ func TestPeekMax(t *testing.T) {
 	itemMin := GenerateTestItem(testPayer, 1, 1)
 	itemMed := GenerateTestItem(testPayer, 1, 2)
 	itemMax := GenerateTestItem(testPayer, 1, 3)
-	require.Nil(sortedMempool.PeekMax(), "Peek UnitPrice is incorrect")
+	max, ok := sortedMempool.PeekMax()
+	require.False(ok)
+	require.Nil(max, "Peek UnitPrice is incorrect")
 	// Check PeekMin
 	sortedMempool.Add(itemMed)
 	require.True(sortedMempool.Has(itemMed.ID()), "TX not included")
-	require.Equal(itemMed, sortedMempool.PeekMax(), "Peek value is incorrect")
+	max, ok = sortedMempool.PeekMax()
+	require.True(ok)
+	require.Equal(itemMed, max, "Peek value is incorrect")
 
 	sortedMempool.Add(itemMin)
 	require.True(sortedMempool.Has(itemMin.ID()), "TX not included")
-	require.Equal(itemMed, sortedMempool.PeekMax(), "Peek value is incorrect")
+	max, ok = sortedMempool.PeekMax()
+	require.True(ok)
+	require.Equal(itemMed, max, "Peek value is incorrect")
 
 	sortedMempool.Add(itemMax)
 	require.True(sortedMempool.Has(itemMax.ID()), "TX not included")
-	require.Equal(itemMax, sortedMempool.PeekMax(), "Peek value is incorrect")
+	max, ok = sortedMempool.PeekMax()
+	require.True(ok)
+	require.Equal(itemMax, max, "Peek value is incorrect")
 }
 
 func TestPopMin(t *testing.T) {
@@ -154,14 +170,22 @@ func TestPopMin(t *testing.T) {
 	itemMin := GenerateTestItem(testPayer, 1, 1)
 	itemMed := GenerateTestItem(testPayer, 1, 2)
 	itemMax := GenerateTestItem(testPayer, 1, 3)
-	require.Nil(sortedMempool.PopMin(), "Pop value is incorrect")
+	min, ok := sortedMempool.PopMin()
+	require.False(ok)
+	require.Nil(min, "Pop value is incorrect")
 	// Check PeekMin
 	sortedMempool.Add(itemMed)
 	sortedMempool.Add(itemMin)
 	sortedMempool.Add(itemMax)
-	require.Equal(itemMin, sortedMempool.PopMin(), "PopMin value is incorrect")
-	require.Equal(itemMed, sortedMempool.PopMin(), "PopMin value is incorrect")
-	require.Equal(itemMax, sortedMempool.PopMin(), "PopMin value is incorrect")
+	min, ok = sortedMempool.PopMin()
+	require.True(ok)
+	require.Equal(itemMin, min, "PopMin value is incorrect")
+	min, ok = sortedMempool.PopMin()
+	require.True(ok)
+	require.Equal(itemMed, min, "PopMin value is incorrect")
+	min, ok = sortedMempool.PopMin()
+	require.True(ok)
+	require.Equal(itemMax, min, "PopMin value is incorrect")
 }
 
 func TestPopMax(t *testing.T) {
@@ -172,15 +196,23 @@ func TestPopMax(t *testing.T) {
 	itemMin := GenerateTestItem(testPayer, 1, 1)
 	itemMed := GenerateTestItem(testPayer, 1, 2)
 	itemMax := GenerateTestItem(testPayer, 1, 3)
-	require.Nil(sortedMempool.PopMax(), "Pop value is incorrect")
+	max, ok := sortedMempool.PopMax()
+	require.False(ok)
+	require.Nil(max, "Pop value is incorrect")
 	// Check PeekMin
 	sortedMempool.Add(itemMed)
 	sortedMempool.Add(itemMin)
 	sortedMempool.Add(itemMax)
 
-	require.Equal(itemMax, sortedMempool.PopMax(), "PopMin value is incorrect")
-	require.Equal(itemMed, sortedMempool.PopMax(), "PopMin value is incorrect")
-	require.Equal(itemMin, sortedMempool.PopMax(), "PopMin value is incorrect")
+	max, ok = sortedMempool.PopMax()
+	require.True(ok)
+	require.Equal(itemMax, max, "PopMin value is incorrect")
+	max, ok = sortedMempool.PopMax()
+	require.True(ok)
+	require.Equal(itemMed, max, "PopMin value is incorrect")
+	max, ok = sortedMempool.PopMax()
+	require.True(ok)
+	require.Equal(itemMin, max, "PopMin value is incorrect")
 }
 
 func TestHas(t *testing.T) {

--- a/mempool/uint64_heap.go
+++ b/mempool/uint64_heap.go
@@ -16,36 +16,36 @@ type Item interface {
 	UnitPrice() uint64
 }
 
-type uint64Entry struct {
-	id  ids.ID // id of entry
-	tx  Item   // associated tx
-	val uint64 // value to be prioritized
+type uint64Entry[T Item] struct {
+	id   ids.ID // id of entry
+	item T      // associated item
+	val  uint64 // value to be prioritized
 
 	index int // index of the entry in heap
 }
 
-// uint64Heap is used to track pending transactions by [val]
-type uint64Heap struct {
-	isMinHeap bool                    // true for Min-Heap, false for Max-Heap
-	items     []*uint64Entry          // items in this heap
-	lookup    map[ids.ID]*uint64Entry // ids in the heap mapping to an entry
+// uint64Heap[T] is used to track pending transactions by [val]
+type uint64Heap[T Item] struct {
+	isMinHeap bool                       // true for Min-Heap, false for Max-Heap
+	items     []*uint64Entry[T]          // items in this heap
+	lookup    map[ids.ID]*uint64Entry[T] // ids in the heap mapping to an entry
 }
 
-// newUint64Heap returns an instance of uint64Heap
-func newUint64Heap(items int, isMinHeap bool) *uint64Heap {
-	return &uint64Heap{
+// newUint64Heap returns an instance of uint64Heap[T]
+func newUint64Heap[T Item](items int, isMinHeap bool) *uint64Heap[T] {
+	return &uint64Heap[T]{
 		isMinHeap: isMinHeap,
 
-		items:  make([]*uint64Entry, 0, items),
-		lookup: make(map[ids.ID]*uint64Entry, items),
+		items:  make([]*uint64Entry[T], 0, items),
+		lookup: make(map[ids.ID]*uint64Entry[T], items),
 	}
 }
 
 // Len returns the number of items in th.
-func (th uint64Heap) Len() int { return len(th.items) }
+func (th uint64Heap[T]) Len() int { return len(th.items) }
 
 // Less compares the priority of [i] and [j] based on th.isMinHeap.
-func (th uint64Heap) Less(i, j int) bool {
+func (th uint64Heap[T]) Less(i, j int) bool {
 	if th.isMinHeap {
 		return th.items[i].val < th.items[j].val
 	}
@@ -53,7 +53,7 @@ func (th uint64Heap) Less(i, j int) bool {
 }
 
 // Swap swaps the [i]th and [j]th element in th.
-func (th uint64Heap) Swap(i, j int) {
+func (th uint64Heap[T]) Swap(i, j int) {
 	th.items[i], th.items[j] = th.items[j], th.items[i]
 	th.items[i].index = i
 	th.items[j].index = j
@@ -61,8 +61,8 @@ func (th uint64Heap) Swap(i, j int) {
 
 // Push addes an *uint64Entry interface to th. If [x.id] is already in
 // th, returns.
-func (th *uint64Heap) Push(x interface{}) {
-	entry, ok := x.(*uint64Entry)
+func (th *uint64Heap[T]) Push(x interface{}) {
+	entry, ok := x.(*uint64Entry[T])
 	if !ok {
 		panic(fmt.Errorf("unexpected %T, expected *uint64Entry", x))
 	}
@@ -75,7 +75,7 @@ func (th *uint64Heap) Push(x interface{}) {
 
 // Pop removes the highest priority item from th and also deletes it from
 // th's lookup map.
-func (th *uint64Heap) Pop() interface{} {
+func (th *uint64Heap[T]) Pop() interface{} {
 	n := len(th.items)
 	item := th.items[n-1]
 	th.items[n-1] = nil // avoid memory leak
@@ -86,13 +86,13 @@ func (th *uint64Heap) Pop() interface{} {
 
 // GetID returns the entry in th associated with [id], and a bool if [id] was
 // found in th.
-func (th *uint64Heap) GetID(id ids.ID) (*uint64Entry, bool) {
+func (th *uint64Heap[T]) GetID(id ids.ID) (*uint64Entry[T], bool) {
 	entry, ok := th.lookup[id]
 	return entry, ok
 }
 
 // HasID returns whether [id] is found in th.
-func (th *uint64Heap) HasID(id ids.ID) bool {
+func (th *uint64Heap[T]) HasID(id ids.ID) bool {
 	_, has := th.GetID(id)
 	return has
 }

--- a/mempool/uint64_heap_test.go
+++ b/mempool/uint64_heap_test.go
@@ -48,30 +48,30 @@ func GenerateTestItem(payer string, t int64, unitPrice uint64) *MempoolTestItem 
 
 func TestUnit64HeapPushPopMin(t *testing.T) {
 	require := require.New(t)
-	minHeap := newUint64Heap(0, true)
+	minHeap := newUint64Heap[*MempoolTestItem](0, true)
 	require.Equal(minHeap.Len(), 0, "heap not initialized properly.")
 	mempoolItem1 := GenerateTestItem(testPayer, 1, 10)
 	mempoolItem2 := GenerateTestItem(testPayer, 2, 7)
 	mempoolItem3 := GenerateTestItem(testPayer, 3, 15)
 
 	// Middle UnitPrice
-	med := &uint64Entry{
+	med := &uint64Entry[*MempoolTestItem]{
 		id:    mempoolItem1.ID(),
-		tx:    mempoolItem1,
+		item:  mempoolItem1,
 		val:   mempoolItem1.UnitPrice(),
 		index: minHeap.Len(),
 	}
 	// Lesser UnitPrice
-	low := &uint64Entry{
+	low := &uint64Entry[*MempoolTestItem]{
 		id:    mempoolItem2.ID(),
-		tx:    mempoolItem2,
+		item:  mempoolItem2,
 		val:   mempoolItem2.UnitPrice(),
 		index: minHeap.Len(),
 	}
 	// Greatest UnitPrice
-	high := &uint64Entry{
+	high := &uint64Entry[*MempoolTestItem]{
 		id:    mempoolItem3.ID(),
-		tx:    mempoolItem3,
+		item:  mempoolItem3,
 		val:   mempoolItem3.UnitPrice(),
 		index: minHeap.Len(),
 	}
@@ -98,7 +98,7 @@ func TestUnit64HeapPushPopMin(t *testing.T) {
 
 func TestUnit64HeapPushPopMax(t *testing.T) {
 	require := require.New(t)
-	maxHeap := newUint64Heap(0, false)
+	maxHeap := newUint64Heap[*MempoolTestItem](0, false)
 	require.Equal(maxHeap.Len(), 0, "heap not initialized properly.")
 
 	mempoolItem1 := GenerateTestItem(testPayer, 1, 10)
@@ -106,23 +106,23 @@ func TestUnit64HeapPushPopMax(t *testing.T) {
 	mempoolItem3 := GenerateTestItem(testPayer, 3, 15)
 
 	// Middle UnitPrice
-	med := &uint64Entry{
+	med := &uint64Entry[*MempoolTestItem]{
 		id:    mempoolItem1.ID(),
-		tx:    mempoolItem1,
+		item:  mempoolItem1,
 		val:   mempoolItem1.UnitPrice(),
 		index: maxHeap.Len(),
 	}
 	// Lesser UnitPrice
-	low := &uint64Entry{
+	low := &uint64Entry[*MempoolTestItem]{
 		id:    mempoolItem2.ID(),
-		tx:    mempoolItem2,
+		item:  mempoolItem2,
 		val:   mempoolItem2.UnitPrice(),
 		index: maxHeap.Len(),
 	}
 	// Greatest UnitPrice
-	high := &uint64Entry{
+	high := &uint64Entry[*MempoolTestItem]{
 		id:    mempoolItem3.ID(),
-		tx:    mempoolItem3,
+		item:  mempoolItem3,
 		val:   mempoolItem3.UnitPrice(),
 		index: maxHeap.Len(),
 	}
@@ -150,12 +150,12 @@ func TestUnit64HeapPushPopMax(t *testing.T) {
 func TestUnit64HeapPushExists(t *testing.T) {
 	// Push an item already in heap
 	require := require.New(t)
-	minHeap := newUint64Heap(0, true)
+	minHeap := newUint64Heap[*MempoolTestItem](0, true)
 	require.Equal(minHeap.Len(), 0, "heap not initialized properly.")
 	mempoolItem := GenerateTestItem(testPayer, 1, 10)
-	entry := &uint64Entry{
+	entry := &uint64Entry[*MempoolTestItem]{
 		id:    mempoolItem.ID(),
-		tx:    mempoolItem,
+		item:  mempoolItem,
 		val:   mempoolItem.UnitPrice(),
 		index: minHeap.Len(),
 	}
@@ -173,13 +173,13 @@ func TestUnit64HeapPushExists(t *testing.T) {
 func TestUnit64HeapGetID(t *testing.T) {
 	// Push an item and grab its ID
 	require := require.New(t)
-	minHeap := newUint64Heap(0, true)
+	minHeap := newUint64Heap[*MempoolTestItem](0, true)
 	require.Equal(minHeap.Len(), 0, "heap not initialized properly.")
 
 	mempoolItem := GenerateTestItem(testPayer, 1, 10)
-	entry := &uint64Entry{
+	entry := &uint64Entry[*MempoolTestItem]{
 		id:    mempoolItem.ID(),
-		tx:    mempoolItem,
+		item:  mempoolItem,
 		val:   mempoolItem.UnitPrice(),
 		index: minHeap.Len(),
 	}
@@ -195,12 +195,12 @@ func TestUnit64HeapGetID(t *testing.T) {
 
 func TestUnit64HeapHasID(t *testing.T) {
 	require := require.New(t)
-	minHeap := newUint64Heap(0, true)
+	minHeap := newUint64Heap[*MempoolTestItem](0, true)
 	require.Equal(minHeap.Len(), 0, "heap not initialized properly.")
 	mempoolItem := GenerateTestItem(testPayer, 1, 10)
-	entry := &uint64Entry{
+	entry := &uint64Entry[*MempoolTestItem]{
 		id:    mempoolItem.ID(),
-		tx:    mempoolItem,
+		item:  mempoolItem,
 		val:   mempoolItem.UnitPrice(),
 		index: minHeap.Len(),
 	}

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -57,7 +57,7 @@ type VM struct {
 	authRegistry   chain.AuthRegistry
 
 	tracer    trace.Tracer
-	mempool   *mempool.Mempool
+	mempool   *mempool.Mempool[*chain.Transaction]
 	appSender common.AppSender
 
 	// track all accepted but still valid txs (replay protection)
@@ -184,7 +184,7 @@ func (vm *VM) Initialize(
 	vm.parsedBlocks = &cache.LRU[ids.ID, *chain.StatelessBlock]{Size: vm.config.GetBlockLRUSize()}
 	vm.verifiedBlocks = make(map[ids.ID]*chain.StatelessBlock)
 
-	vm.mempool = mempool.New(
+	vm.mempool = mempool.New[*chain.Transaction](
 		vm.tracer,
 		vm.config.GetMempoolSize(),
 		vm.config.GetMempoolPayerSize(),

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -47,7 +47,7 @@ func TestBlockCache(t *testing.T) {
 		blocks:         &cache.LRU[ids.ID, *chain.StatelessBlock]{Size: 3},
 		verifiedBlocks: make(map[ids.ID]*chain.StatelessBlock),
 		seen:           emap.NewEMap[*chain.Transaction](),
-		mempool:        mempool.New(tracer, 100, 32, nil),
+		mempool:        mempool.New[*chain.Transaction](tracer, 100, 32, nil),
 		acceptedQueue:  make(chan *chain.StatelessBlock, 1024), // don't block on queue
 		c:              controller,
 	}


### PR DESCRIPTION
Using `mempool.Item` in `mempool.Add` prevents us from adding an array of transactions at once (can't add array of interfaces). Using generics helps us get around this constraint without giving up performance or generality.