### PR TITLE
Optimizing `crypto/ed25519.go`

### DIFF
--- a/crypto/ed25519.go
+++ b/crypto/ed25519.go
@@ -21,6 +21,7 @@ type (
 )
 
 const (
+	CompressedPublicKeySize = 33
 	PublicKeyLen  = ed25519.PublicKeySize
 	PrivateKeyLen = ed25519.PrivateKeySize
 	SignatureLen  = ed25519.SignatureSize
@@ -51,7 +52,6 @@ func ParseAddress(hrp, saddr string) (PublicKey, error) {
 	if phrp != hrp {
 		return EmptyPublicKey, ErrIncorrectHrp
 	}
-	const CompressedPublicKeySize = 33
 	if len(paddr) != CompressedPublicKeySize {
 		return EmptyPublicKey, ErrInvalidPublicKey
 	}
@@ -75,7 +75,7 @@ func GeneratePrivateKey() (PrivateKey, error) {
 // PublicKey returns a PublicKey associated with the Ed25519 PrivateKey p.
 // The PublicKey is the last 32 bytes of p.
 func (p PrivateKey) PublicKey() PublicKey {
-	return PublicKey(p[32:])
+	return PublicKey(p[PublicKeyLen:])
 }
 
 // ToHex converts a PrivateKey to a hex string.

--- a/crypto/ed25519.go
+++ b/crypto/ed25519.go
@@ -24,7 +24,7 @@ const (
 	PublicKeyCompressedSize = 33
 	PublicKeyLen            = ed25519.PublicKeySize
 	PrivateKeyLen           = ed25519.PrivateKeySize
-	PrivateKeySeedSize      = ed25519.SeedSize
+	PrivateKeySeedLen       = ed25519.SeedSize
 	SignatureLen            = ed25519.SignatureSize
 )
 
@@ -57,7 +57,7 @@ func ParseAddress(hrp, saddr string) (PublicKey, error) {
 		return EmptyPublicKey, ErrInvalidPublicKey
 	}
 	var p PublicKey
-	copy(p[:], paddr[:32])
+	copy(p[:], paddr[:PublicKeyLen])
 	return p, nil
 }
 
@@ -76,7 +76,7 @@ func GeneratePrivateKey() (PrivateKey, error) {
 // PublicKey returns a PublicKey associated with the Ed25519 PrivateKey p.
 // The PublicKey is the last 32 bytes of p.
 func (p PrivateKey) PublicKey() PublicKey {
-	rpk := p[PrivateKeyLen:] // privateKey == private|public
+	rpk := p[PublicKeyLen:] // privateKey == private|public
 	var pk PublicKey
 	copy(pk[:], rpk)
 	return pk

--- a/crypto/ed25519.go
+++ b/crypto/ed25519.go
@@ -51,7 +51,8 @@ func ParseAddress(hrp, saddr string) (PublicKey, error) {
 	if phrp != hrp {
 		return EmptyPublicKey, ErrIncorrectHrp
 	}
-	if len(paddr) != 33 /* compressed public key size */ {
+	const CompressedPublicKeySize = 33
+	if len(paddr) != CompressedPublicKeySize {
 		return EmptyPublicKey, ErrInvalidPublicKey
 	}
 	var p PublicKey
@@ -74,10 +75,7 @@ func GeneratePrivateKey() (PrivateKey, error) {
 // PublicKey returns a PublicKey associated with the Ed25519 PrivateKey p.
 // The PublicKey is the last 32 bytes of p.
 func (p PrivateKey) PublicKey() PublicKey {
-	rpk := p[32:] // privateKey == private|public
-	var pk PublicKey
-	copy(pk[:], rpk)
-	return pk
+	return PublicKey(p[32:])
 }
 
 // ToHex converts a PrivateKey to a hex string.

--- a/crypto/ed25519.go
+++ b/crypto/ed25519.go
@@ -76,7 +76,7 @@ func GeneratePrivateKey() (PrivateKey, error) {
 // PublicKey returns a PublicKey associated with the Ed25519 PrivateKey p.
 // The PublicKey is the last 32 bytes of p.
 func (p PrivateKey) PublicKey() PublicKey {
-	rpk := p[PublicKeyLen:] // privateKey == private|public
+	rpk := p[PrivateKeySeedLen:] // privateKey == private|public
 	var pk PublicKey
 	copy(pk[:], rpk)
 	return pk

--- a/crypto/ed25519.go
+++ b/crypto/ed25519.go
@@ -21,7 +21,7 @@ type (
 )
 
 const (
-	PublicKeyCompressedSize = 33
+	PublicKeyCompressedLen	= 33
 	PublicKeyLen            = ed25519.PublicKeySize
 	PrivateKeyLen           = ed25519.PrivateKeySize
 	PrivateKeySeedLen       = ed25519.SeedSize
@@ -53,7 +53,7 @@ func ParseAddress(hrp, saddr string) (PublicKey, error) {
 	if phrp != hrp {
 		return EmptyPublicKey, ErrIncorrectHrp
 	}
-	if len(paddr) != PublicKeyCompressedSize {
+	if len(paddr) != PublicKeyCompressedLen {
 		return EmptyPublicKey, ErrInvalidPublicKey
 	}
 	var p PublicKey

--- a/crypto/ed25519.go
+++ b/crypto/ed25519.go
@@ -75,7 +75,10 @@ func GeneratePrivateKey() (PrivateKey, error) {
 // PublicKey returns a PublicKey associated with the Ed25519 PrivateKey p.
 // The PublicKey is the last 32 bytes of p.
 func (p PrivateKey) PublicKey() PublicKey {
-	return PublicKey(p[PublicKeyLen:])
+	rpk := p[PrivateKeyLen:] // privateKey == private|public
+	var pk PublicKey
+	copy(pk[:], rpk)
+	return pk
 }
 
 // ToHex converts a PrivateKey to a hex string.

--- a/crypto/ed25519.go
+++ b/crypto/ed25519.go
@@ -21,10 +21,11 @@ type (
 )
 
 const (
-	CompressedPublicKeySize = 33
-	PublicKeyLen  = ed25519.PublicKeySize
-	PrivateKeyLen = ed25519.PrivateKeySize
-	SignatureLen  = ed25519.SignatureSize
+	PublicKeyCompressedSize = 33
+	PublicKeyLen            = ed25519.PublicKeySize
+	PrivateKeyLen           = ed25519.PrivateKeySize
+	PrivateKeySeedSize      = ed25519.SeedSize
+	SignatureLen            = ed25519.SignatureSize
 )
 
 var (
@@ -52,7 +53,7 @@ func ParseAddress(hrp, saddr string) (PublicKey, error) {
 	if phrp != hrp {
 		return EmptyPublicKey, ErrIncorrectHrp
 	}
-	if len(paddr) != CompressedPublicKeySize {
+	if len(paddr) != PublicKeyCompressedSize {
 		return EmptyPublicKey, ErrInvalidPublicKey
 	}
 	var p PublicKey


### PR DESCRIPTION
1. **Avoid unnecessary copying of byte arrays**, it is not necessary to make a copy of the byte array in these cases since the byte arrays are the same size and have the same underlying structure. 

2. **Use of constants instead of literals** To make it more declarative`const CompressedPublicKeySize = 33` instead `if len(paddr) != 33`