### PR TITLE
automated devent deploy + skip verify on build

### DIFF
--- a/.github/workflows/tokenvm-load-tests.yml
+++ b/.github/workflows/tokenvm-load-tests.yml
@@ -17,12 +17,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Install fio
-        run: sudo apt-get -y install fio
-      - name: Run disk tests
-        working-directory: ./examples/tokenvm
-        shell: bash
-        run: scripts/tests.disk.sh
+          # - name: Install fio
+          #   run: sudo apt-get -y install fio
+          # - name: Run disk tests
+          #   working-directory: ./examples/tokenvm
+          #   shell: bash
+          #   run: scripts/tests.disk.sh
       - name: Set up Go
         uses: actions/setup-go@v3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ dist/
 tmp-storage-testing
 .token-cli*
 *.html
+data/

--- a/README.md
+++ b/README.md
@@ -582,7 +582,6 @@ compatible with most `hypervms` (and maintained in the `hypersdk`)._
 
 ## Star History
 <p align="center">
-  <img width="90%" alt="hypersdk" src="assets/logo.png">
   <a href="https://star-history.com/#ava-labs/hypersdk&Date"><img width="90%" alt="star history" src="https://api.star-history.com/svg?repos=ava-labs/hypersdk&type=Date" /></a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -580,6 +580,12 @@ that it can understand (so that it can parse inbound AWM messages). In the
 future, we expect that there will be common message definitions that will be
 compatible with most `hypervms` (and maintained in the `hypersdk`)._
 
+## Star History
+<p align="center">
+  <img width="90%" alt="hypersdk" src="assets/logo.png">
+  <a href="https://star-history.com/#ava-labs/hypersdk&Date"><img width="90%" alt="star history" src="https://api.star-history.com/svg?repos=ava-labs/hypersdk&type=Date" /></a>
+</p>
+
 ## Future Work
 _If you want to take the lead on any of these items, please
 [start a discussion](https://github.com/ava-labs/hypersdk/discussions) or reach

--- a/chain/block.go
+++ b/chain/block.go
@@ -5,6 +5,7 @@ package chain
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
 	"time"
 
@@ -97,6 +98,7 @@ type StatelessBlock struct {
 	txsSet set.Set[ids.ID]
 
 	warpMessages map[ids.ID]*warpJob
+	containsWarp bool // this allows us to avoid allocating a map when we build
 	bctx         *block.Context
 	vdrState     validators.State
 
@@ -143,7 +145,8 @@ func ParseBlock(
 	return ParseStatefulBlock(ctx, blk, source, status, vm)
 }
 
-func (b *StatelessBlock) populateTxs(ctx context.Context, verifySigs bool) error {
+// populateTxs is only called on blocks we did not build
+func (b *StatelessBlock) populateTxs(ctx context.Context) error {
 	ctx, span := b.vm.Tracer().Start(ctx, "StatelessBlock.populateTxs")
 	defer span.End()
 
@@ -159,10 +162,7 @@ func (b *StatelessBlock) populateTxs(ctx context.Context, verifySigs bool) error
 	b.txsSet = set.NewSet[ids.ID](len(b.Txs))
 	b.warpMessages = map[ids.ID]*warpJob{}
 	for _, tx := range b.Txs {
-		sigTask := tx.AuthAsyncVerify()
-		if verifySigs {
-			b.sigJob.Go(sigTask)
-		}
+		b.sigJob.Go(tx.AuthAsyncVerify())
 		if b.txsSet.Contains(tx.ID()) {
 			return ErrDuplicateTx
 		}
@@ -188,6 +188,7 @@ func (b *StatelessBlock) populateTxs(ctx context.Context, verifySigs bool) error
 				verifiedChan: make(chan bool, 1),
 				warpNum:      len(b.warpMessages),
 			}
+			b.containsWarp = true
 		}
 	}
 	b.sigJob.Done(func() { sspan.End() })
@@ -243,13 +244,12 @@ func ParseStatefulBlock(
 	}
 
 	// Populate hashes and tx set
-	return b, b.populateTxs(ctx, true)
+	return b, b.populateTxs(ctx)
 }
 
-// [init] is used during block building and testing
-// TODO: remove init
-func (b *StatelessBlock) init(ctx context.Context, results []*Result, validateSigs bool) error {
-	ctx, span := b.vm.Tracer().Start(ctx, "StatelessBlock.init")
+// [initializeBuilt] is invoked after a block is built
+func (b *StatelessBlock) initializeBuilt(ctx context.Context, state merkledb.TrieView, results []*Result) error {
+	_, span := b.vm.Tracer().Start(ctx, "StatelessBlock.initializeBuilt")
 	defer span.End()
 
 	blk, err := b.StatefulBlock.Marshal(b.vm.Registry())
@@ -258,11 +258,17 @@ func (b *StatelessBlock) init(ctx context.Context, results []*Result, validateSi
 	}
 	b.bytes = blk
 	b.id = utils.ToID(b.bytes)
+	b.state = state
 	b.t = time.Unix(b.StatefulBlock.Tmstmp, 0)
 	b.results = results
-
-	// Populate hashes and tx set
-	return b.populateTxs(ctx, validateSigs)
+	b.txsSet = set.NewSet[ids.ID](len(b.Txs))
+	for _, tx := range b.Txs {
+		b.txsSet.Add(tx.ID())
+		if tx.WarpMessage != nil {
+			b.containsWarp = true
+		}
+	}
+	return nil
 }
 
 // implements "snowman.Block.choices.Decidable"
@@ -270,7 +276,7 @@ func (b *StatelessBlock) ID() ids.ID { return b.id }
 
 // implements "block.WithVerifyContext"
 func (b *StatelessBlock) ShouldVerifyWithContext(context.Context) (bool, error) {
-	return len(b.warpMessages) > 0, nil
+	return b.containsWarp, nil
 }
 
 // implements "block.WithVerifyContext"
@@ -283,6 +289,7 @@ func (b *StatelessBlock) VerifyWithContext(ctx context.Context, bctx *block.Cont
 			attribute.Int64("height", int64(b.Hght)),
 			attribute.Bool("stateReady", stateReady),
 			attribute.Int64("pchainHeight", int64(bctx.PChainHeight)),
+			attribute.Bool("built", b.Processed()),
 		),
 	)
 	defer span.End()
@@ -303,6 +310,7 @@ func (b *StatelessBlock) Verify(ctx context.Context) error {
 			attribute.Int("txs", len(b.Txs)),
 			attribute.Int64("height", int64(b.Hght)),
 			attribute.Bool("stateReady", stateReady),
+			attribute.Bool("built", b.Processed()),
 		),
 	)
 	defer span.End()
@@ -311,9 +319,18 @@ func (b *StatelessBlock) Verify(ctx context.Context) error {
 }
 
 func (b *StatelessBlock) verify(ctx context.Context, stateReady bool) error {
-	// If the state of the accepted tip has been fully fetched, it is safe to
-	// verify any block.
-	if stateReady {
+	log := b.vm.Logger()
+	switch {
+	case !stateReady:
+		// If the state of the accepted tip has not been fully fetched, it is not safe to
+		// verify any block.
+		log.Info("skipping verification, state not ready", zap.Uint64("height", b.Hght), zap.Stringer("blkID", b.ID()))
+	case b.Processed():
+		// If we built the block, the state will already be populated and we don't
+		// need to compute it (we assume that we built a correct block and it isn't
+		// necessary to re-verify anything).
+		log.Info("skipping verification, already processed", zap.Uint64("height", b.Hght), zap.Stringer("blkID", b.ID()))
+	default:
 		// Parent may not be processed when we verify this block so [verify] may
 		// recursively compute missing state.
 		state, err := b.innerVerify(ctx)
@@ -325,7 +342,7 @@ func (b *StatelessBlock) verify(ctx context.Context, stateReady bool) error {
 
 	// At any point after this, we may attempt to verify the block. We should be
 	// sure we are prepared to do so.
-
+	//
 	// NOTE: mempool is modified by VM handler
 	b.vm.Verified(ctx, b)
 	return nil
@@ -387,9 +404,8 @@ func (b *StatelessBlock) verifyWarpMessage(ctx context.Context, r Rules, msg *wa
 //     state sync)
 func (b *StatelessBlock) innerVerify(ctx context.Context) (merkledb.TrieView, error) {
 	var (
-		log   = b.vm.Logger()
-		built = len(b.results) > 0
-		r     = b.vm.Rules(b.Tmstmp)
+		log = b.vm.Logger()
+		r   = b.vm.Rules(b.Tmstmp)
 	)
 
 	// Perform basic correctness checks before doing any expensive work
@@ -452,7 +468,7 @@ func (b *StatelessBlock) innerVerify(ctx context.Context) (merkledb.TrieView, er
 
 	// Start validating warp messages, if they exist
 	var invalidWarpResult bool
-	if len(b.warpMessages) > 0 {
+	if b.containsWarp {
 		if b.bctx == nil {
 			log.Error(
 				"missing verify block context",
@@ -567,9 +583,12 @@ func (b *StatelessBlock) innerVerify(ctx context.Context) (merkledb.TrieView, er
 		return nil, ErrWarpResultMismatch
 	}
 
+	// Store height in state to prevent duplicate roots
+	if err := state.Insert(ctx, b.vm.StateManager().HeightKey(), binary.BigEndian.AppendUint64(nil, b.Hght)); err != nil {
+		return nil, err
+	}
+
 	// Compute state root
-	// TODO: consider adding the parent root or height here to ensure state roots
-	// are never repeated
 	computedRoot, err := state.GetMerkleRoot(ctx)
 	if err != nil {
 		return nil, err
@@ -584,13 +603,10 @@ func (b *StatelessBlock) innerVerify(ctx context.Context) (merkledb.TrieView, er
 	}
 
 	// Ensure signatures are verified
-	if !built { // don't need to verify sigs if built
-		_, sspan := b.vm.Tracer().Start(ctx, "StatelessBlock.Verify.WaitSignatures")
-		if err := b.sigJob.Wait(); err != nil {
-			sspan.End()
-			return nil, err
-		}
-		sspan.End()
+	_, sspan := b.vm.Tracer().Start(ctx, "StatelessBlock.Verify.WaitSignatures")
+	defer sspan.End()
+	if err := b.sigJob.Wait(); err != nil {
+		return nil, err
 	}
 	return state, nil
 }

--- a/chain/block.go
+++ b/chain/block.go
@@ -589,10 +589,12 @@ func (b *StatelessBlock) innerVerify(ctx context.Context) (merkledb.TrieView, er
 	}
 
 	// Compute state root
+	start := time.Now()
 	computedRoot, err := state.GetMerkleRoot(ctx)
 	if err != nil {
 		return nil, err
 	}
+	b.vm.RecordRootCalculated(time.Since(start))
 	if b.StateRoot != computedRoot {
 		return nil, fmt.Errorf(
 			"%w: expected=%s found=%s",
@@ -605,9 +607,11 @@ func (b *StatelessBlock) innerVerify(ctx context.Context) (merkledb.TrieView, er
 	// Ensure signatures are verified
 	_, sspan := b.vm.Tracer().Start(ctx, "StatelessBlock.Verify.WaitSignatures")
 	defer sspan.End()
+	start = time.Now()
 	if err := b.sigJob.Wait(); err != nil {
 		return nil, err
 	}
+	b.vm.RecordWaitSignatures(time.Since(start))
 	return state, nil
 }
 

--- a/chain/block.go
+++ b/chain/block.go
@@ -135,8 +135,6 @@ func ParseBlock(
 	ctx, span := vm.Tracer().Start(ctx, "chain.ParseBlock")
 	defer span.End()
 
-	// TODO: avoid un-marshaling again if we already have ID
-	// (https://github.com/ava-labs/hypersdk/issues/125)
 	blk, err := UnmarshalBlock(source, vm)
 	if err != nil {
 		return nil, err

--- a/chain/block.go
+++ b/chain/block.go
@@ -135,6 +135,8 @@ func ParseBlock(
 	ctx, span := vm.Tracer().Start(ctx, "chain.ParseBlock")
 	defer span.End()
 
+	// TODO: avoid un-marshaling again if we already have ID
+	// (https://github.com/ava-labs/hypersdk/issues/125)
 	blk, err := UnmarshalBlock(source, vm)
 	if err != nil {
 		return nil, err

--- a/chain/dependencies.go
+++ b/chain/dependencies.go
@@ -105,6 +105,7 @@ type Rules interface {
 // in a structured manner. If we did not use [StateManager], we may overwrite
 // state written by actions or auth.
 type StateManager interface {
+	HeightKey() []byte
 	IncomingWarpKey(sourceChainID ids.ID, msgID ids.ID) []byte
 	OutgoingWarpKey(txID ids.ID) []byte
 }

--- a/chain/dependencies.go
+++ b/chain/dependencies.go
@@ -5,6 +5,7 @@ package chain
 
 import (
 	"context"
+	"time"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
@@ -62,6 +63,13 @@ type VM interface {
 	// and false if the sync completed with the previous root.
 	UpdateSyncTarget(*StatelessBlock) (bool, error)
 	StateReady() bool
+
+	// Record the duration of various operations to populate chain metrics
+	//
+	// If there was a long-lived [Chain] struct, we would store metrics for chain
+	// there.
+	RecordRootCalculated(t time.Duration) // only called in Verify
+	RecordWaitSignatures(t time.Duration) // only called in Verify
 }
 
 type Mempool interface {

--- a/chain/transaction.go
+++ b/chain/transaction.go
@@ -125,8 +125,6 @@ func (t *Transaction) Expiry() int64 { return t.Base.Timestamp }
 func (t *Transaction) UnitPrice() uint64 { return t.Base.UnitPrice }
 
 // It is ok to have duplicate ReadKeys...the processor will skip them
-//
-// TODO: verify the invariant that [t.id] is set by this point
 func (t *Transaction) StateKeys(stateMapping StateManager) [][]byte {
 	keys := append(t.Action.StateKeys(t.Auth, t.ID()), t.Auth.StateKeys()...)
 	if t.WarpMessage != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -14,12 +14,20 @@ import (
 	"github.com/ava-labs/hypersdk/vm"
 )
 
+const avalancheGoMinCPU = 4
+
 var _ vm.Config = (*Config)(nil)
 
 type Config struct{}
 
-func (c *Config) GetLogLevel() logging.Level             { return logging.Info }
-func (c *Config) GetParallelism() int                    { return runtime.NumCPU() }
+func (c *Config) GetLogLevel() logging.Level { return logging.Info }
+func (c *Config) GetParallelism() int {
+	numCPUs := runtime.NumCPU()
+	if numCPUs > avalancheGoMinCPU {
+		return numCPUs - avalancheGoMinCPU
+	}
+	return 1
+}
 func (c *Config) GetMempoolSize() int                    { return 2_048 }
 func (c *Config) GetMempoolPayerSize() int               { return 32 }
 func (c *Config) GetMempoolExemptPayers() [][]byte       { return nil }

--- a/config/config.go
+++ b/config/config.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/profiler"
-	"github.com/ava-labs/avalanchego/utils/units"
 	"github.com/ava-labs/hypersdk/trace"
 	"github.com/ava-labs/hypersdk/vm"
 )
@@ -28,13 +27,13 @@ func (c *Config) GetDecisionsPort() uint16               { return 0 } // auto-as
 func (c *Config) GetBlocksPort() uint16                  { return 0 } // auto-assigned
 func (c *Config) GetStreamingBacklogSize() int           { return 1024 }
 func (c *Config) GetStateHistoryLength() int             { return 256 }
-func (c *Config) GetStateCacheSize() int                 { return 1 * units.GiB }
+func (c *Config) GetStateCacheSize() int                 { return 65_536 } // nodes
 func (c *Config) GetAcceptorSize() int                   { return 1024 }
 func (c *Config) GetTraceConfig() *trace.Config          { return &trace.Config{Enabled: false} }
 func (c *Config) GetStateSyncParallelism() int           { return 4 }
 func (c *Config) GetStateSyncMinBlocks() uint64          { return 256 }
 func (c *Config) GetStateSyncServerDelay() time.Duration { return 0 } // used for testing
-func (c *Config) GetBlockLRUSize() int { return 128 }
+func (c *Config) GetBlockLRUSize() int                   { return 128 }
 
 func (c *Config) GetContinuousProfilerConfig() *profiler.Config {
 	return &profiler.Config{Enabled: false}

--- a/config/config.go
+++ b/config/config.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/ava-labs/avalanchego/utils/logging"
+	"github.com/ava-labs/avalanchego/utils/profiler"
 	"github.com/ava-labs/avalanchego/utils/units"
 	"github.com/ava-labs/hypersdk/trace"
 	"github.com/ava-labs/hypersdk/vm"
@@ -34,3 +35,6 @@ func (c *Config) GetStateSyncParallelism() int           { return 4 }
 func (c *Config) GetStateSyncMinBlocks() uint64          { return 256 }
 func (c *Config) GetStateSyncServerDelay() time.Duration { return 0 } // used for testing
 func (c *Config) GetBlockLRUSize() int                   { return 128 }
+func (c *Config) GetContinuousProfilerConfig() *profiler.Config {
+	return &profiler.Config{Enabled: false}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -34,7 +34,8 @@ func (c *Config) GetTraceConfig() *trace.Config          { return &trace.Config{
 func (c *Config) GetStateSyncParallelism() int           { return 4 }
 func (c *Config) GetStateSyncMinBlocks() uint64          { return 256 }
 func (c *Config) GetStateSyncServerDelay() time.Duration { return 0 } // used for testing
-func (c *Config) GetBlockLRUSize() int                   { return 128 }
+func (c *Config) GetBlockLRUSize() int { return 128 }
+
 func (c *Config) GetContinuousProfilerConfig() *profiler.Config {
 	return &profiler.Config{Enabled: false}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -31,6 +31,7 @@ func (c *Config) GetParallelism() int {
 func (c *Config) GetMempoolSize() int                    { return 2_048 }
 func (c *Config) GetMempoolPayerSize() int               { return 32 }
 func (c *Config) GetMempoolExemptPayers() [][]byte       { return nil }
+func (c *Config) GetMempoolVerifyBalances() bool         { return true }
 func (c *Config) GetDecisionsPort() uint16               { return 0 } // auto-assigned
 func (c *Config) GetBlocksPort() uint16                  { return 0 } // auto-assigned
 func (c *Config) GetStreamingBacklogSize() int           { return 1024 }

--- a/examples/tokenvm/DEVNETS.md
+++ b/examples/tokenvm/DEVNETS.md
@@ -51,7 +51,7 @@ building with [`v3+`](https://github.com/golang/go/wiki/MinimumRequirements#amd6
 ```
 
 
-### Step 3: Plan Local Network Deploy
+### Step 5: Plan Local Network Deploy
 
 Now we can spin up a new network of 6 nodes with some defaults:
 - `avalanche-ops` supports [Graviton-based processors](https://aws.amazon.com/ec2/graviton/) (ARM64). Use `--arch-type arm64` to run nodes in ARM64 CPUs.
@@ -94,9 +94,29 @@ avalancheup-aws default-spec \
 
 It is recommended to specify your own artifacts to avoid flaky github release page downloads.
 
-### Step 4: Apply Local Network Deploy
+#### Restricting Instance Types
+By default, `avalanche-ops` will attempt to use all available instance types in
+a region in your cluster. If you'd like to restrict which instance types are used,
+edit the output `aops-custom-****-***.yaml` file before deploying:
+```yaml
+machine:
+  anchor_nodes: 3
+  non_anchor_nodes: 3
+  arch_type: amd64
+  rust_os_type: ubuntu20.04
+  instance_types:
+  - t3a.2xlarge
+  - t3.2xlarge
+  - t2.2xlarge
+  - c6a.2xlarge
+  - m6a.2xlarge
+  - m5.2xlarge
+  - c5.2xlarge
+```
 
-The `default-spec` command itselt does not create any resources, and instead outputs the following `apply` and `delete` commands that you can copy and paste:
+### Step 6: Apply Local Network Deploy
+
+The `default-spec` command itself does not create any resources, and instead outputs the following `apply` and `delete` commands that you can copy and paste:
 
 ```bash
 # first make sure you have access to the AWS credential
@@ -138,12 +158,14 @@ group to restrict the inbound rules to your IP.
 where AWS SDK call hangs, which blocks node bootstraps. If a node takes too long to start, connect to that
 instance (e..g, use SSM sesson from your AWS console), and restart the agent with the command `sudo systemctl restart avalanched-aws`.
 
-### Step 5: Install Subnets
+### Step 7: Generate Configs
 
 Now that the network and nodes are up, let's install two subnets, each of which runs its own `tokenvm`. Use the following commands to
 do so (similar to [scripts/run.sh](./scripts/run.sh)):
 
 ```bash
+rm -rf /tmp/avalanche-ops
+
 avalancheup-aws subnet-config \
 --log-level=info \
 --proposer-min-block-delay 0 \
@@ -154,28 +176,28 @@ cat <<EOF > /tmp/avalanche-ops/allocations.json
 EOF
 rm -f /tmp/avalanche-ops/tokenvm-genesis.json
 /tmp/token-cli genesis generate /tmp/avalanche-ops/allocations.json \
---genesis-file /tmp/tokenvm-genesis.json
-cat /tmp/tokenvm-genesis.json
+--genesis-file /tmp/avalanche-ops/tokenvm-genesis.json
+cat /tmp/avalanche-ops/tokenvm-genesis.json
 
-cat <<EOF > /tmp/tokenvm-chain-config.json
+cat <<EOF > /tmp/avalanche-ops/tokenvm-chain-config.json
 {
   "mempoolSize": 10000000,
+  "mempoolPayerSize": 10000000,
   "mempoolExemptPayers":["token1rvzhmceq997zntgvravfagsks6w0ryud3rylh4cdvayry0dl97nsjzf3yp"],
-  "parallelism": 5,
+  "streamingBacklogSize": 10000000,
   "trackedPairs":["*"],
-  "logLevel": "info",
-  "stateSyncServerDelay": 0
+  "logLevel": "info"
 }
 EOF
-cat /tmp/tokenvm-chain-config.json
+cat /tmp/avalanche-ops/tokenvm-chain-config.json
 ```
 
-Note that `--chain-name tokenvm*` and `--node-ids-to-instance-ids` values are different to split nodes into two separate subnets. And `avalancheup-aws install-subnet-chain` **will add the specified nodes as primary network validators (regardless of it's for customer or public networks) before adding them as subnet validators**. So, please make sure the `--key` has enough balance and use `--primary-network-validate-period-in-days` and `--subnet-validate-period-in-days` flags to set custom validate priods (defaults to 16-day for primary network, 14-day for subnet validation):
+### Step 8: Install Chains
+You can run the following commands to spin up 2 `tokenvm` Devnets. Make sure to
+replace the `***` fields, IP addresses, key, and `node-ids-to-instance-ids` with your own data:
 
 ```bash
-# this will prompt you to confirm the outcome!
-# so make sure to check the outputs!
-avalancheup-aws install-subnet-chain \
+/tmp/avalancheup-aws install-subnet-chain \
 --log-level info \
 --region us-west-2 \
 --s3-bucket avalanche-ops-***-us-west-2 \
@@ -185,13 +207,13 @@ avalancheup-aws install-subnet-chain \
 --key 0x56289e99c94b6912bfc12adc093c9b51124f0dc54ac7a766b2bc5ccf558d8027 \
 --primary-network-validate-period-in-days 16 \
 --subnet-validate-period-in-days 14 \
---subnet-config-local-path /tmp/subnet-config.json \
+--subnet-config-local-path /tmp/avalanche-ops/subnet-config.json \
 --subnet-config-remote-dir /data/avalanche-configs/subnets \
---vm-binary-local-path /tmp/tokenvm \
+--vm-binary-local-path /tmp/avalanche-ops/tokenvm \
 --vm-binary-remote-dir /data/avalanche-plugins \
 --chain-name tokenvm1 \
---chain-genesis-path /tmp/tokenvm-genesis.json \
---chain-config-local-path /tmp/tokenvm-chain-config.json \
+--chain-genesis-path /tmp/avalanche-ops/tokenvm-genesis.json \
+--chain-config-local-path /tmp/avalanche-ops/tokenvm-chain-config.json \
 --chain-config-remote-dir /data/avalanche-configs/chains \
 --avalanchego-config-remote-path /data/avalanche-configs/config.json \
 --node-ids-to-instance-ids '{"NodeID-31HAxw7wYJ2u2HQHBkwwF26bnFuxnh2sa":"i-04f6ea239218440f0","NodeID-PLM2si9LWaqvzid6AeJa9tft7rzDXXKg2":"i-0459af0e4cf31fcfa","NodeID-D1RtuFSbmcTiRVY991vkq5UvsTBUpHHLR":"i-0d44cfe5420370c30"}'
@@ -200,7 +222,7 @@ avalancheup-aws install-subnet-chain \
 
 # this will prompt you to confirm the outcome!
 # so make sure to check the outputs!
-avalancheup-aws install-subnet-chain \
+/tmp/avalancheup-aws install-subnet-chain \
 --log-level info \
 --region us-west-2 \
 --s3-bucket avalanche-ops-***-us-west-2 \
@@ -210,13 +232,13 @@ avalancheup-aws install-subnet-chain \
 --key 0x56289e99c94b6912bfc12adc093c9b51124f0dc54ac7a766b2bc5ccf558d8027 \
 --primary-network-validate-period-in-days 16 \
 --subnet-validate-period-in-days 14 \
---subnet-config-local-path /tmp/subnet-config.json \
+--subnet-config-local-path /tmp/avalanche-ops/subnet-config.json \
 --subnet-config-remote-dir /data/avalanche-configs/subnets \
---vm-binary-local-path /tmp/tokenvm \
+--vm-binary-local-path /tmp/avalanche-ops/tokenvm \
 --vm-binary-remote-dir /data/avalanche-plugins \
 --chain-name tokenvm2 \
---chain-genesis-path /tmp/tokenvm-genesis.json \
---chain-config-local-path /tmp/tokenvm-chain-config.json \
+--chain-genesis-path /tmp/avalanche-ops/tokenvm-genesis.json \
+--chain-config-local-path /tmp/avalanche-ops/tokenvm-chain-config.json \
 --chain-config-remote-dir /data/avalanche-configs/chains \
 --avalanchego-config-remote-path /data/avalanche-configs/config.json \
 --node-ids-to-instance-ids '{"NodeID-PNc5fwhKLDLGHBF81qnjTwsdjFbdcZxn1":"i-0c5114f6b1e48e671","NodeID-8oqy47xm46RcdTNFxYo8dpBJtPFqQLLeG":"i-083ccebe7b8d40bc9","NodeID-HC9HVTiThxL6d55bNGqV3bkKPwQmLvEs1":"i-0806a42d5bb597dc5"}'
@@ -224,7 +246,15 @@ avalancheup-aws install-subnet-chain \
 # SUCCESS: subnet Id 2km1PAKNK4vSfpyjgK2iFFoBFD3mXHBAWfDBVsPuzKtNYdPRTY, blockchain Id F1c3GayrV5E7NQdxUCbVfnRPsMSxGbTuHvJLS4R48M3Dcazs6
 ```
 
-To make sure chains are launched successfully, just check the `health` endpoints:
+*Note*: `--chain-name tokenvm*` and `--node-ids-to-instance-ids` values are different to split nodes
+into two separate subnets. And `avalancheup-aws install-subnet-chain` **will add the specified nodes
+as primary network validators (regardless of it's for customer or public networks) before adding them
+as subnet validators**. So, please make sure the `--key` has enough balance and use
+`--primary-network-validate-period-in-days` and `--subnet-validate-period-in-days` flags to set custom
+validate priods (defaults to 16-day for primary network, 14-day for subnet validation).
+
+### Step 9: Check Healthiness
+To make sure chains are launched successfully, query the `health` endpoints:
 
 > curl http://52.88.8.107:9650/ext/health
 >
@@ -233,6 +263,17 @@ To make sure chains are launched successfully, just check the `health` endpoints
 > curl http://44.224.148.127:9650/ext/health
 >
 > {"checks":{"C":{"message":{"consensus":{"longestRunningBlock":"0s","outstandingBlocks":0},"vm":null},"timestamp":"2023-03-14T15:55:08.203325635Z","duration":6570},"F1c3GayrV5E7NQdxUCbVfnRPsMSxGbTuHvJLS4R48M3Dcazs6":{"message":{"consensus":{"longestRunningBlock":"0s","outstandingBlocks":0},"vm":{"database":{"v1.4.5":null},"health":200}},"timestamp":"2023-03-14T15:55:08.204161784Z","duration":927270},"P":{"message":{"consensus":{"longestRunningBlock":"0s","outstandingBlocks":0},"vm":{"2km1PAKNK4vSfpyjgK2iFFoBFD3mXHBAWfDBVsPuzKtNYdPRTY-percentConnected":1,"primary-percentConnected":1}},"timestamp":"2023-03-14T15:55:08.203318015Z","duration":63060},"X":{"message":{"consensus":{"outstandingVertices":0,"snowstorm":{"outstandingTransactions":0}},"vm":null},"timestamp":"2023-03-14T15:55:08.203233714Z","duration":18360},"bootstrapped":{"message":[],"timestamp":"2023-03-14T15:55:08.203205494Z","duration":3010},"database":{"timestamp":"2023-03-14T15:55:08.203214634Z","duration":1350},"diskspace":{"message":{"availableDiskBytes":299770839040},"timestamp":"2023-03-14T15:55:08.203252895Z","duration":5361},"network":{"message":{"connectedPeers":5,"sendFailRate":0,"timeSinceLastMsgReceived":"203.209294ms","timeSinceLastMsgSent":"203.209294ms"},"timestamp":"2023-03-14T15:55:08.203212714Z","duration":6550},"router":{"message":{"longestRunningRequest":"0s","outstandingRequests":0},"timestamp":"2023-03-14T15:55:08.203338225Z","duration":21220}},"healthy":true}
+
+### Step 10: Run Spam
+You can import the demo key and the network configuration from `avalanche-ops`
+using the following commands:
+```bash
+/tmp/token-cli key import demo.pk
+/tmp/token-cli chain import-ops
+```
+
+Once the network information is imported, you can then run `/tmp/token-cli spam
+run` to push network activity on the devnet.
 
 ## Deploy TokenVM in Fuji network with avalanche-ops
 
@@ -251,4 +292,6 @@ avalancheup-aws default-spec \
 --network-name fuji
 ```
 
-And make sure the nodes are in sync with the chain state before installing subnets/chains with `avalancheup-aws install-subnet-chain`. You can check the status of the nodes either via HTTP `/health` endpoints or CloudWatch logs.
+Make sure the nodes are in sync with the chain state before installing
+subnets/chains with `avalancheup-aws install-subnet-chain`. You can check the status
+of the nodes either via HTTP `/health` endpoints or CloudWatch logs.

--- a/examples/tokenvm/DEVNETS.md
+++ b/examples/tokenvm/DEVNETS.md
@@ -43,8 +43,10 @@ echo ${OS_TYPE}
 export HYPERSDK_VERSION="0.0.4"
 rm -f ./tmp/token-cli
 wget "https://github.com/ava-labs/hypersdk/releases/download/v${HYPERSDK_VERSION}/hypersdk_${HYPERSDK_VERSION}_${OS_TYPE}_${ARCH_TYPE}.tar.gz"
-tar -xvf hypersdk_${HYPERSDK_VERSION}_${OS_TYPE}_${ARCH_TYPE}.tar.gz
+tar -xvf hypersdk_${HYPERSDK_VERSION}_${OS_TYPE}_${ARCH_TYPE}.tar.gz -C hypersdk_${HYPERSDK_VERSION}_${OS_TYPE}_${ARCH_TYPE}
 mv hypersdk_${HYPERSDK_VERSION}_${OS_TYPE}_${ARCH_TYPE}/token-cli /tmp/token-cli
+rm -rf hypersdk_${HYPERSDK_VERSION}_${OS_TYPE}_${ARCH_TYPE}
+rm -rf hypersdk_${HYPERSDK_VERSION}_${OS_TYPE}_${ARCH_TYPE}.tar.gz
 ```
 
 ### Step 4: Download `tokenvm`
@@ -56,8 +58,10 @@ building with [`v3+`](https://github.com/golang/go/wiki/MinimumRequirements#amd6
 export HYPERSDK_VERSION="0.0.4"
 rm -f ./tmp/tokenvm
 wget "https://github.com/ava-labs/hypersdk/releases/download/v${HYPERSDK_VERSION}/hypersdk_${HYPERSDK_VERSION}_linux_amd64.tar.gz"
-tar -xvf hypersdk_${HYPERSDK_VERSION}_linux_amd64.tar.gz
+tar -xvf hypersdk_${HYPERSDK_VERSION}_linux_amd64.tar.gz -C hypersdk_${HYPERSDK_VERSION}_linux_amd64/tokenvm
 mv hypersdk_${HYPERSDK_VERSION}_linux_amd64/tokenvm /tmp/tokenvm
+rm -rf hypersdk_${HYPERSDK_VERSION}_linux_amd64/tokenvm
+rm -rf hypersdk_${HYPERSDK_VERSION}_linux_amd64.tar.gz
 ```
 
 *Note*: We must install the linux build because that is compatible with the AWS

--- a/examples/tokenvm/DEVNETS.md
+++ b/examples/tokenvm/DEVNETS.md
@@ -11,22 +11,18 @@ page](https://github.com/ava-labs/avalanche-ops/releases/tag/latest).
 
 #### Option 1: Install `avalanche-ops` on Mac
 ```bash
-export ARCH_TYPE=$(uname -m)
-echo ${ARCH_TYPE}
 rm -f /tmp/avalancheup-aws
-wget "https://github.com/ava-labs/avalanche-ops/releases/download/latest/avalancheup-aws.${ARCH_TYPE}-apple-darwin"
-mv ./avalancheup-aws.${ARCH_TYPE}-apple-darwin /tmp/avalancheup-aws
+wget "https://github.com/ava-labs/avalanche-ops/releases/download/latest/avalancheup-aws.aarch64-apple-darwin"
+mv ./avalancheup-aws.aarch64-apple-darwin /tmp/avalancheup-aws
 chmod +x /tmp/avalancheup-aws
 /tmp/avalancheup-aws --help
 ```
 
 #### Option 2: Install `avalanche-ops` on Linux
 ```bash
-export ARCH_TYPE=$(uname -m)
-echo ${ARCH_TYPE}
 rm -f /tmp/avalancheup-aws
-wget "https://github.com/ava-labs/avalanche-ops/releases/download/latest/avalancheup-aws.${ARCH_TYPE}-linux-gnu"
-mv ./avalancheup-aws.${ARCH_TYPE}-linux-gnu /tmp/avalancheup-aws
+wget "https://github.com/ava-labs/avalanche-ops/releases/download/latest/avalancheup-aws.x86_64-linux-gnu"
+mv ./avalancheup-aws.x86_64-linux-gnu /tmp/avalancheup-aws
 chmod +x /tmp/avalancheup-aws
 /tmp/avalancheup-aws --help
 ```

--- a/examples/tokenvm/DEVNETS.md
+++ b/examples/tokenvm/DEVNETS.md
@@ -41,7 +41,7 @@ echo ${ARCH_TYPE}
 export OS_TYPE=$(uname | tr '[:upper:]' '[:lower:]')
 echo ${OS_TYPE}
 export HYPERSDK_VERSION="0.0.4"
-rm -f ./tmp/token-cli
+rm -f /tmp/token-cli
 wget "https://github.com/ava-labs/hypersdk/releases/download/v${HYPERSDK_VERSION}/hypersdk_${HYPERSDK_VERSION}_${OS_TYPE}_${ARCH_TYPE}.tar.gz"
 mkdir tmp-hypersdk
 tar -xvf hypersdk_${HYPERSDK_VERSION}_${OS_TYPE}_${ARCH_TYPE}.tar.gz -C tmp-hypersdk
@@ -57,7 +57,7 @@ building with [`v3+`](https://github.com/golang/go/wiki/MinimumRequirements#amd6
 
 ```bash
 export HYPERSDK_VERSION="0.0.4"
-rm -f ./tmp/tokenvm
+rm -f /tmp/tokenvm
 wget "https://github.com/ava-labs/hypersdk/releases/download/v${HYPERSDK_VERSION}/hypersdk_${HYPERSDK_VERSION}_linux_amd64.tar.gz"
 mkdir tmp-hypersdk
 tar -xvf hypersdk_${HYPERSDK_VERSION}_linux_amd64.tar.gz -C tmp-hypersdk
@@ -188,7 +188,7 @@ avalancheup-aws apply \
 --spec-file-path /home/ubuntu/aops-custom-****-***.yaml
 
 # run the following to delete resources
-avalancheup-aws delete \
+/tmp/avalancheup-aws delete \
 --delete-cloudwatch-log-group \
 --delete-s3-objects \
 --delete-ebs-volumes \
@@ -307,6 +307,7 @@ AWS Console
 To view metrics, first download and install [Prometheus](https://prometheus.io/download/)
 using the following commands:
 ```bash
+rm -f /tmp/prometheus
 wget https://github.com/prometheus/prometheus/releases/download/v2.43.0/prometheus-2.43.0.darwin-amd64.tar.gz
 tar -xvf prometheus-2.43.0.darwin-amd64.tar.gz
 rm prometheus-2.43.0.darwin-amd64.tar.gz

--- a/examples/tokenvm/DEVNETS.md
+++ b/examples/tokenvm/DEVNETS.md
@@ -88,7 +88,10 @@ Now we can spin up a new network of 6 nodes with some defaults:
 --ip-mode=elastic \
 --metrics-fetch-interval-seconds 60 \
 --network-name custom \
---keys-to-generate 5
+--keys-to-generate 5 \
+--avalanchego-profile-continuous-enabled \
+--avalanchego-profile-continuous-freq 1m \
+--avalanchego-profile-continuous-max-files 10
 ```
 
 The `default-spec` (and `apply`) command only provisions nodes, not Custom VMs.

--- a/examples/tokenvm/DEVNETS.md
+++ b/examples/tokenvm/DEVNETS.md
@@ -211,7 +211,9 @@ cat <<EOF > /tmp/avalanche-ops/tokenvm-chain-config.json
   "mempoolExemptPayers":["token1rvzhmceq997zntgvravfagsks6w0ryud3rylh4cdvayry0dl97nsjzf3yp"],
   "streamingBacklogSize": 10000000,
   "trackedPairs":["*"],
-  "logLevel": "info"
+  "logLevel": "info",
+  "decisionsPort": 9652,
+  "blocksPort": 9653,
 }
 EOF
 cat /tmp/avalanche-ops/tokenvm-chain-config.json

--- a/examples/tokenvm/DEVNETS.md
+++ b/examples/tokenvm/DEVNETS.md
@@ -262,6 +262,29 @@ fields @timestamp, @message, @logStream, @log
 *Note*: The "Log Group" you are asked to select should have a similar name as
 the spec file that was output earlier.
 
+#### Viewing Metrics
+To view metrics, first download and install [Prometheus](https://prometheus.io/download/)
+using the following commands:
+```bash
+wget https://github.com/prometheus/prometheus/releases/download/v2.43.0/prometheus-2.43.0.darwin-amd64.tar.gz
+tar -xvf prometheus-2.43.0.darwin-amd64.tar.gz
+rm prometheus-2.43.0.darwin-amd64.tar.gz
+mv prometheus-2.43.0.darwin-amd64/prometheus /tmp/prometheus
+rm -rf prometheus-2.43.0.darwin-amd64
+```
+
+Once you have Prometheus installed, run the following command to auto-generate
+a configuration file:
+```bash
+/tmp/token-cli metrics prometheus <avalanche-ops spec file path> /tmp/prometheus.yml
+```
+
+In a separate terminal, then run the following command to view collected
+metrics:
+```bash
+/tmp/prometheus --config.file=/tmp/prometheus.yml
+```
+
 ### Step 9: Initialize `token-cli`
 You can import the demo key and the network configuration from `avalanche-ops`
 using the following commands:

--- a/examples/tokenvm/DEVNETS.md
+++ b/examples/tokenvm/DEVNETS.md
@@ -278,14 +278,17 @@ rm -rf prometheus-2.43.0.darwin-amd64
 Once you have Prometheus installed, run the following command to auto-generate
 a configuration file:
 ```bash
-/tmp/token-cli metrics prometheus <avalanche-ops spec file path> /tmp/prometheus.yml
+/tmp/token-cli metrics prometheus <avalanche-ops spec file path> /tmp/prometheus.yaml
 ```
 
 In a separate terminal, then run the following command to view collected
 metrics:
 ```bash
-/tmp/prometheus --config.file=/tmp/prometheus.yml
+/tmp/prometheus --config.file=/tmp/prometheus.yaml
 ```
+
+To remove previously ingested data, delete for a folder called `data` in the
+directory where you last ran Prometheus.
 
 ### Step 9: Initialize `token-cli`
 You can import the demo key and the network configuration from `avalanche-ops`

--- a/examples/tokenvm/DEVNETS.md
+++ b/examples/tokenvm/DEVNETS.md
@@ -77,8 +77,6 @@ Now we can spin up a new network of 6 nodes with some defaults:
 - `avalanche-ops` supports [EC2 Spot instances](https://aws.amazon.com/ec2/spot/) for cost savings. Use `--instance-mode=spot` to run instances in spot mode.
 
 ```bash
-# use "--instance-types=c5.2xlarge,m5.2xlarge"
-# to overwrite "--instance-size" flag value
 /tmp/avalancheup-aws default-spec \
 --arch-type amd64 \
 --rust-os-type ubuntu20.04 \
@@ -86,7 +84,7 @@ Now we can spin up a new network of 6 nodes with some defaults:
 --non-anchor-nodes 3 \
 --region us-west-2 \
 --instance-mode=on-demand \
---instance-size=2xlarge \
+--instance-types=c5.2xlarge \
 --ip-mode=elastic \
 --metrics-fetch-interval-seconds 60 \
 --network-name custom \
@@ -115,24 +113,11 @@ avalancheup-aws default-spec \
 It is recommended to specify your own artifacts to avoid flaky github release page downloads.
 
 #### Restricting Instance Types
-By default, `avalanche-ops` will attempt to use all available instance types in
-a region in your cluster. If you'd like to restrict which instance types are used,
-edit the output `aops-custom-****-***.yaml` file before deploying:
-```yaml
-machine:
-  anchor_nodes: 3
-  non_anchor_nodes: 3
-  arch_type: amd64
-  rust_os_type: ubuntu20.04
-  instance_types:
-  - t3a.2xlarge
-  - t3.2xlarge
-  - t2.2xlarge
-  - c6a.2xlarge
-  - m6a.2xlarge
-  - m5.2xlarge
-  - c5.2xlarge
-```
+By default, `avalanche-ops` will attempt to use all available instance types of
+a given size (scoped by `--instance-size`) in a region in your cluster. If you'd like to restrict which
+instance types are used (and override `--instance-size`), you can populate the `--instance-types` flag.
+You can specify a single instance type (`--instance-types=c5.2xlarge`) or a comma-separated list
+(`--instance-types=c5.2xlarge,m5.2xlarge`).
 
 #### Increasing Rate Limits
 If you are attempting to stress test the Devnet, you should disable CPU, Disk,

--- a/examples/tokenvm/DEVNETS.md
+++ b/examples/tokenvm/DEVNETS.md
@@ -43,10 +43,11 @@ echo ${OS_TYPE}
 export HYPERSDK_VERSION="0.0.4"
 rm -f ./tmp/token-cli
 wget "https://github.com/ava-labs/hypersdk/releases/download/v${HYPERSDK_VERSION}/hypersdk_${HYPERSDK_VERSION}_${OS_TYPE}_${ARCH_TYPE}.tar.gz"
-tar -xvf hypersdk_${HYPERSDK_VERSION}_${OS_TYPE}_${ARCH_TYPE}.tar.gz -C hypersdk_${HYPERSDK_VERSION}_${OS_TYPE}_${ARCH_TYPE}
-mv hypersdk_${HYPERSDK_VERSION}_${OS_TYPE}_${ARCH_TYPE}/token-cli /tmp/token-cli
-rm -rf hypersdk_${HYPERSDK_VERSION}_${OS_TYPE}_${ARCH_TYPE}
+mkdir tmp-hypersdk
+tar -xvf hypersdk_${HYPERSDK_VERSION}_${OS_TYPE}_${ARCH_TYPE}.tar.gz -C tmp-hypersdk
 rm -rf hypersdk_${HYPERSDK_VERSION}_${OS_TYPE}_${ARCH_TYPE}.tar.gz
+mv tmp-hypersdk/token-cli /tmp/token-cli
+rm -rf tmp-hypersdk
 ```
 
 ### Step 4: Download `tokenvm`
@@ -58,10 +59,11 @@ building with [`v3+`](https://github.com/golang/go/wiki/MinimumRequirements#amd6
 export HYPERSDK_VERSION="0.0.4"
 rm -f ./tmp/tokenvm
 wget "https://github.com/ava-labs/hypersdk/releases/download/v${HYPERSDK_VERSION}/hypersdk_${HYPERSDK_VERSION}_linux_amd64.tar.gz"
-tar -xvf hypersdk_${HYPERSDK_VERSION}_linux_amd64.tar.gz -C hypersdk_${HYPERSDK_VERSION}_linux_amd64/tokenvm
-mv hypersdk_${HYPERSDK_VERSION}_linux_amd64/tokenvm /tmp/tokenvm
-rm -rf hypersdk_${HYPERSDK_VERSION}_linux_amd64/tokenvm
+mkdir tmp-hypersdk
+tar -xvf hypersdk_${HYPERSDK_VERSION}_linux_amd64.tar.gz -C tmp-hypersdk
 rm -rf hypersdk_${HYPERSDK_VERSION}_linux_amd64.tar.gz
+mv tmp-hypersdk/tokenvm /tmp/tokenvm
+rm -rf tmp-hypersdk
 ```
 
 *Note*: We must install the linux build because that is compatible with the AWS

--- a/examples/tokenvm/DEVNETS.md
+++ b/examples/tokenvm/DEVNETS.md
@@ -389,7 +389,15 @@ run the following command (defaults to `72000`):
 /tmp/token-cli spam run --max-tx-backlog 5000
 ```
 
-### [OPTIONAL] Step 12: Deploy Another Subnet
+### [OPTIONAL] Step 12: SSH Into Nodes
+You can SSH into any machine created by `avalanche-ops` using the SSH key
+automatically generated during the `apply` command. The commands for doing so
+are emitted during `apply` and look something like this:
+```bash
+ssh -o "StrictHostKeyChecking no" -i aops-custom-202303-21qJUU-ec2-access.key ubuntu@34.209.76.123
+```
+
+### [OPTIONAL] Step 13: Deploy Another Subnet
 To test Avalanche Warp Messaging, you must be running at least 2 Subnets. To do
 so, just replicate the command you ran above with a different `--chain-name` (and
 a different set of validators):

--- a/examples/tokenvm/DEVNETS.md
+++ b/examples/tokenvm/DEVNETS.md
@@ -344,10 +344,17 @@ Here are some useful queries (on an example chainID `3rihqpXh6ZJqxL2dsrVysKkEKro
 * `avalanche_3rihqpXh6ZJqxL2dsrVysKkEKroiD9tvQWLS6iWVnd8K4HST2_vm_go_memstats_alloc_bytes`
 * `avalanche_network_inbound_conn_throttler_rate_limited`
 
-To estimate how many `ms/s` the consensus engine is spending busy, use the
+To estimate how many `ms/s` the consensus engine and `tokenvm` are spending busy, use the
 following query (on an example chainID `k3i5Cxk7UyLWWaEZKC1XSPJbQHSdSMJeZP2awecWxwyuqFDk7`):
 ```
 increase(avalanche_k3i5Cxk7UyLWWaEZKC1XSPJbQHSdSMJeZP2awecWxwyuqFDk7_handler_chits_sum[30s])/1000000/30 + increase(avalanche_k3i5Cxk7UyLWWaEZKC1XSPJbQHSdSMJeZP2awecWxwyuqFDk7_handler_notify_sum[30s])/1000000/30 + increase(avalanche_k3i5Cxk7UyLWWaEZKC1XSPJbQHSdSMJeZP2awecWxwyuqFDk7_handler_get_sum[30s])/1000000/30 + increase(avalanche_k3i5Cxk7UyLWWaEZKC1XSPJbQHSdSMJeZP2awecWxwyuqFDk7_handler_push_query_sum[30s])/1000000/30 + increase(avalanche_k3i5Cxk7UyLWWaEZKC1XSPJbQHSdSMJeZP2awecWxwyuqFDk7_handler_put_sum[30s])/1000000/30 + increase(avalanche_k3i5Cxk7UyLWWaEZKC1XSPJbQHSdSMJeZP2awecWxwyuqFDk7_handler_pull_query_sum[30s])/1000000/30 + increase(avalanche_k3i5Cxk7UyLWWaEZKC1XSPJbQHSdSMJeZP2awecWxwyuqFDk7_handler_query_failed_sum[30s])/1000000/30
+```
+
+To isolate just how many `ms/s` the consensus engine is spending busy (removing
+"build", "verify", and "accept" time spent in `tokenvm`), use the following
+command:
+```
+increase(avalanche_k3i5Cxk7UyLWWaEZKC1XSPJbQHSdSMJeZP2awecWxwyuqFDk7_handler_chits_sum[30s])/1000000/30 + increase(avalanche_k3i5Cxk7UyLWWaEZKC1XSPJbQHSdSMJeZP2awecWxwyuqFDk7_handler_notify_sum[30s])/1000000/30 + increase(avalanche_k3i5Cxk7UyLWWaEZKC1XSPJbQHSdSMJeZP2awecWxwyuqFDk7_handler_get_sum[30s])/1000000/30 + increase(avalanche_k3i5Cxk7UyLWWaEZKC1XSPJbQHSdSMJeZP2awecWxwyuqFDk7_handler_push_query_sum[30s])/1000000/30 + increase(avalanche_k3i5Cxk7UyLWWaEZKC1XSPJbQHSdSMJeZP2awecWxwyuqFDk7_handler_put_sum[30s])/1000000/30 + increase(avalanche_k3i5Cxk7UyLWWaEZKC1XSPJbQHSdSMJeZP2awecWxwyuqFDk7_handler_pull_query_sum[30s])/1000000/30 + increase(avalanche_k3i5Cxk7UyLWWaEZKC1XSPJbQHSdSMJeZP2awecWxwyuqFDk7_handler_query_failed_sum[30s])/1000000/30 - increase(avalanche_k3i5Cxk7UyLWWaEZKC1XSPJbQHSdSMJeZP2awecWxwyuqFDk7_vm_metervm_build_block_sum[30s])/1000000/30 - increase(avalanche_k3i5Cxk7UyLWWaEZKC1XSPJbQHSdSMJeZP2awecWxwyuqFDk7_vm_metervm_verify_sum[30s])/1000000/30 - increase(avalanche_k3i5Cxk7UyLWWaEZKC1XSPJbQHSdSMJeZP2awecWxwyuqFDk7_vm_metervm_accept_sum[30s])/1000000/30
 ```
 
 To remove previously ingested data, delete for a folder called `data` in the

--- a/examples/tokenvm/DEVNETS.md
+++ b/examples/tokenvm/DEVNETS.md
@@ -201,7 +201,9 @@ cat <<EOF > /tmp/avalanche-ops/allocations.json
 EOF
 rm -f /tmp/avalanche-ops/tokenvm-genesis.json
 /tmp/token-cli genesis generate /tmp/avalanche-ops/allocations.json \
---genesis-file /tmp/avalanche-ops/tokenvm-genesis.json
+--genesis-file /tmp/avalanche-ops/tokenvm-genesis.json \
+--window-target-units 100000000000 \
+--window-target-blocks 20
 cat /tmp/avalanche-ops/tokenvm-genesis.json
 
 cat <<EOF > /tmp/avalanche-ops/tokenvm-chain-config.json

--- a/examples/tokenvm/DEVNETS.md
+++ b/examples/tokenvm/DEVNETS.md
@@ -248,7 +248,8 @@ You can import the demo key and the network configuration from `avalanche-ops`
 using the following commands:
 ```bash
 /tmp/token-cli key import demo.pk
-/tmp/token-cli chain import-ops <chainID> <avalanche-ops YAML file>
+/tmp/token-cli chain import-ops <chainID> <avalanche-ops spec file path>
+/tmp/token-cli key balance --check-all-chains
 ```
 
 ### Step 10: Start Integrated Block Explorer

--- a/examples/tokenvm/DEVNETS.md
+++ b/examples/tokenvm/DEVNETS.md
@@ -344,6 +344,12 @@ Here are some useful queries (on an example chainID `3rihqpXh6ZJqxL2dsrVysKkEKro
 * `avalanche_3rihqpXh6ZJqxL2dsrVysKkEKroiD9tvQWLS6iWVnd8K4HST2_vm_go_memstats_alloc_bytes`
 * `avalanche_network_inbound_conn_throttler_rate_limited`
 
+To estimate how many `ms/s` the consensus engine is spending busy, use the
+following query (on an example chainID `k3i5Cxk7UyLWWaEZKC1XSPJbQHSdSMJeZP2awecWxwyuqFDk7`):
+```
+increase(avalanche_k3i5Cxk7UyLWWaEZKC1XSPJbQHSdSMJeZP2awecWxwyuqFDk7_handler_chits_sum[30s])/1000000/30 + increase(avalanche_k3i5Cxk7UyLWWaEZKC1XSPJbQHSdSMJeZP2awecWxwyuqFDk7_handler_notify_sum[30s])/1000000/30 + increase(avalanche_k3i5Cxk7UyLWWaEZKC1XSPJbQHSdSMJeZP2awecWxwyuqFDk7_handler_get_sum[30s])/1000000/30 + increase(avalanche_k3i5Cxk7UyLWWaEZKC1XSPJbQHSdSMJeZP2awecWxwyuqFDk7_handler_push_query_sum[30s])/1000000/30 + increase(avalanche_k3i5Cxk7UyLWWaEZKC1XSPJbQHSdSMJeZP2awecWxwyuqFDk7_handler_put_sum[30s])/1000000/30 + increase(avalanche_k3i5Cxk7UyLWWaEZKC1XSPJbQHSdSMJeZP2awecWxwyuqFDk7_handler_pull_query_sum[30s])/1000000/30 + increase(avalanche_k3i5Cxk7UyLWWaEZKC1XSPJbQHSdSMJeZP2awecWxwyuqFDk7_handler_query_failed_sum[30s])/1000000/30
+```
+
 To remove previously ingested data, delete for a folder called `data` in the
 directory where you last ran Prometheus.
 

--- a/examples/tokenvm/DEVNETS.md
+++ b/examples/tokenvm/DEVNETS.md
@@ -244,7 +244,7 @@ cat <<EOF > /tmp/avalanche-ops/tokenvm-chain-config.json
   "trackedPairs":["*"],
   "logLevel": "info",
   "preferredBlocksPerSecond": 3,
-  "continuousProfileDir": "/var/log/tokenvm-profile",
+  "continuousProfilerDir": "/var/log/tokenvm-profile",
   "decisionsPort": 9652,
   "blocksPort": 9653
 }

--- a/examples/tokenvm/DEVNETS.md
+++ b/examples/tokenvm/DEVNETS.md
@@ -213,7 +213,7 @@ cat <<EOF > /tmp/avalanche-ops/tokenvm-chain-config.json
   "trackedPairs":["*"],
   "logLevel": "info",
   "decisionsPort": 9652,
-  "blocksPort": 9653,
+  "blocksPort": 9653
 }
 EOF
 cat /tmp/avalanche-ops/tokenvm-chain-config.json
@@ -245,6 +245,23 @@ replace the `***` fields, IP addresses, key, and `node-ids-to-instance-ids` with
 --node-ids-to-instance-ids <TODO>
 ```
 
+#### Viewing Logs
+1) Open the [AWS CloudWatch](https://aws.amazon.com/cloudwatch) product on your
+AWS Console
+2) Click "Logs Insights"
+3) Use the following query to view all logs (in reverse-chronological order)
+for all nodes in your Devnet:
+```
+fields @timestamp, @message, @logStream, @log
+| filter(@logStream not like "avalanche-telemetry-cloudwatch.log")
+| filter(@logStream not like "syslog")
+| sort @timestamp desc
+| limit 20
+```
+
+*Note*: The "Log Group" you are asked to select should have a similar name as
+the spec file that was output earlier.
+
 ### Step 9: Initialize `token-cli`
 You can import the demo key and the network configuration from `avalanche-ops`
 using the following commands:
@@ -252,6 +269,12 @@ using the following commands:
 /tmp/token-cli key import demo.pk
 /tmp/token-cli chain import-ops <chainID> <avalanche-ops spec file path>
 /tmp/token-cli key balance --check-all-chains
+```
+
+If you previously used `token-cli`, you may want to delete data you previously
+ingested into it. You can do this with the following command:
+```bash
+rm -rf .token-cli
 ```
 
 ### Step 10: Start Integrated Block Explorer

--- a/examples/tokenvm/DEVNETS.md
+++ b/examples/tokenvm/DEVNETS.md
@@ -220,7 +220,6 @@ cat /tmp/avalanche-ops/tokenvm-chain-config.json
 ### Step 8: Install Chains
 You can run the following commands to spin up 2 `tokenvm` Devnets. Make sure to
 replace the `***` fields, IP addresses, key, and `node-ids-to-instance-ids` with your own data:
-
 ```bash
 /tmp/avalancheup-aws install-subnet-chain \
 --log-level info \
@@ -237,27 +236,6 @@ replace the `***` fields, IP addresses, key, and `node-ids-to-instance-ids` with
 --vm-binary-local-path /tmp/tokenvm \
 --vm-binary-remote-dir /data/avalanche-plugins \
 --chain-name tokenvm1 \
---chain-genesis-path /tmp/avalanche-ops/tokenvm-genesis.json \
---chain-config-local-path /tmp/avalanche-ops/tokenvm-chain-config.json \
---chain-config-remote-dir /data/avalanche-configs/chains \
---avalanchego-config-remote-path /data/avalanche-configs/config.json \
---node-ids-to-instance-ids <TODO>
-
-/tmp/avalancheup-aws install-subnet-chain \
---log-level info \
---region us-west-2 \
---s3-bucket <TODO> \
---s3-key-prefix <TODO> \
---ssm-doc <TODO> \
---chain-rpc-url <TODO> \
---key <TODO> \
---primary-network-validate-period-in-days 16 \
---subnet-validate-period-in-days 14 \
---subnet-config-local-path /tmp/avalanche-ops/subnet-config.json \
---subnet-config-remote-dir /data/avalanche-configs/subnets \
---vm-binary-local-path /tmp/avalanche-ops/tokenvm \
---vm-binary-remote-dir /data/avalanche-plugins \
---chain-name tokenvm2 \
 --chain-genesis-path /tmp/avalanche-ops/tokenvm-genesis.json \
 --chain-config-local-path /tmp/avalanche-ops/tokenvm-chain-config.json \
 --chain-config-remote-dir /data/avalanche-configs/chains \
@@ -291,6 +269,33 @@ Once the network information is imported, you can then run the following
 command to drive an arbitrary amount of load:
 ```bash
 /tmp/token-cli spam run
+```
+
+### [OPTIONAL] Step 12: Deploy Another Subnet
+To test Avalanche Warp Messaging, you must be running at least 2 Subnets. To do
+so, just replicate the command you ran above with a different `--chain-name` (and
+a different set of validators):
+```bash
+/tmp/avalancheup-aws install-subnet-chain \
+--log-level info \
+--region us-west-2 \
+--s3-bucket <TODO> \
+--s3-key-prefix <TODO> \
+--ssm-doc <TODO> \
+--chain-rpc-url <TODO> \
+--key <TODO> \
+--primary-network-validate-period-in-days 16 \
+--subnet-validate-period-in-days 14 \
+--subnet-config-local-path /tmp/avalanche-ops/subnet-config.json \
+--subnet-config-remote-dir /data/avalanche-configs/subnets \
+--vm-binary-local-path /tmp/tokenvm \
+--vm-binary-remote-dir /data/avalanche-plugins \
+--chain-name tokenvm2 \
+--chain-genesis-path /tmp/avalanche-ops/tokenvm-genesis.json \
+--chain-config-local-path /tmp/avalanche-ops/tokenvm-chain-config.json \
+--chain-config-remote-dir /data/avalanche-configs/chains \
+--avalanchego-config-remote-path /data/avalanche-configs/config.json \
+--node-ids-to-instance-ids <TODO>
 ```
 
 ## Deploy TokenVM in Fuji network with avalanche-ops

--- a/examples/tokenvm/DEVNETS.md
+++ b/examples/tokenvm/DEVNETS.md
@@ -42,7 +42,7 @@ export OS_TYPE=$(uname | tr '[:upper:]' '[:lower:]')
 echo ${OS_TYPE}
 export HYPERSDK_VERSION="0.0.4"
 rm -f ./tmp/token-cli
-wget "https://github.com/ava-labs/hypersdk/releases/download/v${HYPERSDK_VERSION}/hypersdk_${HYPERSDK_VERSION}_${OS_TYPE}_${ARCH_TYPE}.tar.gz
+wget "https://github.com/ava-labs/hypersdk/releases/download/v${HYPERSDK_VERSION}/hypersdk_${HYPERSDK_VERSION}_${OS_TYPE}_${ARCH_TYPE}.tar.gz"
 tar -xvf hypersdk_${HYPERSDK_VERSION}_${OS_TYPE}_${ARCH_TYPE}.tar.gz
 mv hypersdk_${HYPERSDK_VERSION}_${OS_TYPE}_${ARCH_TYPE}/token-cli /tmp/token-cli
 ```
@@ -55,7 +55,7 @@ building with [`v3+`](https://github.com/golang/go/wiki/MinimumRequirements#amd6
 ```bash
 export HYPERSDK_VERSION="0.0.4"
 rm -f ./tmp/tokenvm
-wget "https://github.com/ava-labs/hypersdk/releases/download/v${HYPERSDK_VERSION}/hypersdk_${HYPERSDK_VERSION}_linux_amd64.tar.gz
+wget "https://github.com/ava-labs/hypersdk/releases/download/v${HYPERSDK_VERSION}/hypersdk_${HYPERSDK_VERSION}_linux_amd64.tar.gz"
 tar -xvf hypersdk_${HYPERSDK_VERSION}_linux_amd64.tar.gz
 mv hypersdk_${HYPERSDK_VERSION}_linux_amd64/tokenvm /tmp/tokenvm
 ```

--- a/examples/tokenvm/DEVNETS.md
+++ b/examples/tokenvm/DEVNETS.md
@@ -266,7 +266,7 @@ replace the `***` fields, IP addresses, key, and `node-ids-to-instance-ids` with
 --key <TODO> \
 --primary-network-validate-period-in-days 16 \
 --subnet-validate-period-in-days 14 \
---subnet-config-local-path /tmp/avalanche-ops/subnet-config.json \
+--subnet-config-local-path /tmp/avalanche-ops/tokenvm-subnet-config.json \
 --subnet-config-remote-dir /data/avalanche-configs/subnets \
 --vm-binary-local-path /tmp/tokenvm \
 --vm-binary-remote-dir /data/avalanche-plugins \

--- a/examples/tokenvm/DEVNETS.md
+++ b/examples/tokenvm/DEVNETS.md
@@ -11,22 +11,22 @@ page](https://github.com/ava-labs/avalanche-ops/releases/tag/latest).
 
 #### Option 1: Install `avalanche-ops` on Mac
 ```bash
-export LINUX_ARCH_TYPE=$(uname -m)
-echo ${LINUX_ARCH_TYPE}
-rm -f ./avalancheup-aws.${LINUX_ARCH_TYPE}-apple-darwin
-wget "https://github.com/ava-labs/avalanche-ops/releases/download/latest/avalancheup-aws.${LINUX_ARCH_TYPE}-apple-darwin"
-mv ./avalancheup-aws.${LINUX_ARCH_TYPE}-apple-darwin /tmp/avalancheup-aws
+export ARCH_TYPE=$(uname -m)
+echo ${ARCH_TYPE}
+rm -f ./tmp/avalancheup-aws
+wget "https://github.com/ava-labs/avalanche-ops/releases/download/latest/avalancheup-aws.${ARCH_TYPE}-apple-darwin"
+mv ./avalancheup-aws.${ARCH_TYPE}-apple-darwin /tmp/avalancheup-aws
 chmod +x /tmp/avalancheup-aws
 /tmp/avalancheup-aws --help
 ```
 
 #### Option 2: Install `avalanche-ops` on Linux
 ```bash
-export LINUX_ARCH_TYPE=$(uname -m)
-echo ${LINUX_ARCH_TYPE}
-rm -f ./avalancheup-aws.${LINUX_ARCH_TYPE}-linux-gnu
-wget "https://github.com/ava-labs/avalanche-ops/releases/download/latest/avalancheup-aws.${LINUX_ARCH_TYPE}-linux-gnu"
-mv ./avalancheup-aws.${LINUX_ARCH_TYPE}-linux-gnu /tmp/avalancheup-aws
+export ARCH_TYPE=$(uname -m)
+echo ${ARCH_TYPE}
+rm -f ./tmp/avalancheup-aws
+wget "https://github.com/ava-labs/avalanche-ops/releases/download/latest/avalancheup-aws.${ARCH_TYPE}-linux-gnu"
+mv ./avalancheup-aws.${ARCH_TYPE}-linux-gnu /tmp/avalancheup-aws
 chmod +x /tmp/avalancheup-aws
 /tmp/avalancheup-aws --help
 ```
@@ -38,7 +38,17 @@ manipulate CloudFormation.
 Once you've installed the AWS CLI, run `aws configure` to set the access key to
 use while deploying your devnet.
 
-### Step 3: Download `token-cli` and `tokenvm`
+### Step 3: Download `token-cli`
+```bash
+```
+
+### Step 4: Download `tokenvm`
+`tokenvm` is currently compiled with `GOAMD=v1`. If you want to significantly
+improve the performance of cryptographic operations, you should consider
+building with [`v3+`](https://github.com/golang/go/wiki/MinimumRequirements#amd64).
+
+```bash
+```
 
 
 ### Step 3: Plan Local Network Deploy

--- a/examples/tokenvm/DEVNETS.md
+++ b/examples/tokenvm/DEVNETS.md
@@ -191,7 +191,7 @@ do so (similar to [scripts/run.sh](./scripts/run.sh)):
 ```bash
 rm -rf /tmp/avalanche-ops
 
-avalancheup-aws subnet-config \
+/tmp/avalancheup-aws subnet-config \
 --log-level=info \
 --proposer-min-block-delay 0 \
 --file-path /tmp/avalanche-ops/subnet-config.json
@@ -225,36 +225,32 @@ replace the `***` fields, IP addresses, key, and `node-ids-to-instance-ids` with
 /tmp/avalancheup-aws install-subnet-chain \
 --log-level info \
 --region us-west-2 \
---s3-bucket avalanche-ops-***-us-west-2 \
---s3-key-prefix aops-custom-***/install-subnet-chain \
---ssm-doc aops-custom-***-ssm-install-subnet-chain \
---chain-rpc-url http://52.88.8.107:9650 \
---key 0x56289e99c94b6912bfc12adc093c9b51124f0dc54ac7a766b2bc5ccf558d8027 \
+--s3-bucket <TODO> \
+--s3-key-prefix <TODO> \
+--ssm-doc <TODO> \
+--chain-rpc-url <TODO> \
+--key <TODO> \
 --primary-network-validate-period-in-days 16 \
 --subnet-validate-period-in-days 14 \
 --subnet-config-local-path /tmp/avalanche-ops/subnet-config.json \
 --subnet-config-remote-dir /data/avalanche-configs/subnets \
---vm-binary-local-path /tmp/avalanche-ops/tokenvm \
+--vm-binary-local-path /tmp/tokenvm \
 --vm-binary-remote-dir /data/avalanche-plugins \
 --chain-name tokenvm1 \
 --chain-genesis-path /tmp/avalanche-ops/tokenvm-genesis.json \
 --chain-config-local-path /tmp/avalanche-ops/tokenvm-chain-config.json \
 --chain-config-remote-dir /data/avalanche-configs/chains \
 --avalanchego-config-remote-path /data/avalanche-configs/config.json \
---node-ids-to-instance-ids '{"NodeID-31HAxw7wYJ2u2HQHBkwwF26bnFuxnh2sa":"i-04f6ea239218440f0","NodeID-PLM2si9LWaqvzid6AeJa9tft7rzDXXKg2":"i-0459af0e4cf31fcfa","NodeID-D1RtuFSbmcTiRVY991vkq5UvsTBUpHHLR":"i-0d44cfe5420370c30"}'
-#  VM Id 'tHBYNu8ikt25R77fH4znHYC4B5mkaEnXPFmsJnECZjq59dySw', chain name 'tokenvm1'
-# SUCCESS: subnet Id 2DLqm2Wk4SFtdmeqkmyfAvTdfvNKmbjwZwztMqRaQCwnDbRHCo, blockchain Id G9CbuiKLoyeYhabA8ph7TBiisKt9LS6Hx1QRgoajnwxd1xFC8
+--node-ids-to-instance-ids <TODO>
 
-# this will prompt you to confirm the outcome!
-# so make sure to check the outputs!
 /tmp/avalancheup-aws install-subnet-chain \
 --log-level info \
 --region us-west-2 \
---s3-bucket avalanche-ops-***-us-west-2 \
---s3-key-prefix aops-custom-***/install-subnet-chain \
---ssm-doc aops-custom-***-ssm-install-subnet-chain \
---chain-rpc-url http://52.88.8.107:9650 \
---key 0x56289e99c94b6912bfc12adc093c9b51124f0dc54ac7a766b2bc5ccf558d8027 \
+--s3-bucket <TODO> \
+--s3-key-prefix <TODO> \
+--ssm-doc <TODO> \
+--chain-rpc-url <TODO> \
+--key <TODO> \
 --primary-network-validate-period-in-days 16 \
 --subnet-validate-period-in-days 14 \
 --subnet-config-local-path /tmp/avalanche-ops/subnet-config.json \
@@ -266,30 +262,10 @@ replace the `***` fields, IP addresses, key, and `node-ids-to-instance-ids` with
 --chain-config-local-path /tmp/avalanche-ops/tokenvm-chain-config.json \
 --chain-config-remote-dir /data/avalanche-configs/chains \
 --avalanchego-config-remote-path /data/avalanche-configs/config.json \
---node-ids-to-instance-ids '{"NodeID-PNc5fwhKLDLGHBF81qnjTwsdjFbdcZxn1":"i-0c5114f6b1e48e671","NodeID-8oqy47xm46RcdTNFxYo8dpBJtPFqQLLeG":"i-083ccebe7b8d40bc9","NodeID-HC9HVTiThxL6d55bNGqV3bkKPwQmLvEs1":"i-0806a42d5bb597dc5"}'
-# VM Id 'tHBYNu8ikt4i8cEV4nsSuj7Ldc9sXAHc8L6qKRJR4e5CR7T3t', chain name 'tokenvm2'
-# SUCCESS: subnet Id 2km1PAKNK4vSfpyjgK2iFFoBFD3mXHBAWfDBVsPuzKtNYdPRTY, blockchain Id F1c3GayrV5E7NQdxUCbVfnRPsMSxGbTuHvJLS4R48M3Dcazs6
+--node-ids-to-instance-ids <TODO>
 ```
 
-*Note*: `--chain-name tokenvm*` and `--node-ids-to-instance-ids` values are different to split nodes
-into two separate subnets. And `avalancheup-aws install-subnet-chain` **will add the specified nodes
-as primary network validators (regardless of it's for customer or public networks) before adding them
-as subnet validators**. So, please make sure the `--key` has enough balance and use
-`--primary-network-validate-period-in-days` and `--subnet-validate-period-in-days` flags to set custom
-validate priods (defaults to 16-day for primary network, 14-day for subnet validation).
-
-### Step 9: Check Healthiness
-To make sure chains are launched successfully, query the `health` endpoints:
-
-> curl http://52.88.8.107:9650/ext/health
->
-> {"checks":{"C":{"message":{"consensus":{"longestRunningBlock":"0s","outstandingBlocks":0},"vm":null},"timestamp":"2023-03-14T15:55:08.256378577Z","duration":14020},"F1c3GayrV5E7NQdxUCbVfnRPsMSxGbTuHvJLS4R48M3Dcazs6":{"message":{"consensus":{"longestRunningBlock":"0s","outstandingBlocks":0},"vm":{"database":{"v1.4.5":null},"health":200}},"timestamp":"2023-03-14T15:55:08.257445968Z","duration":1061711},"P":{"message":{"consensus":{"longestRunningBlock":"0s","outstandingBlocks":0},"vm":{"2km1PAKNK4vSfpyjgK2iFFoBFD3mXHBAWfDBVsPuzKtNYdPRTY-percentConnected":1,"primary-percentConnected":1}},"timestamp":"2023-03-14T15:55:08.256454548Z","duration":74871},"X":{"message":{"consensus":{"outstandingVertices":0,"snowstorm":{"outstandingTransactions":0}},"vm":null},"timestamp":"2023-03-14T15:55:08.256459848Z","duration":15850},"bootstrapped":{"message":[],"timestamp":"2023-03-14T15:55:08.256438778Z","duration":6020},"database":{"timestamp":"2023-03-14T15:55:08.256464299Z","duration":1420},"diskspace":{"message":{"availableDiskBytes":299770843136},"timestamp":"2023-03-14T15:55:08.256466309Z","duration":4070},"network":{"message":{"connectedPeers":5,"sendFailRate":0,"timeSinceLastMsgReceived":"256.459548ms","timeSinceLastMsgSent":"256.459548ms"},"timestamp":"2023-03-14T15:55:08.256461929Z","duration":5551},"router":{"message":{"longestRunningRequest":"0s","outstandingRequests":0},"timestamp":"2023-03-14T15:55:08.256363507Z","duration":17231}},"healthy":true}
-
-> curl http://44.224.148.127:9650/ext/health
->
-> {"checks":{"C":{"message":{"consensus":{"longestRunningBlock":"0s","outstandingBlocks":0},"vm":null},"timestamp":"2023-03-14T15:55:08.203325635Z","duration":6570},"F1c3GayrV5E7NQdxUCbVfnRPsMSxGbTuHvJLS4R48M3Dcazs6":{"message":{"consensus":{"longestRunningBlock":"0s","outstandingBlocks":0},"vm":{"database":{"v1.4.5":null},"health":200}},"timestamp":"2023-03-14T15:55:08.204161784Z","duration":927270},"P":{"message":{"consensus":{"longestRunningBlock":"0s","outstandingBlocks":0},"vm":{"2km1PAKNK4vSfpyjgK2iFFoBFD3mXHBAWfDBVsPuzKtNYdPRTY-percentConnected":1,"primary-percentConnected":1}},"timestamp":"2023-03-14T15:55:08.203318015Z","duration":63060},"X":{"message":{"consensus":{"outstandingVertices":0,"snowstorm":{"outstandingTransactions":0}},"vm":null},"timestamp":"2023-03-14T15:55:08.203233714Z","duration":18360},"bootstrapped":{"message":[],"timestamp":"2023-03-14T15:55:08.203205494Z","duration":3010},"database":{"timestamp":"2023-03-14T15:55:08.203214634Z","duration":1350},"diskspace":{"message":{"availableDiskBytes":299770839040},"timestamp":"2023-03-14T15:55:08.203252895Z","duration":5361},"network":{"message":{"connectedPeers":5,"sendFailRate":0,"timeSinceLastMsgReceived":"203.209294ms","timeSinceLastMsgSent":"203.209294ms"},"timestamp":"2023-03-14T15:55:08.203212714Z","duration":6550},"router":{"message":{"longestRunningRequest":"0s","outstandingRequests":0},"timestamp":"2023-03-14T15:55:08.203338225Z","duration":21220}},"healthy":true}
-
-### Step 10: Initialize `token-cli`
+### Step 9: Initialize `token-cli`
 You can import the demo key and the network configuration from `avalanche-ops`
 using the following commands:
 ```bash
@@ -297,7 +273,7 @@ using the following commands:
 /tmp/token-cli chain import-ops <chainID> <avalanche-ops YAML file>
 ```
 
-### Step 11: Start Integrated Block Explorer
+### Step 10: Start Integrated Block Explorer
 To view activity on each Subnet you created, you can run the `token-cli`'s
 integrated block explorer. To do this, run the following command:
 ```bash
@@ -310,7 +286,7 @@ following command to get additional transaction details:
 /tmp/token-cli chain watch
 ```
 
-### Step 12: Run Load
+### Step 11: Run Load
 Once the network information is imported, you can then run the following
 command to drive an arbitrary amount of load:
 ```bash
@@ -318,7 +294,6 @@ command to drive an arbitrary amount of load:
 ```
 
 ## Deploy TokenVM in Fuji network with avalanche-ops
-
 Same as above, except you use `--network-name fuji` and do not need anchor nodes:
 
 ```bash

--- a/examples/tokenvm/DEVNETS.md
+++ b/examples/tokenvm/DEVNETS.md
@@ -134,8 +134,8 @@ avalanchego_config:
     throttler-inbound-disk-validator-alloc: 10737418240000
     throttler-outbound-validator-alloc-size: 107374182
     snow-mixed-query-num-push-vdr-uint: 10
-    consensus-on-accept-gossip-peer-size: 0
-    consensus-accepted-frontier-gossip-peer-size: 0
+    consensus-on-accept-gossip-peer-size: 5
+    consensus-accepted-frontier-gossip-peer-size: 5
 ```
 
 Make sure to remove `throttler-inbound-at-large-alloc-size` and
@@ -209,15 +209,19 @@ do so (similar to [scripts/run.sh](./scripts/run.sh)):
 ```bash
 rm -rf /tmp/avalanche-ops
 
-/tmp/avalancheup-aws subnet-config \
---log-level=info \
---proposer-min-block-delay 0 \
---file-path /tmp/avalanche-ops/subnet-config.json
+cat <<EOF > /tmp/avalanche-ops/tokenvm-subnet-config.json
+{
+  "proposerMinBlockDelay": 0,
+  "gossipOnAcceptPeerSize": 0,
+  "gossipAcceptedFrontierPeerSize": 0
+}
+EOF
+cat /tmp/avalanche-ops/tokenvm-subnet-config.json
 
 cat <<EOF > /tmp/avalanche-ops/allocations.json
-[{"address":"token1rvzhmceq997zntgvravfagsks6w0ryud3rylh4cdvayry0dl97nsjzf3yp", "balance":1000000000000}]
+[{"address":"token1rvzhmceq997zntgvravfagsks6w0ryud3rylh4cdvayry0dl97nsjzf3yp", "balance":1000000000000000}]
 EOF
-rm -f /tmp/avalanche-ops/tokenvm-genesis.json
+
 /tmp/token-cli genesis generate /tmp/avalanche-ops/allocations.json \
 --genesis-file /tmp/avalanche-ops/tokenvm-genesis.json \
 --max-block-units 4000000 \
@@ -418,7 +422,7 @@ a different set of validators):
 --key <TODO> \
 --primary-network-validate-period-in-days 16 \
 --subnet-validate-period-in-days 14 \
---subnet-config-local-path /tmp/avalanche-ops/subnet-config.json \
+--subnet-config-local-path /tmp/avalanche-ops/tokenvm-subnet-config.json \
 --subnet-config-remote-dir /data/avalanche-configs/subnets \
 --vm-binary-local-path /tmp/tokenvm \
 --vm-binary-remote-dir /data/avalanche-plugins \

--- a/examples/tokenvm/DEVNETS.md
+++ b/examples/tokenvm/DEVNETS.md
@@ -342,6 +342,13 @@ command to drive an arbitrary amount of load:
 /tmp/token-cli spam run
 ```
 
+#### Limiting Inflight Txs
+To ensure you don't create too large of a backlog on the network, you can add
+run the following command (defaults to `72000`):
+```bash
+/tmp/token-cli spam run --max-tx-backlog 5000
+```
+
 ### [OPTIONAL] Step 12: Deploy Another Subnet
 To test Avalanche Warp Messaging, you must be running at least 2 Subnets. To do
 so, just replicate the command you ran above with a different `--chain-name` (and

--- a/examples/tokenvm/DEVNETS.md
+++ b/examples/tokenvm/DEVNETS.md
@@ -294,9 +294,12 @@ Here are some useful queries (on an example chainID `3rihqpXh6ZJqxL2dsrVysKkEKro
 * [verify latency in ms] `increase(avalanche_3rihqpXh6ZJqxL2dsrVysKkEKroiD9tvQWLS6iWVnd8K4HST2_vm_metervm_verify_sum[30s:1s])/increase(avalanche_3rihqpXh6ZJqxL2dsrVysKkEKroiD9tvQWLS6iWVnd8K4HST2_vm_metervm_verify_count[30s:1s])/1000000`
 * [accept latency in ms] `increase(avalanche_3rihqpXh6ZJqxL2dsrVysKkEKroiD9tvQWLS6iWVnd8K4HST2_vm_metervm_accept_sum[30s:1s])/increase(avalanche_3rihqpXh6ZJqxL2dsrVysKkEKroiD9tvQWLS6iWVnd8K4HST2_vm_metervm_accept_count[30s:1s])/1000000`
 * [transactions per second] `deriv(avalanche_3rihqpXh6ZJqxL2dsrVysKkEKroiD9tvQWLS6iWVnd8K4HST2_vm_hyper_sdk_vm_txs_accepted[30s:1s])`
+* [accepted block size] `increase(avalanche_3rihqpXh6ZJqxL2dsrVysKkEKroiD9tvQWLS6iWVnd8K4HST2_blks_accepted_container_size_sum[30s:1s])/increase(avalanche_3rihqpXh6ZJqxL2dsrVysKkEKroiD9tvQWLS6iWVnd8K4HST2_blks_accepted_count[30s:1s])`
 * `avalanche_3rihqpXh6ZJqxL2dsrVysKkEKroiD9tvQWLS6iWVnd8K4HST2_vm_hyper_sdk_vm_txs_accepted`
 * [disk used] `300000000000-avalanche_resource_tracker_disk_available_space`
 * `avalanche_resource_tracker_cpu_usage`
+* `avalanche_resource_tracker_disk_reads`
+* `avalanche_resource_tracker_disk_writes`
 * `avalanche_3rihqpXh6ZJqxL2dsrVysKkEKroiD9tvQWLS6iWVnd8K4HST2_vm_go_goroutines`
 * `avalanche_3rihqpXh6ZJqxL2dsrVysKkEKroiD9tvQWLS6iWVnd8K4HST2_vm_go_memstats_alloc_bytes`
 * `avalanche_network_inbound_conn_throttler_rate_limited`

--- a/examples/tokenvm/DEVNETS.md
+++ b/examples/tokenvm/DEVNETS.md
@@ -4,30 +4,12 @@ _In the world of Avalanche, we refer to short-lived, test Subnets as Devnets._
 ### Step 1: Install `avalanche-ops`
 [avalanche-ops](https://github.com/ava-labs/avalanche-ops) provides a command-line
 interface to setup nodes and install Custom VMs on both custom networks and on
-Fuji using [AWS CloudFormation](https://aws.amazon.com/cloudformation/). `avalanche-ops`
-is written in Rust, so you must either install Rust and compile `avalanche-ops` or
-download the latest from the `avalanche-ops` repo.
+Fuji using [AWS CloudFormation](https://aws.amazon.com/cloudformation/).
 
-#### Option 1: Install Rust and Compile
-Install [Rust](https://www.rust-lang.org/tools/install):
-```bash
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-```
+You can view a full list of pre-built binaries on the [latest release
+page](https://github.com/ava-labs/avalanche-ops/releases/tag/latest).
 
-Compile `avalanche-ops`:
-```bash
-git clone git@github.com:ava-labs/avalanche-ops.git
-cd ./avalanche-ops
-./scripts/build.release.sh
-mv ./target/release/avalancheup-aws /tmp/avalancheup-aws
-chmod +x /tmp/avalancheup-aws
-/tmp/avalancheup-aws --help
-```
-
-#### Option 2: Download Pre-Built CLI
-You can view a full list of pre-built binaries on the [latest release page](https://github.com/ava-labs/avalanche-ops/releases/tag/latest).
-
-##### Install `avalanche-ops` on Mac
+#### Option 1: Install `avalanche-ops` on Mac
 ```bash
 export LINUX_ARCH_TYPE=$(uname -m)
 echo ${LINUX_ARCH_TYPE}
@@ -38,7 +20,7 @@ chmod +x /tmp/avalancheup-aws
 /tmp/avalancheup-aws --help
 ```
 
-##### Install `avalanche-ops` on Linux
+#### Option 2: Install `avalanche-ops` on Linux
 ```bash
 export LINUX_ARCH_TYPE=$(uname -m)
 echo ${LINUX_ARCH_TYPE}
@@ -50,7 +32,8 @@ chmod +x /tmp/avalancheup-aws
 ```
 
 ### Step 2: Install and Configure `aws-cli`
-Next, make sure to install the [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html).
+Next, install the [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html). This is used to
+manipulate CloudFormation.
 
 Once you've installed the AWS CLI, run `aws configure` to set the access key to
 use while deploying your devnet.

--- a/examples/tokenvm/DEVNETS.md
+++ b/examples/tokenvm/DEVNETS.md
@@ -287,6 +287,20 @@ metrics:
 /tmp/prometheus --config.file=/tmp/prometheus.yaml
 ```
 
+Here are some useful queries (on an example chainID `3rihqpXh6ZJqxL2dsrVysKkEKroiD9tvQWLS6iWVnd8K4HST2`):
+* `avalanche_3rihqpXh6ZJqxL2dsrVysKkEKroiD9tvQWLS6iWVnd8K4HST2_blks_processing`
+* `avalanche_3rihqpXh6ZJqxL2dsrVysKkEKroiD9tvQWLS6iWVnd8K4HST2_blks_rejected_count`
+* `avalanche_3rihqpXh6ZJqxL2dsrVysKkEKroiD9tvQWLS6iWVnd8K4HST2_blks_accepted_count`
+* [verify latency in ms] `increase(avalanche_3rihqpXh6ZJqxL2dsrVysKkEKroiD9tvQWLS6iWVnd8K4HST2_vm_metervm_verify_sum[30s:1s])/increase(avalanche_3rihqpXh6ZJqxL2dsrVysKkEKroiD9tvQWLS6iWVnd8K4HST2_vm_metervm_verify_count[30s:1s])/1000000`
+* [accept latency in ms] `increase(avalanche_3rihqpXh6ZJqxL2dsrVysKkEKroiD9tvQWLS6iWVnd8K4HST2_vm_metervm_accept_sum[30s:1s])/increase(avalanche_3rihqpXh6ZJqxL2dsrVysKkEKroiD9tvQWLS6iWVnd8K4HST2_vm_metervm_accept_count[30s:1s])/1000000`
+* [transactions per second] `deriv(avalanche_3rihqpXh6ZJqxL2dsrVysKkEKroiD9tvQWLS6iWVnd8K4HST2_vm_hyper_sdk_vm_txs_accepted[30s:1s])`
+* `avalanche_3rihqpXh6ZJqxL2dsrVysKkEKroiD9tvQWLS6iWVnd8K4HST2_vm_hyper_sdk_vm_txs_accepted`
+* [disk used] `300000000000-avalanche_resource_tracker_disk_available_space`
+* `avalanche_resource_tracker_cpu_usage`
+* `avalanche_3rihqpXh6ZJqxL2dsrVysKkEKroiD9tvQWLS6iWVnd8K4HST2_vm_go_goroutines`
+* `avalanche_3rihqpXh6ZJqxL2dsrVysKkEKroiD9tvQWLS6iWVnd8K4HST2_vm_go_memstats_alloc_bytes`
+* `avalanche_network_inbound_conn_throttler_rate_limited`
+
 To remove previously ingested data, delete for a folder called `data` in the
 directory where you last ran Prometheus.
 

--- a/examples/tokenvm/DEVNETS.md
+++ b/examples/tokenvm/DEVNETS.md
@@ -84,7 +84,7 @@ Now we can spin up a new network of 6 nodes with some defaults:
 --non-anchor-nodes 3 \
 --region us-west-2 \
 --instance-mode=on-demand \
---instance-types=c5.2xlarge \
+--instance-types=c5.4xlarge \
 --ip-mode=elastic \
 --metrics-fetch-interval-seconds 60 \
 --network-name custom \
@@ -122,6 +122,10 @@ instance types are used (and override `--instance-size`), you can populate the `
 You can specify a single instance type (`--instance-types=c5.2xlarge`) or a comma-separated list
 (`--instance-types=c5.2xlarge,m5.2xlarge`).
 
+`avalanchego` will use at least `<expected block size> * (2048[bytesToIDCache] + 2048[decidedBlocksCache])`
+for caching blocks. This overhead will be significantly reduced when
+[this issue is resolved](https://github.com/ava-labs/hypersdk/issues/129).
+
 #### Increasing Rate Limits
 If you are attempting to stress test the Devnet, you should disable CPU, Disk,
 and Bandwidth rate limiting. You can do this by adding the following lines to
@@ -141,10 +145,6 @@ avalanchego_config:
     consensus-on-accept-gossip-peer-size: 5
     consensus-accepted-frontier-gossip-peer-size: 5
 ```
-
-Make sure to remove `throttler-inbound-at-large-alloc-size` and
-`throttler-inbound-node-max-at-large-bytes` from the default YAML, otherwise
-you will have duplicate keys.
 
 #### Supporting All Metrics
 By default, `avalanche-ops` does not support ingest all metrics into AWS
@@ -253,7 +253,8 @@ cat /tmp/avalanche-ops/tokenvm-chain-config.json
 
 *Note*: Make sure that port `9652` and `9653` are open on the AWS Security Group applied to all
 nodes otherwise the `token-cli` will not work properly. This requirement will
-be removed when the HyperSDK migrates to using proper WebSockets.
+be removed when the [HyperSDK migrates to using proper
+WebSockets](https://github.com/ava-labs/hypersdk/issues/64).
 
 ### Step 8: Install Chains
 You can run the following commands to spin up 2 `tokenvm` Devnets. Make sure to

--- a/examples/tokenvm/DEVNETS.md
+++ b/examples/tokenvm/DEVNETS.md
@@ -168,6 +168,12 @@ avalancheup-aws delete \
 
 That is, `apply` creates AWS resources, whereas `delete` destroys after testing is done.
 
+If you see the following command, that is expected (it means `avalanche-ops` is
+reusing a S3 bucket it previously created):
+```
+[2023-03-23T23:49:01Z WARN  aws_manager::s3] bucket already exists so returning early (original error 'service error')
+```
+
 *SECURITY*: By default, the SSH and HTTP ports are open to public. Once you complete provisioning the nodes, go to EC2 security
 group to restrict the inbound rules to your IP.
 

--- a/examples/tokenvm/DEVNETS.md
+++ b/examples/tokenvm/DEVNETS.md
@@ -230,7 +230,7 @@ EOF
 rm -f /tmp/avalanche-ops/tokenvm-genesis.json
 /tmp/token-cli genesis generate /tmp/avalanche-ops/allocations.json \
 --genesis-file /tmp/avalanche-ops/tokenvm-genesis.json \
---max-block-unts 4000000 \
+--max-block-units 4000000 \
 --window-target-units 100000000000 \
 --window-target-blocks 20
 cat /tmp/avalanche-ops/tokenvm-genesis.json

--- a/examples/tokenvm/DEVNETS.md
+++ b/examples/tokenvm/DEVNETS.md
@@ -133,6 +133,22 @@ machine:
   - c5.2xlarge
 ```
 
+#### Increasing Rate Limits
+If you are attempting to stress test the Devnet, you should disable CPU, Disk,
+and Bandwidth rate limiting. You can do this by adding the following lines to
+`avalanchego_config` in the spec file:
+```yaml
+avalanchego_config:
+    proposervm-use-current-height: true
+    throttler-inbound-validator-alloc-size: 107374182
+    throttler-inbound-node-max-processing-msgs: 100000
+    throttler-inbound-bandwidth-refill-rate: 1073741824
+    throttler-inbound-bandwidth-max-burst-size: 1073741824
+    throttler-inbound-cpu-validator-alloc: 100000
+    throttler-inbound-disk-validator-alloc: 10737418240000
+    throttler-outbound-validator-alloc-size: 107374182
+```
+
 ### Step 6: Apply Local Network Deploy
 
 The `default-spec` command itself does not create any resources, and instead outputs the following `apply` and `delete` commands that you can copy and paste:
@@ -220,6 +236,10 @@ cat <<EOF > /tmp/avalanche-ops/tokenvm-chain-config.json
 EOF
 cat /tmp/avalanche-ops/tokenvm-chain-config.json
 ```
+
+*Note*: Make sure that port `9652` and `9653` are open on the AWS Security Group applied to all
+nodes otherwise the `token-cli` will not work properly. This requirement will
+be removed when the HyperSDK migrates to using proper WebSockets.
 
 ### Step 8: Install Chains
 You can run the following commands to spin up 2 `tokenvm` Devnets. Make sure to

--- a/examples/tokenvm/DEVNETS.md
+++ b/examples/tokenvm/DEVNETS.md
@@ -152,6 +152,15 @@ Make sure to remove `throttler-inbound-at-large-alloc-size` and
 `throttler-inbound-node-max-at-large-bytes` from the default YAML, otherwise
 you will have duplicate keys.
 
+#### Supporting All Metrics
+By default, `avalanche-ops` does not support ingest all metrics into AWS
+CloudWatch. To ingest all metrics, change the configured filters in
+`upload_artifacts.prometheus_metrics_rules_file_path` to:
+```yaml
+filters:
+  - regex: ^*$
+```
+
 ### Step 6: Apply Local Network Deploy
 
 The `default-spec` command itself does not create any resources, and instead outputs the following `apply` and `delete` commands that you can copy and paste:
@@ -273,7 +282,7 @@ replace the `***` fields, IP addresses, key, and `node-ids-to-instance-ids` with
 #### Viewing Logs
 1) Open the [AWS CloudWatch](https://aws.amazon.com/cloudwatch) product on your
 AWS Console
-2) Click "Logs Insights"
+2) Click "Logs Insights" on the left pane
 3) Use the following query to view all logs (in reverse-chronological order)
 for all nodes in your Devnet:
 ```
@@ -288,6 +297,13 @@ fields @timestamp, @message, @logStream, @log
 the spec file that was output earlier.
 
 #### Viewing Metrics
+#### Option 1: AWS CloudWatch
+1) Open the [AWS CloudWatch](https://aws.amazon.com/cloudwatch) product on your
+AWS Console
+2) Click "All Metrics" on the left pane
+3) Click the "Custom Namespace" that matches the name of the spec file
+
+#### Option 2: Prometheus
 To view metrics, first download and install [Prometheus](https://prometheus.io/download/)
 using the following commands:
 ```bash

--- a/examples/tokenvm/DEVNETS.md
+++ b/examples/tokenvm/DEVNETS.md
@@ -13,7 +13,7 @@ page](https://github.com/ava-labs/avalanche-ops/releases/tag/latest).
 ```bash
 export ARCH_TYPE=$(uname -m)
 echo ${ARCH_TYPE}
-rm -f ./tmp/avalancheup-aws
+rm -f /tmp/avalancheup-aws
 wget "https://github.com/ava-labs/avalanche-ops/releases/download/latest/avalancheup-aws.${ARCH_TYPE}-apple-darwin"
 mv ./avalancheup-aws.${ARCH_TYPE}-apple-darwin /tmp/avalancheup-aws
 chmod +x /tmp/avalancheup-aws
@@ -24,7 +24,7 @@ chmod +x /tmp/avalancheup-aws
 ```bash
 export ARCH_TYPE=$(uname -m)
 echo ${ARCH_TYPE}
-rm -f ./tmp/avalancheup-aws
+rm -f /tmp/avalancheup-aws
 wget "https://github.com/ava-labs/avalanche-ops/releases/download/latest/avalancheup-aws.${ARCH_TYPE}-linux-gnu"
 mv ./avalancheup-aws.${ARCH_TYPE}-linux-gnu /tmp/avalancheup-aws
 chmod +x /tmp/avalancheup-aws

--- a/examples/tokenvm/DEVNETS.md
+++ b/examples/tokenvm/DEVNETS.md
@@ -289,7 +289,7 @@ To make sure chains are launched successfully, query the `health` endpoints:
 >
 > {"checks":{"C":{"message":{"consensus":{"longestRunningBlock":"0s","outstandingBlocks":0},"vm":null},"timestamp":"2023-03-14T15:55:08.203325635Z","duration":6570},"F1c3GayrV5E7NQdxUCbVfnRPsMSxGbTuHvJLS4R48M3Dcazs6":{"message":{"consensus":{"longestRunningBlock":"0s","outstandingBlocks":0},"vm":{"database":{"v1.4.5":null},"health":200}},"timestamp":"2023-03-14T15:55:08.204161784Z","duration":927270},"P":{"message":{"consensus":{"longestRunningBlock":"0s","outstandingBlocks":0},"vm":{"2km1PAKNK4vSfpyjgK2iFFoBFD3mXHBAWfDBVsPuzKtNYdPRTY-percentConnected":1,"primary-percentConnected":1}},"timestamp":"2023-03-14T15:55:08.203318015Z","duration":63060},"X":{"message":{"consensus":{"outstandingVertices":0,"snowstorm":{"outstandingTransactions":0}},"vm":null},"timestamp":"2023-03-14T15:55:08.203233714Z","duration":18360},"bootstrapped":{"message":[],"timestamp":"2023-03-14T15:55:08.203205494Z","duration":3010},"database":{"timestamp":"2023-03-14T15:55:08.203214634Z","duration":1350},"diskspace":{"message":{"availableDiskBytes":299770839040},"timestamp":"2023-03-14T15:55:08.203252895Z","duration":5361},"network":{"message":{"connectedPeers":5,"sendFailRate":0,"timeSinceLastMsgReceived":"203.209294ms","timeSinceLastMsgSent":"203.209294ms"},"timestamp":"2023-03-14T15:55:08.203212714Z","duration":6550},"router":{"message":{"longestRunningRequest":"0s","outstandingRequests":0},"timestamp":"2023-03-14T15:55:08.203338225Z","duration":21220}},"healthy":true}
 
-### Step 10: Run Spam
+### Step 10: Initialize `token-cli`
 You can import the demo key and the network configuration from `avalanche-ops`
 using the following commands:
 ```bash
@@ -297,8 +297,25 @@ using the following commands:
 /tmp/token-cli chain import-ops
 ```
 
-Once the network information is imported, you can then run `/tmp/token-cli spam
-run` to push network activity on the devnet.
+### Step 11: Start Integrated Block Explorer
+To view activity on each Subnet you created, you can run the `token-cli`'s
+integrated block explorer. To do this, run the following command:
+```bash
+/tmp/token-cli chain watch --hide-txs
+```
+
+If you don't plan to load test the devnet, you may wush to just run the
+following command to get additional transaction details:
+```bash
+/tmp/token-cli chain watch
+```
+
+### Step 12: Run Load
+Once the network information is imported, you can then run the following
+command to drive an arbitrary amount of load:
+```bash
+/tmp/token-cli spam run
+```
 
 ## Deploy TokenVM in Fuji network with avalanche-ops
 

--- a/examples/tokenvm/DEVNETS.md
+++ b/examples/tokenvm/DEVNETS.md
@@ -77,6 +77,8 @@ Now we can spin up a new network of 6 nodes with some defaults:
 - `avalanche-ops` supports [EC2 Spot instances](https://aws.amazon.com/ec2/spot/) for cost savings. Use `--instance-mode=spot` to run instances in spot mode.
 
 ```bash
+# use "--instance-types=c5.2xlarge,m5.2xlarge"
+# to overwrite "--instance-size" flag value
 /tmp/avalancheup-aws default-spec \
 --arch-type amd64 \
 --rust-os-type ubuntu20.04 \

--- a/examples/tokenvm/DEVNETS.md
+++ b/examples/tokenvm/DEVNETS.md
@@ -148,6 +148,9 @@ avalanchego_config:
     throttler-inbound-cpu-validator-alloc: 100000
     throttler-inbound-disk-validator-alloc: 10737418240000
     throttler-outbound-validator-alloc-size: 107374182
+    snow-mixed-query-num-push-vdr-uint: 10
+    consensus-on-accept-gossip-peer-size: 0
+    consensus-accepted-frontier-gossip-peer-size: 0
 ```
 
 Make sure to remove `throttler-inbound-at-large-alloc-size` and
@@ -234,7 +237,7 @@ rm -f /tmp/avalanche-ops/tokenvm-genesis.json
 --genesis-file /tmp/avalanche-ops/tokenvm-genesis.json \
 --max-block-units 4000000 \
 --window-target-units 100000000000 \
---window-target-blocks 20
+--window-target-blocks 30
 cat /tmp/avalanche-ops/tokenvm-genesis.json
 
 cat <<EOF > /tmp/avalanche-ops/tokenvm-chain-config.json

--- a/examples/tokenvm/DEVNETS.md
+++ b/examples/tokenvm/DEVNETS.md
@@ -244,6 +244,7 @@ cat <<EOF > /tmp/avalanche-ops/tokenvm-chain-config.json
   "trackedPairs":["*"],
   "logLevel": "info",
   "preferredBlocksPerSecond": 3,
+  "continuousProfileDir": "/var/log/tokenvm-profile",
   "decisionsPort": 9652,
   "blocksPort": 9653
 }

--- a/examples/tokenvm/DEVNETS.md
+++ b/examples/tokenvm/DEVNETS.md
@@ -230,6 +230,7 @@ EOF
 rm -f /tmp/avalanche-ops/tokenvm-genesis.json
 /tmp/token-cli genesis generate /tmp/avalanche-ops/allocations.json \
 --genesis-file /tmp/avalanche-ops/tokenvm-genesis.json \
+--max-block-unts 4000000 \
 --window-target-units 100000000000 \
 --window-target-blocks 20
 cat /tmp/avalanche-ops/tokenvm-genesis.json
@@ -242,6 +243,7 @@ cat <<EOF > /tmp/avalanche-ops/tokenvm-chain-config.json
   "streamingBacklogSize": 10000000,
   "trackedPairs":["*"],
   "logLevel": "info",
+  "preferredBlocksPerSecond": 3,
   "decisionsPort": 9652,
   "blocksPort": 9653
 }

--- a/examples/tokenvm/DEVNETS.md
+++ b/examples/tokenvm/DEVNETS.md
@@ -38,8 +38,17 @@ manipulate CloudFormation.
 Once you've installed the AWS CLI, run `aws configure` to set the access key to
 use while deploying your devnet.
 
-### Step 3: Download `token-cli`
+### Step 3: Install `token-cli`
 ```bash
+export ARCH_TYPE=$(uname -m)
+echo ${ARCH_TYPE}
+export OS_TYPE=$(uname | tr '[:upper:]' '[:lower:]')
+echo ${OS_TYPE}
+export HYPERSDK_VERSION="0.0.4"
+rm -f ./tmp/token-cli
+wget "https://github.com/ava-labs/hypersdk/releases/download/v${HYPERSDK_VERSION}/hypersdk_${HYPERSDK_VERSION}_${OS_TYPE}_${ARCH_TYPE}.tar.gz
+tar -xvf hypersdk_${HYPERSDK_VERSION}_${OS_TYPE}_${ARCH_TYPE}.tar.gz
+mv hypersdk_${HYPERSDK_VERSION}_${OS_TYPE}_${ARCH_TYPE}/token-cli /tmp/token-cli
 ```
 
 ### Step 4: Download `tokenvm`
@@ -48,7 +57,15 @@ improve the performance of cryptographic operations, you should consider
 building with [`v3+`](https://github.com/golang/go/wiki/MinimumRequirements#amd64).
 
 ```bash
+export HYPERSDK_VERSION="0.0.4"
+rm -f ./tmp/tokenvm
+wget "https://github.com/ava-labs/hypersdk/releases/download/v${HYPERSDK_VERSION}/hypersdk_${HYPERSDK_VERSION}_linux_amd64.tar.gz
+tar -xvf hypersdk_${HYPERSDK_VERSION}_linux_amd64.tar.gz
+mv hypersdk_${HYPERSDK_VERSION}_linux_amd64/tokenvm /tmp/tokenvm
 ```
+
+*Note*: We must install the linux build because that is compatible with the AWS
+deployment target. If you use Graivtron CPUs, make sure to use `arm64` here.
 
 
 ### Step 5: Plan Local Network Deploy

--- a/examples/tokenvm/DEVNETS.md
+++ b/examples/tokenvm/DEVNETS.md
@@ -125,6 +125,7 @@ and Bandwidth rate limiting. You can do this by adding the following lines to
 `avalanchego_config` in the spec file:
 ```yaml
 avalanchego_config:
+    ...
     proposervm-use-current-height: true
     throttler-inbound-validator-alloc-size: 107374182
     throttler-inbound-node-max-processing-msgs: 100000
@@ -208,6 +209,7 @@ do so (similar to [scripts/run.sh](./scripts/run.sh)):
 
 ```bash
 rm -rf /tmp/avalanche-ops
+mkdir /tmp/avalanche-ops
 
 cat <<EOF > /tmp/avalanche-ops/tokenvm-subnet-config.json
 {

--- a/examples/tokenvm/DEVNETS.md
+++ b/examples/tokenvm/DEVNETS.md
@@ -294,7 +294,7 @@ You can import the demo key and the network configuration from `avalanche-ops`
 using the following commands:
 ```bash
 /tmp/token-cli key import demo.pk
-/tmp/token-cli chain import-ops
+/tmp/token-cli chain import-ops <chainID> <avalanche-ops YAML file>
 ```
 
 ### Step 11: Start Integrated Block Explorer

--- a/examples/tokenvm/DEVNETS.md
+++ b/examples/tokenvm/DEVNETS.md
@@ -77,7 +77,6 @@ Now we can spin up a new network of 6 nodes with some defaults:
 - `avalanche-ops` supports [EC2 Spot instances](https://aws.amazon.com/ec2/spot/) for cost savings. Use `--instance-mode=spot` to run instances in spot mode.
 
 ```bash
-# launch/download all artifacts for x86 platform
 /tmp/avalancheup-aws default-spec \
 --arch-type amd64 \
 --rust-os-type ubuntu20.04 \
@@ -148,6 +147,10 @@ avalanchego_config:
     throttler-inbound-disk-validator-alloc: 10737418240000
     throttler-outbound-validator-alloc-size: 107374182
 ```
+
+Make sure to remove `throttler-inbound-at-large-alloc-size` and
+`throttler-inbound-node-max-at-large-bytes` from the default YAML, otherwise
+you will have duplicate keys.
 
 ### Step 6: Apply Local Network Deploy
 

--- a/examples/tokenvm/README.md
+++ b/examples/tokenvm/README.md
@@ -426,6 +426,12 @@ command:
 docker-compose -f trace/zipkin.yml down
 ```
 
+## Deploying to a Devnet
+_In the world of Avalanche, we refer to short-lived, test Subnets as Devnets._
+
+To programaticaly deploy `tokenvm` to a distributed cluster of nodes running on
+your own custom network or on Fuji, check out this [doc](DEVNETS.md).
+
 ## Future Work
 _If you want to take the lead on any of these items, please
 [start a discussion](https://github.com/ava-labs/hypersdk/discussions) or reach

--- a/examples/tokenvm/avalanche-ops.aws.md
+++ b/examples/tokenvm/avalanche-ops.aws.md
@@ -60,6 +60,8 @@ avalancheup-aws default-spec \
 The default commands above will download the public release binaries from github. To test your own binaries, use the following flags to upload to S3. These binaries must be built for the target remote machine platform (e.g., build for `aarch64` and Linux to run them in Graviton processors):
 
 ```bash
+avalancheup-aws default-spec \
+...
 --upload-artifacts-aws-volume-provisioner-local-bin ${AWS_VOLUME_PROVISIONER_BIN_PATH} \
 --upload-artifacts-aws-ip-provisioner-local-bin ${AWS_IP_PROVISIONER_BIN_PATH} \
 --upload-artifacts-avalanche-telemetry-cloudwatch-local-bin ${AVALANCHE_TELEMETRY_CLOUDWATCH_BIN_PATH} \
@@ -69,9 +71,26 @@ The default commands above will download the public release binaries from github
 
 It is recommended to specify your own artifacts to avoid flaky github release page downloads.
 
+*NOTE*: The `default-spec` (and `apply`) command only provisions nodes, not custom VMs. The subnet and custom VM installation are done via `install-subnet-chain` sub-commands.
+
 ### Step 3
 
-The `default-spec` command above will output the following `apply` and `delete` commands that you can copy and paste:
+The `default-spec` command itselt does not create any resources, and instead outputs the following `apply` and `delete` commands that you can copy and paste:
+
+```bash
+# first make sure you have access to the AWS credential
+aws sts get-caller-identity
+
+# "avalancheup-aws apply" would not work...
+# An error occurred (ExpiredToken) when calling the GetCallerIdentity operation: The security token included in the request is expired
+
+# "avalancheup-aws apply" will work with the following credential
+# {
+#   "UserId": "...:abc@abc.com",
+#   "Account": "...",
+#   "Arn": "arn:aws:sts::....:assumed-role/name/abc@abc.com"
+# }
+```
 
 ```bash
 # run the following to create resources

--- a/examples/tokenvm/avalanche-ops.aws.md
+++ b/examples/tokenvm/avalanche-ops.aws.md
@@ -146,7 +146,7 @@ EOF
 cat /tmp/tokenvm-chain-config.json
 ```
 
-Note that `--chain-name tokenvm*` and `--node-ids-to-instance-ids` values are different to split nodes into two separate subnets. And `avalancheup-aws install-subnet-chain` **will add the specified nodes as primary network validators (regardless of it's for customer or public networks) before adding them as subnet validators**. So, please make sure the `--key` has enough balance and use `--primary-network-validate-period-in-days` and `--subnet-validate-period-in-days` flags to set custom validate priods (defaults to 15-day for primary network, 14-day for subnet validation):
+Note that `--chain-name tokenvm*` and `--node-ids-to-instance-ids` values are different to split nodes into two separate subnets. And `avalancheup-aws install-subnet-chain` **will add the specified nodes as primary network validators (regardless of it's for customer or public networks) before adding them as subnet validators**. So, please make sure the `--key` has enough balance and use `--primary-network-validate-period-in-days` and `--subnet-validate-period-in-days` flags to set custom validate priods (defaults to 16-day for primary network, 14-day for subnet validation):
 
 ```bash
 # this will prompt you to confirm the outcome!
@@ -159,7 +159,7 @@ avalancheup-aws install-subnet-chain \
 --ssm-doc aops-custom-***-ssm-install-subnet-chain \
 --chain-rpc-url http://52.88.8.107:9650 \
 --key 0x56289e99c94b6912bfc12adc093c9b51124f0dc54ac7a766b2bc5ccf558d8027 \
---primary-network-validate-period-in-days 15 \
+--primary-network-validate-period-in-days 16 \
 --subnet-validate-period-in-days 14 \
 --subnet-config-local-path /tmp/subnet-config.json \
 --subnet-config-remote-dir /data/avalanche-configs/subnets \
@@ -184,7 +184,7 @@ avalancheup-aws install-subnet-chain \
 --ssm-doc aops-custom-***-ssm-install-subnet-chain \
 --chain-rpc-url http://52.88.8.107:9650 \
 --key 0x56289e99c94b6912bfc12adc093c9b51124f0dc54ac7a766b2bc5ccf558d8027 \
---primary-network-validate-period-in-days 15 \
+--primary-network-validate-period-in-days 16 \
 --subnet-validate-period-in-days 14 \
 --subnet-config-local-path /tmp/subnet-config.json \
 --subnet-config-remote-dir /data/avalanche-configs/subnets \

--- a/examples/tokenvm/avalanche-ops.aws.md
+++ b/examples/tokenvm/avalanche-ops.aws.md
@@ -159,7 +159,8 @@ avalancheup-aws install-subnet-chain \
 --ssm-doc aops-custom-***-ssm-install-subnet-chain \
 --chain-rpc-url http://52.88.8.107:9650 \
 --key 0x56289e99c94b6912bfc12adc093c9b51124f0dc54ac7a766b2bc5ccf558d8027 \
---subnet-validate-period-in-days 15 \
+--primary-network-validate-period-in-days 15 \
+--subnet-validate-period-in-days 14 \
 --subnet-config-local-path /tmp/subnet-config.json \
 --subnet-config-remote-dir /data/avalanche-configs/subnets \
 --vm-binary-local-path /tmp/tokenvm \
@@ -183,7 +184,8 @@ avalancheup-aws install-subnet-chain \
 --ssm-doc aops-custom-***-ssm-install-subnet-chain \
 --chain-rpc-url http://52.88.8.107:9650 \
 --key 0x56289e99c94b6912bfc12adc093c9b51124f0dc54ac7a766b2bc5ccf558d8027 \
---subnet-validate-period-in-days 15 \
+--primary-network-validate-period-in-days 15 \
+--subnet-validate-period-in-days 14 \
 --subnet-config-local-path /tmp/subnet-config.json \
 --subnet-config-remote-dir /data/avalanche-configs/subnets \
 --vm-binary-local-path /tmp/tokenvm \

--- a/examples/tokenvm/cmd/token-cli/cmd/chain.go
+++ b/examples/tokenvm/cmd/token-cli/cmd/chain.go
@@ -17,7 +17,6 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/hypersdk/utils"
-	hutils "github.com/ava-labs/hypersdk/utils"
 	"github.com/ava-labs/hypersdk/vm"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
@@ -245,7 +244,7 @@ var watchChainCmd = &cobra.Command{
 			return err
 		}
 		uri := fmt.Sprintf("%s:%d", host, port)
-		hutils.Outf("{{yellow}}uri:{{/}} %s\n", uri)
+		utils.Outf("{{yellow}}uri:{{/}} %s\n", uri)
 		scli, err := vm.NewBlockRPCClient(uri)
 		if err != nil {
 			return err

--- a/examples/tokenvm/cmd/token-cli/cmd/chain.go
+++ b/examples/tokenvm/cmd/token-cli/cmd/chain.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/hypersdk/utils"
+	hutils "github.com/ava-labs/hypersdk/utils"
 	"github.com/ava-labs/hypersdk/vm"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
@@ -243,7 +244,9 @@ var watchChainCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		scli, err := vm.NewBlockRPCClient(fmt.Sprintf("%s:%d", host, port))
+		uri := fmt.Sprintf("%s:%d", host, port)
+		hutils.Outf("{{yellow}}uri:{{/}} %s\n", uri)
+		scli, err := vm.NewBlockRPCClient(uri)
 		if err != nil {
 			return err
 		}

--- a/examples/tokenvm/cmd/token-cli/cmd/chain.go
+++ b/examples/tokenvm/cmd/token-cli/cmd/chain.go
@@ -7,6 +7,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
 	"reflect"
 	"strconv"
 	"strings"
@@ -18,6 +19,7 @@ import (
 	"github.com/ava-labs/hypersdk/utils"
 	"github.com/ava-labs/hypersdk/vm"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
 
 	"github.com/ava-labs/hypersdk/examples/tokenvm/actions"
 	"github.com/ava-labs/hypersdk/examples/tokenvm/auth"
@@ -123,6 +125,68 @@ var importANRChainCmd = &cobra.Command{
 			}
 		}
 		return StoreDefault(defaultChainKey, filledChainID[:])
+	},
+}
+
+type AvalancheOpsConfig struct {
+	Resources struct {
+		CreatedNodes []struct {
+			HTTPEndpoint string `yaml:"httpEndpoint"`
+		} `yaml:"created_nodes"`
+	} `yaml:"resources"`
+}
+
+var importAvalancheOpsChainCmd = &cobra.Command{
+	Use: "import-ops [chainID] [path]",
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 2 {
+			return ErrInvalidArgs
+		}
+		_, err := ids.FromString(args[0])
+		return err
+	},
+	RunE: func(_ *cobra.Command, args []string) error {
+		// Delete previous items
+		if deleteOtherChains {
+			oldChains, err := DeleteChains()
+			if err != nil {
+				return err
+			}
+			if len(oldChains) > 0 {
+				utils.Outf("{{yellow}}deleted old chains:{{/}} %+v\n", oldChains)
+			}
+		}
+
+		// Load chainID
+		chainID, err := ids.FromString(args[0])
+		if err != nil {
+			return err
+		}
+
+		// Load yaml file
+		var opsConfig AvalancheOpsConfig
+		yamlFile, err := os.ReadFile(args[1])
+		if err != nil {
+			return err
+		}
+		err = yaml.Unmarshal(yamlFile, &opsConfig)
+		if err != nil {
+			return err
+		}
+
+		// Add chains
+		for _, node := range opsConfig.Resources.CreatedNodes {
+			uri := fmt.Sprintf("%s/ext/bc/%s", node.HTTPEndpoint, chainID)
+			if err := StoreChain(chainID, uri); err != nil {
+				return err
+			}
+			utils.Outf(
+				"{{yellow}}stored chainID:{{/}} %s {{yellow}}uri:{{/}} %s\n",
+				chainID,
+				uri,
+			)
+		}
+		return StoreDefault(defaultChainKey, chainID[:])
 	},
 }
 

--- a/examples/tokenvm/cmd/token-cli/cmd/genesis.go
+++ b/examples/tokenvm/cmd/token-cli/cmd/genesis.go
@@ -34,6 +34,12 @@ var genGenesisCmd = &cobra.Command{
 		if minUnitPrice >= 0 {
 			g.MinUnitPrice = uint64(minUnitPrice)
 		}
+		if windowTargetUnits >= 0 {
+			g.WindowTargetUnits = uint64(windowTargetUnits)
+		}
+		if windowTargetBlocks >= 0 {
+			g.WindowTargetBlocks = uint64(windowTargetBlocks)
+		}
 
 		a, err := os.ReadFile(args[0])
 		if err != nil {

--- a/examples/tokenvm/cmd/token-cli/cmd/genesis.go
+++ b/examples/tokenvm/cmd/token-cli/cmd/genesis.go
@@ -34,6 +34,9 @@ var genGenesisCmd = &cobra.Command{
 		if minUnitPrice >= 0 {
 			g.MinUnitPrice = uint64(minUnitPrice)
 		}
+		if maxBlockUnits >= 0 {
+			g.MaxBlockUnits = uint64(maxBlockUnits)
+		}
 		if windowTargetUnits >= 0 {
 			g.WindowTargetUnits = uint64(windowTargetUnits)
 		}

--- a/examples/tokenvm/cmd/token-cli/cmd/key.go
+++ b/examples/tokenvm/cmd/token-cli/cmd/key.go
@@ -124,7 +124,12 @@ var balanceKeyCmd = &cobra.Command{
 	Use: "balance",
 	RunE: func(*cobra.Command, []string) error {
 		ctx := context.Background()
-		_, priv, _, cli, err := defaultActor()
+
+		priv, err := GetDefaultKey()
+		if err != nil {
+			return err
+		}
+		_, uris, err := GetDefaultChain()
 		if err != nil {
 			return err
 		}
@@ -133,7 +138,17 @@ var balanceKeyCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		_, _, err = getAssetInfo(ctx, cli, priv.PublicKey(), assetID, true)
-		return err
+
+		max := len(uris)
+		if !checkAllChains {
+			max = 1
+		}
+		for _, uri := range uris[:max] {
+			hutils.Outf("{{yellow}}uri:{{/}} %s\n", uri)
+			if _, _, err = getAssetInfo(ctx, client.New(uri), priv.PublicKey(), assetID, true); err != nil {
+				return err
+			}
+		}
+		return nil
 	},
 }

--- a/examples/tokenvm/cmd/token-cli/cmd/metrics.go
+++ b/examples/tokenvm/cmd/token-cli/cmd/metrics.go
@@ -1,0 +1,84 @@
+// Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package cmd
+
+import (
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+)
+
+var metricsCmd = &cobra.Command{
+	Use: "metrics",
+	RunE: func(*cobra.Command, []string) error {
+		return ErrMissingSubcommand
+	},
+}
+
+type PrometheusStaticConfig struct {
+	Targets []string `yaml:"targets"`
+}
+
+type PrometheusScrapeConfig struct {
+	JobName       string                    `yaml:"job_name"`
+	StaticConfigs []*PrometheusStaticConfig `yaml:"static_configs"`
+	MetricsPath   string                    `yaml:"metrics_path"`
+}
+
+type PrometheusConfig struct {
+	Global struct {
+		ScrapeInterval     string `yaml:"scrape_interval"`
+		EvaluationInterval string `yaml:"evaluation_interval"`
+	} `yaml:"global"`
+	ScrapeConfigs []*PrometheusScrapeConfig `yaml:"scrape_configs"`
+}
+
+var prometheusCmd = &cobra.Command{
+	Use: "prometheus [path] [output]",
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 2 {
+			return ErrInvalidArgs
+		}
+		return nil
+	},
+	RunE: func(_ *cobra.Command, args []string) error {
+		// Load HTTP Endpoints
+		var opsConfig AvalancheOpsConfig
+		yamlFile, err := os.ReadFile(args[0])
+		if err != nil {
+			return err
+		}
+		err = yaml.Unmarshal(yamlFile, &opsConfig)
+		if err != nil {
+			return err
+		}
+		endpoints := make([]string, len(opsConfig.Resources.CreatedNodes))
+		for i, node := range opsConfig.Resources.CreatedNodes {
+			endpoints[i] = strings.TrimPrefix(node.HTTPEndpoint, "http://")
+		}
+
+		// Create Prometheus YAML
+		var prometheusConfig PrometheusConfig
+		prometheusConfig.Global.ScrapeInterval = "15s"
+		prometheusConfig.Global.EvaluationInterval = "15s"
+		prometheusConfig.ScrapeConfigs = []*PrometheusScrapeConfig{
+			{
+				JobName: "prometheus",
+				StaticConfigs: []*PrometheusStaticConfig{
+					{
+						Targets: endpoints,
+					},
+				},
+				MetricsPath: "/ext/metrics",
+			},
+		}
+		yamlData, err := yaml.Marshal(&prometheusConfig)
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(args[1], yamlData, fsModeWrite)
+	},
+}

--- a/examples/tokenvm/cmd/token-cli/cmd/root.go
+++ b/examples/tokenvm/cmd/token-cli/cmd/root.go
@@ -24,11 +24,12 @@ var (
 	dbPath string
 	db     database.Database
 
-	genesisFile     string
-	minUnitPrice    int64
-	hideTxs         bool
-	randomRecipient bool
-	maxTxBacklog    int
+	genesisFile       string
+	minUnitPrice      int64
+	hideTxs           bool
+	randomRecipient   bool
+	maxTxBacklog      int
+	deleteOtherChains bool
 
 	rootCmd = &cobra.Command{
 		Use:        "token-cli",
@@ -95,9 +96,16 @@ func init() {
 		false,
 		"hide txs",
 	)
+	importAvalancheOpsChainCmd.PersistentFlags().BoolVar(
+		&deleteOtherChains,
+		"delete-other-chains",
+		true,
+		"delete other chains",
+	)
 	chainCmd.AddCommand(
 		importChainCmd,
 		importANRChainCmd,
+		importAvalancheOpsChainCmd,
 		setChainCmd,
 		chainInfoCmd,
 		watchChainCmd,

--- a/examples/tokenvm/cmd/token-cli/cmd/root.go
+++ b/examples/tokenvm/cmd/token-cli/cmd/root.go
@@ -30,6 +30,7 @@ var (
 	randomRecipient   bool
 	maxTxBacklog      int
 	deleteOtherChains bool
+	checkAllChains    bool
 
 	rootCmd = &cobra.Command{
 		Use:        "token-cli",
@@ -82,6 +83,12 @@ func init() {
 	)
 
 	// key
+	balanceKeyCmd.PersistentFlags().BoolVar(
+		&checkAllChains,
+		"check-all-chains",
+		false,
+		"check all chains",
+	)
 	keyCmd.AddCommand(
 		genKeyCmd,
 		importKeyCmd,

--- a/examples/tokenvm/cmd/token-cli/cmd/root.go
+++ b/examples/tokenvm/cmd/token-cli/cmd/root.go
@@ -26,6 +26,7 @@ var (
 
 	genesisFile        string
 	minUnitPrice       int64
+	maxBlockUnits      int64
 	windowTargetUnits  int64
 	windowTargetBlocks int64
 	hideTxs            bool
@@ -80,6 +81,12 @@ func init() {
 		"min-unit-price",
 		-1,
 		"minimum price",
+	)
+	genGenesisCmd.PersistentFlags().Int64Var(
+		&maxBlockUnits,
+		"max-block-units",
+		-1,
+		"max block units",
 	)
 	genGenesisCmd.PersistentFlags().Int64Var(
 		&windowTargetUnits,

--- a/examples/tokenvm/cmd/token-cli/cmd/root.go
+++ b/examples/tokenvm/cmd/token-cli/cmd/root.go
@@ -49,6 +49,7 @@ func init() {
 		chainCmd,
 		actionCmd,
 		spamCmd,
+		metricsCmd,
 	)
 	rootCmd.PersistentFlags().StringVar(
 		&dbPath,
@@ -164,6 +165,11 @@ func init() {
 	)
 	spamCmd.AddCommand(
 		runSpamCmd,
+	)
+
+	// metrics
+	metricsCmd.AddCommand(
+		prometheusCmd,
 	)
 }
 

--- a/examples/tokenvm/cmd/token-cli/cmd/root.go
+++ b/examples/tokenvm/cmd/token-cli/cmd/root.go
@@ -24,13 +24,15 @@ var (
 	dbPath string
 	db     database.Database
 
-	genesisFile       string
-	minUnitPrice      int64
-	hideTxs           bool
-	randomRecipient   bool
-	maxTxBacklog      int
-	deleteOtherChains bool
-	checkAllChains    bool
+	genesisFile        string
+	minUnitPrice       int64
+	windowTargetUnits  int64
+	windowTargetBlocks int64
+	hideTxs            bool
+	randomRecipient    bool
+	maxTxBacklog       int
+	deleteOtherChains  bool
+	checkAllChains     bool
 
 	rootCmd = &cobra.Command{
 		Use:        "token-cli",
@@ -66,9 +68,6 @@ func init() {
 	rootCmd.SilenceErrors = true
 
 	// genesis
-	genesisCmd.AddCommand(
-		genGenesisCmd,
-	)
 	genGenesisCmd.PersistentFlags().StringVar(
 		&genesisFile,
 		"genesis-file",
@@ -80,6 +79,21 @@ func init() {
 		"min-unit-price",
 		-1,
 		"minimum price",
+	)
+	genGenesisCmd.PersistentFlags().Int64Var(
+		&windowTargetUnits,
+		"window-target-units",
+		-1,
+		"window target units",
+	)
+	genGenesisCmd.PersistentFlags().Int64Var(
+		&windowTargetBlocks,
+		"window-target-blocks",
+		-1,
+		"window target blocks",
+	)
+	genesisCmd.AddCommand(
+		genGenesisCmd,
 	)
 
 	// key

--- a/examples/tokenvm/cmd/token-cli/cmd/spam.go
+++ b/examples/tokenvm/cmd/token-cli/cmd/spam.go
@@ -252,6 +252,7 @@ var runSpamCmd = &cobra.Command{
 		// broadcast txs
 		t := time.NewTimer(0) // ensure no duplicates created
 		defer t.Stop()
+		var runs int
 		for !exiting {
 			select {
 			case <-t.C:
@@ -308,6 +309,14 @@ var runSpamCmd = &cobra.Command{
 					issuer.l.Lock()
 					issuer.outstandingTxs++
 					issuer.l.Unlock()
+
+					// Only send 1 transaction per second until we are sure Snowman++ is
+					// activated.
+					if runs < 10 {
+						hutils.Outf("{{yellow}}only sending 1 tx in %d run{{/}}\n", runs)
+						runs++
+						break
+					}
 				}
 				l.Lock()
 				infl.Lock()

--- a/examples/tokenvm/config/config.go
+++ b/examples/tokenvm/config/config.go
@@ -35,7 +35,7 @@ type Config struct {
 	TraceSampleRate float64 `json:"traceSampleRate"`
 
 	// Profiling
-	ContinuousProfileDir string `json:"continuousProfileDir"`
+	ContinuousProfilerDir string `json:"continuousProfilerDir"`
 
 	// Streaming Ports
 	DecisionsPort        uint16 `json:"decisionsPort"`
@@ -120,12 +120,12 @@ func (c *Config) GetTraceConfig() *trace.Config {
 func (c *Config) GetStateSyncServerDelay() time.Duration { return c.StateSyncServerDelay }
 func (c *Config) GetStreamingBacklogSize() int           { return c.StreamingBacklogSize }
 func (c *Config) GetContinuousProfilerConfig() *profiler.Config {
-	if len(c.ContinuousProfileDir) == 0 {
+	if len(c.ContinuousProfilerDir) == 0 {
 		return &profiler.Config{Enabled: false}
 	}
 	return &profiler.Config{
 		Enabled:     true,
-		Dir:         c.ContinuousProfileDir,
+		Dir:         c.ContinuousProfilerDir,
 		Freq:        defaultContinuousProfilerFrequency,
 		MaxNumFiles: defaultContinuousProfilerMaxFiles,
 	}

--- a/examples/tokenvm/config/config.go
+++ b/examples/tokenvm/config/config.go
@@ -20,6 +20,8 @@ import (
 
 var _ vm.Config = (*Config)(nil)
 
+const DefaultPreferredBlocksPerSecond = 2
+
 type Config struct {
 	*config.Config
 
@@ -45,9 +47,10 @@ type Config struct {
 	TrackedPairs []string `json:"trackedPairs"` // which asset ID pairs we care about
 
 	// Misc
-	TestMode    bool          `json:"testMode"` // makes gossip/building manual
-	LogLevel    logging.Level `json:"logLevel"`
-	Parallelism int           `json:"parallelism"`
+	TestMode                 bool          `json:"testMode"` // makes gossip/building manual
+	LogLevel                 logging.Level `json:"logLevel"`
+	Parallelism              int           `json:"parallelism"`
+	PreferredBlocksPerSecond uint64        `json:"preferredBlocksPerSecond"`
 
 	// State Sync
 	StateSyncServerDelay time.Duration `json:"stateSyncServerDelay"` // for testing
@@ -81,20 +84,22 @@ func New(nodeID ids.NodeID, b []byte) (*Config, error) {
 func (c *Config) setDefault() {
 	c.LogLevel = c.Config.GetLogLevel()
 	c.Parallelism = c.Config.GetParallelism()
+	c.PreferredBlocksPerSecond = DefaultPreferredBlocksPerSecond
 	c.MempoolSize = c.Config.GetMempoolSize()
 	c.MempoolPayerSize = c.Config.GetMempoolPayerSize()
 	c.StateSyncServerDelay = c.Config.GetStateSyncServerDelay()
 	c.StreamingBacklogSize = c.Config.GetStreamingBacklogSize()
 }
 
-func (c *Config) GetLogLevel() logging.Level       { return c.LogLevel }
-func (c *Config) GetTestMode() bool                { return c.TestMode }
-func (c *Config) GetParallelism() int              { return c.Parallelism }
-func (c *Config) GetMempoolSize() int              { return c.MempoolSize }
-func (c *Config) GetMempoolPayerSize() int         { return c.MempoolPayerSize }
-func (c *Config) GetMempoolExemptPayers() [][]byte { return c.parsedExemptPayers }
-func (c *Config) GetDecisionsPort() uint16         { return c.DecisionsPort }
-func (c *Config) GetBlocksPort() uint16            { return c.BlocksPort }
+func (c *Config) GetLogLevel() logging.Level          { return c.LogLevel }
+func (c *Config) GetTestMode() bool                   { return c.TestMode }
+func (c *Config) GetParallelism() int                 { return c.Parallelism }
+func (c *Config) GetPreferredBlocksPerSecond() uint64 { return c.PreferredBlocksPerSecond }
+func (c *Config) GetMempoolSize() int                 { return c.MempoolSize }
+func (c *Config) GetMempoolPayerSize() int            { return c.MempoolPayerSize }
+func (c *Config) GetMempoolExemptPayers() [][]byte    { return c.parsedExemptPayers }
+func (c *Config) GetDecisionsPort() uint16            { return c.DecisionsPort }
+func (c *Config) GetBlocksPort() uint16               { return c.BlocksPort }
 func (c *Config) GetTraceConfig() *trace.Config {
 	return &trace.Config{
 		Enabled:         c.TraceEnabled,

--- a/examples/tokenvm/config/config.go
+++ b/examples/tokenvm/config/config.go
@@ -26,6 +26,7 @@ const (
 	defaultPreferredBlocksPerSecond    = 2
 	defaultContinuousProfilerFrequency = 1 * time.Minute
 	defaultContinuousProfilerMaxFiles  = 10
+	defaultMempoolVerifyBalances       = true
 )
 
 type Config struct {
@@ -44,9 +45,10 @@ type Config struct {
 	StreamingBacklogSize int    `json:"streamingBacklogSize"`
 
 	// Mempool
-	MempoolSize         int      `json:"mempoolSize"`
-	MempoolPayerSize    int      `json:"mempoolPayerSize"`
-	MempoolExemptPayers []string `json:"mempoolExemptPayers"`
+	MempoolSize           int      `json:"mempoolSize"`
+	MempoolPayerSize      int      `json:"mempoolPayerSize"`
+	MempoolExemptPayers   []string `json:"mempoolExemptPayers"`
+	MempoolVerifyBalances bool     `json:"mempoolVerifyBalances"`
 
 	// Order Book
 	//
@@ -96,6 +98,7 @@ func (c *Config) setDefault() {
 	c.PreferredBlocksPerSecond = defaultPreferredBlocksPerSecond
 	c.MempoolSize = c.Config.GetMempoolSize()
 	c.MempoolPayerSize = c.Config.GetMempoolPayerSize()
+	c.MempoolVerifyBalances = defaultMempoolVerifyBalances
 	c.StateSyncServerDelay = c.Config.GetStateSyncServerDelay()
 	c.StreamingBacklogSize = c.Config.GetStreamingBacklogSize()
 }
@@ -107,6 +110,7 @@ func (c *Config) GetPreferredBlocksPerSecond() uint64 { return c.PreferredBlocks
 func (c *Config) GetMempoolSize() int                 { return c.MempoolSize }
 func (c *Config) GetMempoolPayerSize() int            { return c.MempoolPayerSize }
 func (c *Config) GetMempoolExemptPayers() [][]byte    { return c.parsedExemptPayers }
+func (c *Config) GetMempoolVerifyBalances() bool      { return c.MempoolVerifyBalances }
 func (c *Config) GetDecisionsPort() uint16            { return c.DecisionsPort }
 func (c *Config) GetBlocksPort() uint16               { return c.BlocksPort }
 func (c *Config) GetTraceConfig() *trace.Config {

--- a/examples/tokenvm/config/config.go
+++ b/examples/tokenvm/config/config.go
@@ -5,6 +5,7 @@ package config
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/ava-labs/avalanchego/ids"
@@ -35,7 +36,7 @@ type Config struct {
 	TraceSampleRate float64 `json:"traceSampleRate"`
 
 	// Profiling
-	ContinuousProfilerDir string `json:"continuousProfilerDir"`
+	ContinuousProfilerDir string `json:"continuousProfilerDir"` // "*" is replaced with rand int
 
 	// Streaming Ports
 	DecisionsPort        uint16 `json:"decisionsPort"`
@@ -123,6 +124,9 @@ func (c *Config) GetContinuousProfilerConfig() *profiler.Config {
 	if len(c.ContinuousProfilerDir) == 0 {
 		return &profiler.Config{Enabled: false}
 	}
+	// Replace all instances of "*" with nodeID. This is useful when
+	// running multiple instances of tokenvm on the same machine.
+	c.ContinuousProfilerDir = strings.ReplaceAll(c.ContinuousProfilerDir, "*", c.nodeID.String())
 	return &profiler.Config{
 		Enabled:     true,
 		Dir:         c.ContinuousProfilerDir,

--- a/examples/tokenvm/controller/controller.go
+++ b/examples/tokenvm/controller/controller.go
@@ -143,7 +143,9 @@ func (c *Controller) Initialize(
 		build = builder.NewManual(inner)
 		gossip = gossiper.NewManual(inner)
 	} else {
-		build = builder.NewTime(inner, builder.DefaultTimeConfig())
+		bcfg := builder.DefaultTimeConfig()
+		bcfg.PreferredBlocksPerSecond = c.config.GetPreferredBlocksPerSecond()
+		build = builder.NewTime(inner, bcfg)
 		gcfg := gossiper.DefaultProposerConfig()
 		gcfg.BuildProposerDiff = 1 // don't gossip if producing the next block
 		gossip = gossiper.NewProposer(inner, gcfg)

--- a/examples/tokenvm/controller/state_manager.go
+++ b/examples/tokenvm/controller/state_manager.go
@@ -10,6 +10,10 @@ import (
 
 type StateManager struct{}
 
+func (*StateManager) HeightKey() []byte {
+	return storage.HeightKey()
+}
+
 func (*StateManager) IncomingWarpKey(sourceChainID ids.ID, msgID ids.ID) []byte {
 	return storage.IncomingWarpKeyPrefix(sourceChainID, msgID)
 }

--- a/examples/tokenvm/go.mod
+++ b/examples/tokenvm/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/prometheus/client_golang v1.14.0
 	github.com/spf13/cobra v1.6.1
 	go.uber.org/zap v1.24.0
+	gopkg.in/yaml.v2 v2.4.0
 )
 
 require (
@@ -138,7 +139,6 @@ require (
 	gopkg.in/ini.v1 v1.66.4 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
 	gopkg.in/urfave/cli.v1 v1.20.0 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 

--- a/examples/tokenvm/scripts/run.sh
+++ b/examples/tokenvm/scripts/run.sh
@@ -98,6 +98,9 @@ if [[ -z "${GENESIS_PATH}" ]]; then
   echo "creating VM genesis file with allocations"
   rm -f /tmp/tokenvm.genesis
   /tmp/token-cli genesis generate /tmp/allocations.json \
+  --max-block-units 4000000 \
+  --window-target-units 100000000000 \
+  --window-target-blocks 30 \
   --genesis-file /tmp/tokenvm.genesis
 else
   echo "copying custom genesis file"
@@ -111,6 +114,7 @@ fi
 
 echo "creating vm config"
 rm -f /tmp/tokenvm.config
+rm -rf /tmp/tokenvm-e2e-profiles
 cat <<EOF > /tmp/tokenvm.config
 {
   "mempoolSize": 10000000,
@@ -119,10 +123,13 @@ cat <<EOF > /tmp/tokenvm.config
   "parallelism": 5,
   "streamingBacklogSize": 10000000,
   "trackedPairs":["*"],
+  "preferredBlocksPerSecond": 3,
+  "continuousProfilerDir":"/tmp/tokenvm-e2e-profiles/*",
   "logLevel": "${LOGLEVEL}",
   "stateSyncServerDelay": ${STATESYNC_DELAY}
 }
 EOF
+mkdir -p /tmp/tokenvm-e2e-profiles
 
 ############################
 
@@ -132,7 +139,7 @@ echo "creating subnet config"
 rm -f /tmp/tokenvm.subnet
 cat <<EOF > /tmp/tokenvm.subnet
 {
-  "proposerMinBlockDelay":100000000
+  "proposerMinBlockDelay": 100000000
 }
 EOF
 

--- a/examples/tokenvm/tests/e2e/e2e_test.go
+++ b/examples/tokenvm/tests/e2e/e2e_test.go
@@ -179,6 +179,8 @@ var _ = ginkgo.BeforeSuite(func() {
 		ctx,
 		execPath,
 		runner_sdk.WithPluginDir(pluginDir),
+		// We don't diable PUT gossip here because the E2E test adds multiple
+		// non-validating nodes (which will fall behind).
 		runner_sdk.WithGlobalNodeConfig(`{
 				"log-display-level":"info",
 				"proposervm-use-current-height":true,
@@ -280,18 +282,26 @@ var _ = ginkgo.BeforeSuite(func() {
 
 	instancesA = []instance{}
 	for _, nodeName := range subnetA {
-		u := fmt.Sprintf("%s/ext/bc/%s", nodeInfos[nodeName].Uri, blockchainIDA)
+		info := nodeInfos[nodeName]
+		u := fmt.Sprintf("%s/ext/bc/%s", info.Uri, blockchainIDA)
+		nodeID, err := ids.NodeIDFromString(info.GetId())
+		gomega.Expect(err).Should(gomega.BeNil())
 		instancesA = append(instancesA, instance{
-			uri: u,
-			cli: client.New(u),
+			nodeID: nodeID,
+			uri:    u,
+			cli:    client.New(u),
 		})
 	}
 	instancesB = []instance{}
 	for _, nodeName := range subnetB {
-		u := fmt.Sprintf("%s/ext/bc/%s", nodeInfos[nodeName].Uri, blockchainIDB)
+		info := nodeInfos[nodeName]
+		u := fmt.Sprintf("%s/ext/bc/%s", info.Uri, blockchainIDB)
+		nodeID, err := ids.NodeIDFromString(info.GetId())
+		gomega.Expect(err).Should(gomega.BeNil())
 		instancesB = append(instancesB, instance{
-			uri: u,
-			cli: client.New(u),
+			nodeID: nodeID,
+			uri:    u,
+			cli:    client.New(u),
 		})
 	}
 
@@ -321,8 +331,9 @@ var (
 )
 
 type instance struct {
-	uri string
-	cli *client.Client
+	nodeID ids.NodeID
+	uri    string
+	cli    *client.Client
 }
 
 var _ = ginkgo.AfterSuite(func() {
@@ -338,11 +349,11 @@ var _ = ginkgo.AfterSuite(func() {
 		hutils.Outf("{{yellow}}skipping cluster shutdown{{/}}\n\n")
 		hutils.Outf("{{cyan}}Blockchain:{{/}} %s\n", blockchainIDA)
 		for _, member := range instancesA {
-			hutils.Outf("URI: %s\n", member.uri)
+			hutils.Outf("%s URI: %s\n", member.nodeID, member.uri)
 		}
 		hutils.Outf("\n{{cyan}}Blockchain:{{/}} %s\n", blockchainIDB)
 		for _, member := range instancesB {
-			hutils.Outf("URI: %s\n", member.uri)
+			hutils.Outf("%s URI: %s\n", member.nodeID, member.uri)
 		}
 	}
 	gomega.Expect(anrCli.Close()).Should(gomega.BeNil())

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -9,8 +9,11 @@ import (
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/trace"
+	"github.com/ava-labs/avalanchego/utils/math"
 	"github.com/ava-labs/avalanchego/utils/set"
 )
+
+const maxPrealloc = 4_096
 
 type Mempool[T Item] struct {
 	tracer trace.Tracer
@@ -46,11 +49,11 @@ func New[T Item](
 		maxPayerSize: maxPayerSize,
 
 		pm: NewSortedMempool(
-			maxSize, /* pre-allocate total size */
+			math.Min(maxSize, maxPrealloc),
 			func(item T) uint64 { return item.UnitPrice() },
 		),
 		tm: NewSortedMempool(
-			maxSize, /* pre-allocate total size */
+			math.Min(maxSize, maxPrealloc),
 			func(item T) uint64 { return uint64(item.Expiry()) },
 		),
 		owned:        map[string]set.Set[ids.ID]{},

--- a/vm/dependencies.go
+++ b/vm/dependencies.go
@@ -28,6 +28,7 @@ type Config interface {
 	GetMempoolSize() int
 	GetMempoolPayerSize() int
 	GetMempoolExemptPayers() [][]byte
+	GetMempoolVerifyBalances() bool
 	GetDecisionsPort() uint16
 	GetBlocksPort() uint16
 	GetStreamingBacklogSize() int

--- a/vm/dependencies.go
+++ b/vm/dependencies.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/snow/engine/common"
 	atrace "github.com/ava-labs/avalanchego/trace"
+	"github.com/ava-labs/avalanchego/utils/profiler"
 
 	"github.com/ava-labs/hypersdk/builder"
 	"github.com/ava-labs/hypersdk/chain"
@@ -37,6 +38,7 @@ type Config interface {
 	GetStateSyncMinBlocks() uint64
 	GetStateSyncServerDelay() time.Duration
 	GetBlockLRUSize() int
+	GetContinuousProfilerConfig() *profiler.Config
 }
 
 type Genesis interface {

--- a/vm/metrics.go
+++ b/vm/metrics.go
@@ -4,7 +4,6 @@
 package vm
 
 import (
-	ametrics "github.com/ava-labs/avalanchego/api/metrics"
 	"github.com/ava-labs/avalanchego/utils/wrappers"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -19,7 +18,7 @@ type Metrics struct {
 	blocksRPCConnections    prometheus.Gauge
 }
 
-func newMetrics(gatherer ametrics.MultiGatherer) (*Metrics, error) {
+func newMetrics() (*prometheus.Registry, *Metrics, error) {
 	m := &Metrics{
 		unitsVerified: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: "chain",
@@ -67,7 +66,6 @@ func newMetrics(gatherer ametrics.MultiGatherer) (*Metrics, error) {
 		r.Register(m.txsAccepted),
 		r.Register(m.decisionsRPCConnections),
 		r.Register(m.blocksRPCConnections),
-		gatherer.Register("hyper_sdk", r),
 	)
-	return m, errs.Err
+	return r, m, errs.Err
 }

--- a/vm/metrics.go
+++ b/vm/metrics.go
@@ -4,6 +4,7 @@
 package vm
 
 import (
+	"github.com/ava-labs/avalanchego/utils/metric"
 	"github.com/ava-labs/avalanchego/utils/wrappers"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -16,9 +17,32 @@ type Metrics struct {
 	txsAccepted             prometheus.Counter
 	decisionsRPCConnections prometheus.Gauge
 	blocksRPCConnections    prometheus.Gauge
+	rootCalculated          metric.Averager
+	waitSignatures          metric.Averager
 }
 
 func newMetrics() (*prometheus.Registry, *Metrics, error) {
+	r := prometheus.NewRegistry()
+
+	rootCalculated, err := metric.NewAverager(
+		"chain",
+		"root_calculated",
+		"time spent calculating the state root in verify",
+		r,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	waitSignatures, err := metric.NewAverager(
+		"chain",
+		"wait_signatures",
+		"time spent waiting for signature verification in verify",
+		r,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	m := &Metrics{
 		unitsVerified: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: "chain",
@@ -55,8 +79,9 @@ func newMetrics() (*prometheus.Registry, *Metrics, error) {
 			Name:      "blocks_rpc_connections",
 			Help:      "number of open blocks connections",
 		}),
+		rootCalculated: rootCalculated,
+		waitSignatures: waitSignatures,
 	}
-	r := prometheus.NewRegistry()
 	errs := wrappers.Errs{}
 	errs.Add(
 		r.Register(m.unitsVerified),

--- a/vm/proposer_monitor.go
+++ b/vm/proposer_monitor.go
@@ -78,7 +78,7 @@ func (p *ProposerMonitor) refresh(ctx context.Context) error {
 		pks[string(bls.PublicKeyToBytes(v.PublicKey))] = struct{}{}
 	}
 	p.validatorPublicKeys = pks
-	p.vm.snowCtx.Log.Info(
+	p.vm.snowCtx.Log.Debug(
 		"refreshed proposer monitor",
 		zap.Uint64("previous", p.currentPHeight),
 		zap.Uint64("new", pHeight),

--- a/vm/resolutions.go
+++ b/vm/resolutions.go
@@ -321,3 +321,11 @@ func (vm *VM) StateSyncEnabled(ctx context.Context) (bool, error) {
 func (vm *VM) StateManager() chain.StateManager {
 	return vm.c.StateManager()
 }
+
+func (vm *VM) RecordRootCalculated(t time.Duration) {
+	vm.metrics.rootCalculated.Observe(float64(t))
+}
+
+func (vm *VM) RecordWaitSignatures(t time.Duration) {
+	vm.metrics.waitSignatures.Observe(float64(t))
+}

--- a/vm/streaming.go
+++ b/vm/streaming.go
@@ -142,7 +142,7 @@ func (c *decisionRPCConnection) handleReads() {
 		p := codec.NewReader(msgBytes, chain.NetworkSizeLimit) // will likely be much smaller
 		tx, err := chain.UnmarshalTx(p, c.vm.actionRegistry, c.vm.authRegistry)
 		if err != nil {
-			c.vm.snowCtx.Log.Error("failed to unmarshal tx",
+			c.vm.snowCtx.Log.Debug("failed to unmarshal tx",
 				zap.Int("len", len(msgBytes)),
 				zap.Error(err),
 			)
@@ -151,7 +151,7 @@ func (c *decisionRPCConnection) handleReads() {
 
 		sigVerify := tx.AuthAsyncVerify()
 		if err := sigVerify(); err != nil {
-			c.vm.snowCtx.Log.Error("failed to verify sig",
+			c.vm.snowCtx.Log.Debug("failed to verify sig",
 				zap.Error(err),
 			)
 			return
@@ -161,7 +161,7 @@ func (c *decisionRPCConnection) handleReads() {
 		// Submit will remove from [txWaiters] if it is not added
 		txID := tx.ID()
 		if err := c.vm.Submit(ctx, false, []*chain.Transaction{tx})[0]; err != nil {
-			c.vm.snowCtx.Log.Error("failed to submit tx",
+			c.vm.snowCtx.Log.Debug("failed to submit tx",
 				zap.Stringer("txID", txID),
 				zap.Error(err),
 			)

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -185,7 +185,7 @@ func (vm *VM) Initialize(
 	// Setup profiler
 	if cfg := vm.config.GetContinuousProfilerConfig(); cfg.Enabled {
 		vm.profiler = profiler.NewContinuous(cfg.Dir, cfg.Freq, cfg.MaxNumFiles)
-		go vm.profiler.Dispatch()
+		go vm.profiler.Dispatch() //nolint:errcheck
 	}
 
 	// Instantiate DBs

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -54,11 +54,10 @@ func TestBlockCache(t *testing.T) {
 
 	// Init metrics (called in [Accepted])
 	gatherer := ametrics.NewMultiGatherer()
-	m, err := newMetrics(gatherer)
-	if err != nil {
-		t.Fatal(err)
-	}
+	reg, m, err := newMetrics()
+	require.NoError(err)
 	vm.metrics = m
+	require.NoError(gatherer.Register("hyper_sdk", reg))
 	require.NoError(vm.snowCtx.Metrics.Register(gatherer))
 
 	// put the block into the cache "vm.blocks"


### PR DESCRIPTION
<img width="1172" alt="Screenshot 2023-03-15 at 12 04 18 AM" src="https://user-images.githubusercontent.com/6799218/225065307-e7b39df4-37e8-41b2-b52f-9b8e6796d01a.png">

<img width="1311" alt="Screenshot 2023-03-15 at 12 04 33 AM" src="https://user-images.githubusercontent.com/6799218/225065438-db772082-0fc3-4f13-be05-004c26a6642c.png">

## TODO
- [x] disable `consensus-on-accept-gossip-peer-size`
- [x] mempool metrics
- [x] merkledb commit metrics
- [x] verify right after build?
- [x] document `--instance-types` flag
- [x] try disabling network compression
- [x] limit default parallelism to cores - min required avalanchego (to avoid choking main execution loop)
- [x] only re-gossip transaction if originally submitted to node (discard all received txs after next block build -> originally sender will likely forward to producer again)
- [x] add metric for time waiting for root gen #133 
- [x] add metric for time waiting for signatures #133 
- [ ] #132  (how much faster is not verifying balances -> should be massive contention reduction with merkledb?)
  - [x] #134 