### PR TITLE
go1.20

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -73,3 +73,7 @@ jobs:
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -24,3 +24,7 @@ jobs:
       - name: Run static analysis tests
         shell: bash
         run: scripts/tests.lint.sh
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.20
           check-latest: true
       - name: Run static analysis tests
         shell: bash

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20
+          go-version: "1.20"
           check-latest: true
       - name: Run static analysis tests
         shell: bash

--- a/.github/workflows/tokenvm-load-tests.yml
+++ b/.github/workflows/tokenvm-load-tests.yml
@@ -1,0 +1,27 @@
+# Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
+# See the file LICENSE for licensing terms.
+
+name: TokenVM Load Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  tests:
+    runs-on:
+      labels: ubuntu-latest-16-cores
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: "1.20"
+          check-latest: true
+      - name: Run load tests
+        working-directory: ./examples/tokenvm
+        shell: bash
+        run: scripts/tests.load.sh

--- a/.github/workflows/tokenvm-load-tests.yml
+++ b/.github/workflows/tokenvm-load-tests.yml
@@ -31,3 +31,7 @@ jobs:
         working-directory: ./examples/tokenvm
         shell: bash
         run: scripts/tests.load.sh
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true

--- a/.github/workflows/tokenvm-load-tests.yml
+++ b/.github/workflows/tokenvm-load-tests.yml
@@ -21,6 +21,10 @@ jobs:
         with:
           go-version: "1.20"
           check-latest: true
+      - name: Run disk tests
+        working-directory: ./examples/tokenvm
+        shell: bash
+        run: scripts/tests.disk.sh
       - name: Run load tests
         working-directory: ./examples/tokenvm
         shell: bash

--- a/.github/workflows/tokenvm-load-tests.yml
+++ b/.github/workflows/tokenvm-load-tests.yml
@@ -16,15 +16,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Install fio
+        run: sudo apt-get -y install fio
+      - name: Run disk tests
+        working-directory: ./examples/tokenvm
+        shell: bash
+        run: scripts/tests.disk.sh
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
           go-version: "1.20"
           check-latest: true
-      - name: Run disk tests
-        working-directory: ./examples/tokenvm
-        shell: bash
-        run: scripts/tests.disk.sh
       - name: Run load tests
         working-directory: ./examples/tokenvm
         shell: bash

--- a/.github/workflows/tokenvm-static-analysis.yml
+++ b/.github/workflows/tokenvm-static-analysis.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20
+          go-version: "1.20"
           check-latest: true
       - name: Run static analysis tests
         working-directory: ./examples/tokenvm

--- a/.github/workflows/tokenvm-static-analysis.yml
+++ b/.github/workflows/tokenvm-static-analysis.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.20
           check-latest: true
       - name: Run static analysis tests
         working-directory: ./examples/tokenvm

--- a/.github/workflows/tokenvm-static-analysis.yml
+++ b/.github/workflows/tokenvm-static-analysis.yml
@@ -25,3 +25,7 @@ jobs:
         working-directory: ./examples/tokenvm
         shell: bash
         run: scripts/tests.lint.sh
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true

--- a/.github/workflows/tokenvm-sync-tests.yml
+++ b/.github/workflows/tokenvm-sync-tests.yml
@@ -7,8 +7,6 @@ on:
   push:
     branches:
       - main
-    tags:
-      - "*"
   pull_request:
 
 jobs:
@@ -16,14 +14,13 @@ jobs:
     runs-on:
       labels: ubuntu-latest-16-cores
     steps:
-      - name: Git checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+      - name: Checkout
+        uses: actions/checkout@v3
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.20
+          go-version: "1.20"
+          check-latest: true
       - name: Run sync tests
         working-directory: ./examples/tokenvm
         shell: bash

--- a/.github/workflows/tokenvm-sync-tests.yml
+++ b/.github/workflows/tokenvm-sync-tests.yml
@@ -27,3 +27,7 @@ jobs:
         run: scripts/run.sh
         env:
           MODE: "full-test"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true

--- a/.github/workflows/tokenvm-sync-tests.yml
+++ b/.github/workflows/tokenvm-sync-tests.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19
+          go-version: 1.20
       - name: Run sync tests
         working-directory: ./examples/tokenvm
         shell: bash

--- a/.github/workflows/tokenvm-unit-tests.yml
+++ b/.github/workflows/tokenvm-unit-tests.yml
@@ -7,22 +7,19 @@ on:
   push:
     branches:
       - main
-    tags:
-      - "*"
   pull_request:
 
 jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-      - name: Git checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+      - name: Checkout
+        uses: actions/checkout@v3
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.20
+          go-version: "1.20"
+          check-latest: true
       - name: Run unit tests
         working-directory: ./examples/tokenvm
         shell: bash

--- a/.github/workflows/tokenvm-unit-tests.yml
+++ b/.github/workflows/tokenvm-unit-tests.yml
@@ -34,3 +34,7 @@ jobs:
         run: scripts/run.sh
         env:
           MODE: "test"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true

--- a/.github/workflows/tokenvm-unit-tests.yml
+++ b/.github/workflows/tokenvm-unit-tests.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19
+          go-version: 1.20
       - name: Run unit tests
         working-directory: ./examples/tokenvm
         shell: bash

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -24,3 +24,7 @@ jobs:
       - name: Run unit tests
         shell: bash
         run: scripts/tests.unit.sh
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19
+          go-version: 1.20
       - name: Run unit tests
         shell: bash
         run: scripts/tests.unit.sh

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -7,8 +7,6 @@ on:
   push:
     branches:
       - main
-    tags:
-      - "*"
   pull_request:
 
 jobs:
@@ -16,14 +14,13 @@ jobs:
     name: Unit Tests
     runs-on: ubuntu-latest
     steps:
-      - name: Git checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+      - name: Checkout
+        uses: actions/checkout@v3
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.20
+          go-version: "1.20"
+          check-latest: true
       - name: Run unit tests
         shell: bash
         run: scripts/tests.unit.sh

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ genesis.json
 
 dist/
 *.pk
+tmp-storage-testing

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -98,7 +98,7 @@ linters-settings:
       - name: useless-break
         disabled: false
   staticcheck:
-    go: "1.18"
+    go: "1.20"
     # https://staticcheck.io/docs/options#checks
     checks:
       - "all"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Thank you for your interest in contributing to `hypersdk`! By contributing to hy
 
 To contribute to `hypersdk`, you'll need:
 
-- [Go](https://golang.org/dl/) 1.19 or higher
+- [Go](https://golang.org/dl/) 1.20 or higher
 
 ### Setting up your development environment
 

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ To use the `hypersdk`, you must import it into your own `hypervm` and implement 
 required interfaces. Below, we'll cover some of the ones that your
 `hypervm` must implement.
 
-> *Note: hypersdk requires a minimum Go version of 1.19.*
+> _Note: `hypersdk` requires a minimum Go version of 1.20_
 
 ### Controller
 ```golang

--- a/chain/transaction.go
+++ b/chain/transaction.go
@@ -142,7 +142,7 @@ func (t *Transaction) PreExecute(
 		return ErrInsufficientPrice
 	}
 	if _, err := t.Auth.Verify(ctx, r, db, t.Action); err != nil {
-		return fmt.Errorf("%w: %v", ErrAuthFailed, err)
+		return fmt.Errorf("%w: %v", ErrAuthFailed, err) //nolint:errorlint
 	}
 	return t.Auth.CanDeduct(ctx, db, t.MaxUnits(r)*unitPrice)
 }

--- a/examples/tokenvm/.golangci.yml
+++ b/examples/tokenvm/.golangci.yml
@@ -98,7 +98,7 @@ linters-settings:
       - name: useless-break
         disabled: false
   staticcheck:
-    go: "1.18"
+    go: "1.20"
     # https://staticcheck.io/docs/options#checks
     checks:
       - "all"

--- a/examples/tokenvm/README.md
+++ b/examples/tokenvm/README.md
@@ -286,6 +286,31 @@ height:6 txs:1 units:464 root:M5M5ZXNAPoBvkkjRCzpFD8qKkiuKpZKSYCSvdhby3gYA7GKww
 ✅ 2iTnmhJUiUvC3wrwx8KLkV4aCJJCWAwZVRE8YVp8i6LdpDTyqg actor: token1rvzhmceq997zntgvravfagsks6w0ryud3rylh4cdvayry0dl97nsjzf3yp units: 464 summary (*actions.CloseOrder): [orderID: DZK5sQGk8jTyAfcPDxfHwdx5z9WFEFeqKQPgpNevLkeRV52xq]
 ```
 
+## Running a Load Test
+The `tokenvm` load test will provision 5 `tokenvms` and process 500k transfers
+on each between 10k different accounts.
+
+```bash
+./scripts/tests.load.sh
+```
+
+_This test SOLELY tests the speed of the `tokenvm`. It does not include any
+network delay or consensus overhead. It just tests the underlying performance
+of the `hypersdk` and the storage engine used (in this case MerkleDB on top of
+Pebble)._
+
+### Measuring Disk Speed
+This test is extremely sensitive to disk performance. When reporting any TPS
+results, please include the output of:
+
+```bash
+./scripts/tests.disk.sh
+```
+
+_Run this test RARELY. It writes/reads many GBs from your disk and can fry an
+SSD if you run it too often. We run this in CI to standardize the result of all
+load tests._
+
 ## Future Work
 _If you want to take the lead on any of these items, please
 [start a discussion](https://github.com/ava-labs/hypersdk/discussions) or reach

--- a/examples/tokenvm/README.md
+++ b/examples/tokenvm/README.md
@@ -5,9 +5,10 @@
   Mint, Transfer, and Trade User-Generated Tokens, All On-Chain
 </p>
 <p align="center">
+  <a href="https://github.com/ava-labs/hypersdk/actions/workflows/tokenvm-static-analysis.yml"><img src="https://github.com/ava-labs/hypersdk/actions/workflows/tokenvm-static-analysis.yml/badge.svg" /></a>
   <a href="https://github.com/ava-labs/hypersdk/actions/workflows/tokenvm-unit-tests.yml"><img src="https://github.com/ava-labs/hypersdk/actions/workflows/tokenvm-unit-tests.yml/badge.svg" /></a>
   <a href="https://github.com/ava-labs/hypersdk/actions/workflows/tokenvm-sync-tests.yml"><img src="https://github.com/ava-labs/hypersdk/actions/workflows/tokenvm-sync-tests.yml/badge.svg" /></a>
-  <a href="https://github.com/ava-labs/hypersdk/actions/workflows/tokenvm-static-analysis.yml"><img src="https://github.com/ava-labs/hypersdk/actions/workflows/tokenvm-static-analysis.yml/badge.svg" /></a>
+  <a href="https://github.com/ava-labs/hypersdk/actions/workflows/tokenvm-load-tests.yml"><img src="https://github.com/ava-labs/hypersdk/actions/workflows/tokenvm-load-tests.yml/badge.svg" /></a>
 </p>
 
 We created the [`tokenvm`](./examples/tokenvm) to showcase how to use the

--- a/examples/tokenvm/config/config.go
+++ b/examples/tokenvm/config/config.go
@@ -1,7 +1,5 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
-//
-//nolint:revive
 package config
 
 import (

--- a/examples/tokenvm/go.mod
+++ b/examples/tokenvm/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e // indirect
 	github.com/cockroachdb/errors v1.8.1 // indirect
 	github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f // indirect
-	github.com/cockroachdb/pebble v0.0.0-20230217215838-f01d8eff3f8b // indirect
+	github.com/cockroachdb/pebble v0.0.0-20230224221607-fccb83b60d5c // indirect
 	github.com/cockroachdb/redact v1.0.8 // indirect
 	github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/examples/tokenvm/go.mod
+++ b/examples/tokenvm/go.mod
@@ -1,6 +1,6 @@
 module github.com/ava-labs/hypersdk/examples/tokenvm
 
-go 1.18
+go 1.20
 
 require (
 	github.com/ava-labs/avalanche-network-runner v1.3.5

--- a/examples/tokenvm/go.sum
+++ b/examples/tokenvm/go.sum
@@ -132,8 +132,8 @@ github.com/cockroachdb/errors v1.8.1 h1:A5+txlVZfOqFBDa4mGz2bUWSp0aHElvHX2bKkdbQ
 github.com/cockroachdb/errors v1.8.1/go.mod h1:qGwQn6JmZ+oMjuLwjWzUNqblqk0xl4CVV3SQbGwK7Ac=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f h1:o/kfcElHqOiXqcou5a3rIlMc7oJbMQkeLk0VQJ7zgqY=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
-github.com/cockroachdb/pebble v0.0.0-20230217215838-f01d8eff3f8b h1:SbHWO4K6cZ+8SL8Pyhj2c/Q5BKvHvAcVQgUE0/KqBiA=
-github.com/cockroachdb/pebble v0.0.0-20230217215838-f01d8eff3f8b/go.mod h1:9lRMC4XN3/BLPtIp6kAKwIaHu369NOf2rMucPzipz50=
+github.com/cockroachdb/pebble v0.0.0-20230224221607-fccb83b60d5c h1:BvCMEtKLZrlcBY2li3COY2q9335JHRK9bC8YTsx60/E=
+github.com/cockroachdb/pebble v0.0.0-20230224221607-fccb83b60d5c/go.mod h1:9lRMC4XN3/BLPtIp6kAKwIaHu369NOf2rMucPzipz50=
 github.com/cockroachdb/redact v1.0.8 h1:8QG/764wK+vmEYoOlfobpe12EQcS81ukx/a4hdVMxNw=
 github.com/cockroachdb/redact v1.0.8/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2 h1:IKgmqgMQlVJIZj19CdocBeSfSaiCbEBZGKODaixqtHM=

--- a/examples/tokenvm/scripts/tests.disk.sh
+++ b/examples/tokenvm/scripts/tests.disk.sh
@@ -11,5 +11,5 @@ if ! [[ "$0" =~ scripts/tests.disk.sh ]]; then
   exit 255
 fi
 
-go install -v github.com/cunnie/gobonniego/gobonniego@latest
-gobonniego
+go install -v github.com/cunnie/gobonniego/gobonniego@3ef1d09d1be6d0aa7c760600be80e111393d8ed1
+gobonniego -v --runs 3 --size 100 --iops-duration=60

--- a/examples/tokenvm/scripts/tests.disk.sh
+++ b/examples/tokenvm/scripts/tests.disk.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
+# See the file LICENSE for licensing terms.
+
+set -o errexit
+set -o pipefail
+set -e
+
+if ! [[ "$0" =~ scripts/tests.disk.sh ]]; then
+  echo "must be run from repository root"
+  exit 255
+fi
+
+go install -v github.com/cunnie/gobonniego/gobonniego@latest
+gobonniego

--- a/examples/tokenvm/scripts/tests.disk.sh
+++ b/examples/tokenvm/scripts/tests.disk.sh
@@ -29,35 +29,35 @@ fi
 
 # This testing approach was inspired by this article:
 # https://cloud.google.com/compute/docs/disks/benchmarking-pd-performance
-echo "testing write throughput"
+echo -e "\033[0;32mtesting write throughput\033[0m"
 rm -rf tmp-storage-testing
 mkdir -p tmp-storage-testing
-fio --name=write_throughput --directory=tmp-storage-testing --numjobs=16 \
---size=10G --time_based --runtime=60s --ramp_time=2s \
+fio --name=write_throughput --directory=tmp-storage-testing --numjobs=5 \
+--size=10G --time_based --runtime=30s --ramp_time=2s \
 --direct=1 --verify=0 --bs=1M --iodepth=64 --rw=write \
 --group_reporting=1
 
-echo "testing write iops"
+echo -e "\033[0;32mtesting write iops\033[0m"
 rm -rf tmp-storage-testing
 mkdir -p tmp-storage-testing
 fio --name=write_iops --directory=tmp-storage-testing --size=10G \
---time_based --runtime=60s --ramp_time=2s --direct=1 \
+--time_based --runtime=30s --ramp_time=2s --direct=1 \
 --verify=0 --bs=4K --iodepth=256 --rw=randwrite --group_reporting=1
 
-echo "testing read throughput"
+echo -e "\033[0;32mtesting read throughput\033[0m"
 rm -rf tmp-storage-testing
 mkdir -p tmp-storage-testing
-fio --name=read_throughput --directory=tmp-storage-testing --numjobs=16 \
---size=10G --time_based --runtime=60s --ramp_time=2s \
+fio --name=read_throughput --directory=tmp-storage-testing --numjobs=5 \
+--size=10G --time_based --runtime=30s --ramp_time=2s \
 --direct=1 --verify=0 --bs=1M --iodepth=64 --rw=read \
 --group_reporting=1
 
-echo "testing read iops"
+echo -e "\033[0;32mtesting read iops\033[0m"
 rm -rf tmp-storage-testing
 mkdir -p tmp-storage-testing
 fio --name=read_iops --directory=tmp-storage-testing --size=10G \
---time_based --runtime=60s --ramp_time=2s --direct=1 \
+--time_based --runtime=30s --ramp_time=2s --direct=1 \
 --verify=0 --bs=4K --iodepth=256 --rw=randread --group_reporting=1
 
-echo "cleaning up..."
+echo -e "\033[0;32mcleaning up...\033[0m"
 rm -rf tmp-storage-testing

--- a/examples/tokenvm/scripts/tests.lint.sh
+++ b/examples/tokenvm/scripts/tests.lint.sh
@@ -34,7 +34,7 @@ TESTS=${TESTS:-"golangci_lint license_header"}
 
 # https://github.com/golangci/golangci-lint/releases
 function test_golangci_lint {
-  go install -v github.com/golangci/golangci-lint/cmd/golangci-lint@v1.49.0 || true
+  go install -v github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.2 || true
   golangci-lint run --config .golangci.yml
 }
 

--- a/examples/tokenvm/scripts/tests.lint.sh
+++ b/examples/tokenvm/scripts/tests.lint.sh
@@ -2,7 +2,6 @@
 # Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 # See the file LICENSE for licensing terms.
 
-
 set -o errexit
 set -o pipefail
 set -e

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ava-labs/hypersdk
 
-go 1.19
+go 1.20
 
 require (
 	github.com/ava-labs/avalanchego v1.9.9

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/ava-labs/avalanchego v1.9.9
-	github.com/cockroachdb/pebble v0.0.0-20230217215838-f01d8eff3f8b
+	github.com/cockroachdb/pebble v0.0.0-20230224221607-fccb83b60d5c
 	github.com/golang/mock v1.6.0
 	github.com/gorilla/rpc v1.2.0
 	github.com/neilotoole/errgroup v0.1.6

--- a/go.sum
+++ b/go.sum
@@ -106,8 +106,8 @@ github.com/cockroachdb/errors v1.8.1 h1:A5+txlVZfOqFBDa4mGz2bUWSp0aHElvHX2bKkdbQ
 github.com/cockroachdb/errors v1.8.1/go.mod h1:qGwQn6JmZ+oMjuLwjWzUNqblqk0xl4CVV3SQbGwK7Ac=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f h1:o/kfcElHqOiXqcou5a3rIlMc7oJbMQkeLk0VQJ7zgqY=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
-github.com/cockroachdb/pebble v0.0.0-20230217215838-f01d8eff3f8b h1:SbHWO4K6cZ+8SL8Pyhj2c/Q5BKvHvAcVQgUE0/KqBiA=
-github.com/cockroachdb/pebble v0.0.0-20230217215838-f01d8eff3f8b/go.mod h1:9lRMC4XN3/BLPtIp6kAKwIaHu369NOf2rMucPzipz50=
+github.com/cockroachdb/pebble v0.0.0-20230224221607-fccb83b60d5c h1:BvCMEtKLZrlcBY2li3COY2q9335JHRK9bC8YTsx60/E=
+github.com/cockroachdb/pebble v0.0.0-20230224221607-fccb83b60d5c/go.mod h1:9lRMC4XN3/BLPtIp6kAKwIaHu369NOf2rMucPzipz50=
 github.com/cockroachdb/redact v1.0.8 h1:8QG/764wK+vmEYoOlfobpe12EQcS81ukx/a4hdVMxNw=
 github.com/cockroachdb/redact v1.0.8/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2 h1:IKgmqgMQlVJIZj19CdocBeSfSaiCbEBZGKODaixqtHM=

--- a/mempool/sorted_mempool.go
+++ b/mempool/sorted_mempool.go
@@ -94,7 +94,7 @@ func (sm *SortedMempool[T]) SetMinVal(val uint64) []T {
 // PeekMin returns the minimum value in sm.
 func (sm *SortedMempool[T]) PeekMin() (T, bool) {
 	if sm.minHeap.Len() == 0 {
-		return *new(T), false //nolint:gocritic
+		return *new(T), false
 	}
 	return sm.minHeap.items[0].Item, true
 }
@@ -102,7 +102,7 @@ func (sm *SortedMempool[T]) PeekMin() (T, bool) {
 // PopMin removes the minimum value in sm.
 func (sm *SortedMempool[T]) PopMin() (T, bool) {
 	if sm.minHeap.Len() == 0 {
-		return *new(T), false //nolint:gocritic
+		return *new(T), false
 	}
 	item := sm.minHeap.items[0].Item
 	sm.Remove(item.ID())
@@ -112,7 +112,7 @@ func (sm *SortedMempool[T]) PopMin() (T, bool) {
 // PopMin returns the maximum value in sm.
 func (sm *SortedMempool[T]) PeekMax() (T, bool) {
 	if sm.Len() == 0 {
-		return *new(T), false //nolint:gocritic
+		return *new(T), false
 	}
 	return sm.maxHeap.items[0].Item, true
 }
@@ -120,7 +120,7 @@ func (sm *SortedMempool[T]) PeekMax() (T, bool) {
 // PopMin removes the maximum value in sm.
 func (sm *SortedMempool[T]) PopMax() (T, bool) {
 	if sm.Len() == 0 {
-		return *new(T), false //nolint:gocritic
+		return *new(T), false
 	}
 	item := sm.maxHeap.items[0].Item
 	sm.Remove(item.ID())

--- a/scripts/tests.lint.sh
+++ b/scripts/tests.lint.sh
@@ -28,7 +28,7 @@ TESTS=${TESTS:-"golangci_lint license_header"}
 
 # https://github.com/golangci/golangci-lint/releases
 function test_golangci_lint {
-  go install -v github.com/golangci/golangci-lint/cmd/golangci-lint@v1.47.3
+  go install -v github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.2
   golangci-lint run --config .golangci.yml
 }
 

--- a/utils/bounded_buffer.go
+++ b/utils/bounded_buffer.go
@@ -51,7 +51,7 @@ func (b *BoundedBuffer[K]) Insert(h K) {
 // [K] and [false].
 func (b *BoundedBuffer[K]) Last() (K, bool) {
 	if b.lastPos == -1 {
-		return *new(K), false //nolint:gocritic
+		return *new(K), false
 	}
 	return b.buffer[b.lastPos], true
 }


### PR DESCRIPTION
Bumps the minimum version from `1.19` to `1.20` for some nice new syntax features that can greatly reduce memory usage: https://go.dev/blog/go1.20

Blocks: #23 