### PR TITLE
AvalancheGo@v1.9.12-rc.5 (`x/merkledb` locking improvements)

### DIFF
--- a/chain/block.go
+++ b/chain/block.go
@@ -714,7 +714,7 @@ func (b *StatelessBlock) childState(
 		if err != nil {
 			return nil, err
 		}
-		return state.NewPreallocatedView(ctx, estimatedChanges)
+		return state.NewPreallocatedView(estimatedChanges)
 	}
 
 	// Process block if not yet processed and not yet accepted.
@@ -727,7 +727,7 @@ func (b *StatelessBlock) childState(
 		}
 		b.state = state
 	}
-	return b.state.NewPreallocatedView(ctx, estimatedChanges)
+	return b.state.NewPreallocatedView(estimatedChanges)
 }
 
 func (b *StatelessBlock) IsRepeat(

--- a/examples/tokenvm/go.mod
+++ b/examples/tokenvm/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/ava-labs/avalanche-network-runner v1.3.10-0.20230315100749-fc888ba0646f
-	github.com/ava-labs/avalanchego v1.9.11
+	github.com/ava-labs/avalanchego v1.9.12-rc.5
 	github.com/ava-labs/hypersdk v0.0.1
 	github.com/fatih/color v1.13.0
 	github.com/manifoldco/promptui v0.9.0

--- a/examples/tokenvm/go.sum
+++ b/examples/tokenvm/go.sum
@@ -67,8 +67,8 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/ava-labs/avalanche-network-runner v1.3.10-0.20230315100749-fc888ba0646f h1:3vgRD7mCdrtupG3n/Rn0j2bAlU2xG1zM4Ej4Ue785+c=
 github.com/ava-labs/avalanche-network-runner v1.3.10-0.20230315100749-fc888ba0646f/go.mod h1:/mKIh+RWwE3jN9xkRu0gw8oL0e+c0XtBxEe88OhJqMc=
-github.com/ava-labs/avalanchego v1.9.11 h1:5hXHJMvErfaolWD7Hw9gZaVylck2shBaV/2NTHA0BfA=
-github.com/ava-labs/avalanchego v1.9.11/go.mod h1:nNc+4JCIJMaEt2xRmeMVAUyQwDIap7RvnMrfWD2Tpo8=
+github.com/ava-labs/avalanchego v1.9.12-rc.5 h1:Ffd/H5wmIcSLWjsjENIUHSDSIOxztwTwbw1e61hkPT8=
+github.com/ava-labs/avalanchego v1.9.12-rc.5/go.mod h1:nNc+4JCIJMaEt2xRmeMVAUyQwDIap7RvnMrfWD2Tpo8=
 github.com/ava-labs/coreth v0.11.8-rc.3 h1:pS+OTFPc9edcFuCJIQGn5TdyAZncT9Hhs9jCcmm7+PM=
 github.com/ava-labs/coreth v0.11.8-rc.3/go.mod h1:pc44yvJD4jTPIwkPI64pUXyJDvQ/UAqkbmhXOx78PXA=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=

--- a/examples/tokenvm/scripts/run.sh
+++ b/examples/tokenvm/scripts/run.sh
@@ -17,7 +17,7 @@ if ! [[ "$0" =~ scripts/run.sh ]]; then
   exit 255
 fi
 
-VERSION=1.9.11
+VERSION=1.9.12-rc.5
 MODE=${MODE:-run}
 LOGLEVEL=${LOGLEVEL:-info}
 STATESYNC_DELAY=${STATESYNC_DELAY:-0}

--- a/examples/tokenvm/tests/integration/integration_test.go
+++ b/examples/tokenvm/tests/integration/integration_test.go
@@ -986,7 +986,7 @@ var _ = ginkgo.Describe("[Tx Processing]", func() {
 		result := results[0]
 		gomega.Ω(result.Success).Should(gomega.BeFalse())
 		gomega.Ω(string(result.Output)).
-			Should(gomega.ContainSubstring("overflow occurred"))
+			Should(gomega.ContainSubstring("overflow"))
 
 		balance, err := instances[0].cli.Balance(context.TODO(), sender2, asset1ID)
 		gomega.Ω(err).Should(gomega.BeNil())

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ava-labs/hypersdk
 go 1.20
 
 require (
-	github.com/ava-labs/avalanchego v1.9.11
+	github.com/ava-labs/avalanchego v1.9.12-rc.5
 	github.com/cockroachdb/pebble v0.0.0-20230224221607-fccb83b60d5c
 	github.com/golang/mock v1.6.0
 	github.com/gorilla/rpc v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -52,8 +52,8 @@ github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/ava-labs/avalanchego v1.9.11 h1:5hXHJMvErfaolWD7Hw9gZaVylck2shBaV/2NTHA0BfA=
-github.com/ava-labs/avalanchego v1.9.11/go.mod h1:nNc+4JCIJMaEt2xRmeMVAUyQwDIap7RvnMrfWD2Tpo8=
+github.com/ava-labs/avalanchego v1.9.12-rc.5 h1:Ffd/H5wmIcSLWjsjENIUHSDSIOxztwTwbw1e61hkPT8=
+github.com/ava-labs/avalanchego v1.9.12-rc.5/go.mod h1:nNc+4JCIJMaEt2xRmeMVAUyQwDIap7RvnMrfWD2Tpo8=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -182,10 +182,10 @@ func (vm *VM) Initialize(
 
 	// Instantiate DBs
 	vm.stateDB, err = merkledb.New(ctx, vm.rawStateDB, merkledb.Config{
-		HistoryLength:  vm.config.GetStateHistoryLength(),
-		NodeCacheSize:  vm.config.GetStateCacheSize(),
-		ValueCacheSize: vm.config.GetStateCacheSize(),
-		Tracer:         vm.tracer,
+		HistoryLength: vm.config.GetStateHistoryLength(),
+		NodeCacheSize: vm.config.GetStateCacheSize(),
+		// TODO: add metrics
+		Tracer: vm.tracer,
 	})
 	if err != nil {
 		return err
@@ -238,7 +238,7 @@ func (vm *VM) Initialize(
 		snowCtx.Log.Info("initialized vm from last accepted", zap.Stringer("block", blkID))
 	} else {
 		// Set Balances
-		view, err := vm.stateDB.NewView(ctx)
+		view, err := vm.stateDB.NewView()
 		if err != nil {
 			return err
 		}

--- a/workers/workers_test.go
+++ b/workers/workers_test.go
@@ -147,33 +147,8 @@ func TestJobWait(t *testing.T) {
 	go func() {
 		job.result <- testError
 	}()
-	time.Sleep(10 * time.Millisecond)
 	returned := job.Wait()
 	require.ErrorIs(testError, returned, "Incorrect error returned.")
-}
-
-func TestJobDone(t *testing.T) {
-	require := require.New(t)
-	job := Job{
-		tasks:     make(chan func() error),
-		completed: make(chan struct{}),
-		result:    make(chan error),
-	}
-	var callMU sync.Mutex
-	called := false
-	job.Done(func() {
-		callMU.Lock()
-		defer callMU.Unlock()
-		called = true
-	})
-	job.completed <- struct{}{}
-	// Check that the callback function was called
-	callMU.Lock()
-	require.True(called, "Callback function not called")
-	callMU.Unlock()
-
-	// Ensure task channel was closed
-	require.Empty(job.tasks, "Tasks channel not closed")
 }
 
 func TestJobGo(t *testing.T) {


### PR DESCRIPTION
Replaces: #91 

Before (verify ~49079 TPS):
```
[03-20|16:05:09.672] INFO load/load_test.go:318 block generation {"t": "16.074968917s", "avg(ms)": 121, "tps": 31104.259210804918}
[03-20|16:05:09.672] INFO load/load_test.go:335 block verification {"instance": 1, "t": "9ns", "parse(ms/b)": 2.955259106060605, "parse1(ms/b)": 2.872465104477612, "parse2(ms/b)": 2.906456470588235, "verify(ms/b)": 49.35374779545455, "verify1(ms/b)": 47.72139923880595, "verify2(ms/b)": 48.78471999999999, "accept(ms/b)": 22.146842484848488, "accept1(ms/b)": 21.770861268656716, "accept2(ms/b)": 21.540227985294113, "tps": 50874.15990949028, "disk size (MB)": 0.002300262451171875}
[03-20|16:05:09.672] INFO load/load_test.go:335 block verification {"instance": 2, "t": "10ns", "parse(ms/b)": 3.0424772499999992, "parse1(ms/b)": 2.906384343283582, "parse2(ms/b)": 3.0423418529411768, "verify(ms/b)": 53.36583965909091, "verify1(ms/b)": 51.0256921641791, "verify2(ms/b)": 53.31719794117647, "accept(ms/b)": 23.260120560606065, "accept1(ms/b)": 22.438404238805973, "accept2(ms/b)": 23.04357102941177, "tps": 47545.53883800672, "disk size (MB)": 0.002300262451171875}
[03-20|16:05:09.672] INFO load/load_test.go:335 block verification {"instance": 3, "t": "10ns", "parse(ms/b)": 3.0584766590909087, "parse1(ms/b)": 2.8101492537313435, "parse2(ms/b)": 3.1682193970588224, "verify(ms/b)": 51.15229447727274, "verify1(ms/b)": 44.796388686567155, "verify2(ms/b)": 55.158012191176454, "accept(ms/b)": 22.88556217424242, "accept1(ms/b)": 21.884113179104478, "accept2(ms/b)": 22.862626823529414, "tps": 49131.76314907434, "disk size (MB)": 0.002300262451171875}
[03-20|16:05:09.673] INFO load/load_test.go:335 block verification {"instance": 4, "t": "10ns", "parse(ms/b)": 2.991739530303031, "parse1(ms/b)": 2.8698625074626873, "parse2(ms/b)": 2.9798357352941176, "verify(ms/b)": 51.815356393939396, "verify1(ms/b)": 44.65642664179105, "verify2(ms/b)": 56.58303616176469, "accept(ms/b)": 22.866864318181822, "accept1(ms/b)": 21.293153686567166, "accept2(ms/b)": 23.408599897058817, "tps": 48766.39192924672, "disk size (MB)": 0.002300262451171875}
```

After (verify ~57619 TPS):
```
[03-20|16:02:12.294] INFO load/load_test.go:318 block generation {"t": "15.638354417s", "avg(ms)": 118, "tps": 31972.673509462387}
[03-20|16:02:12.294] INFO load/load_test.go:335 block verification {"instance": 1, "t": "8ns", "parse(ms/b)": 2.912440886363637, "parse1(ms/b)": 2.9266821343283578, "parse2(ms/b)": 2.769919029411764, "verify(ms/b)": 43.63127998484849, "verify1(ms/b)": 43.58496514925373, "verify2(ms/b)": 41.752004308823516, "accept(ms/b)": 18.820694151515163, "accept1(ms/b)": 19.02345529850747, "accept2(ms/b)": 17.790590044117643, "tps": 57950.16732822802, "disk size (MB)": 0.002300262451171875}
[03-20|16:02:12.295] INFO load/load_test.go:335 block verification {"instance": 2, "t": "8ns", "parse(ms/b)": 3.1096067121212116, "parse1(ms/b)": 3.10656714925373, "parse2(ms/b)": 2.9754130441176465, "verify(ms/b)": 43.75952587878785, "verify1(ms/b)": 41.50550123880596, "verify2(ms/b)": 44.049835779411744, "accept(ms/b)": 19.524738931818177, "accept1(ms/b)": 18.922647402985074, "accept2(ms/b)": 19.256590632352946, "tps": 57051.63294449793, "disk size (MB)": 0.002300262451171875}
[03-20|16:02:12.295] INFO load/load_test.go:335 block verification {"instance": 3, "t": "8ns", "parse(ms/b)": 2.8610381893939394, "parse1(ms/b)": 2.6197755373134326, "parse2(ms/b)": 2.972530588235294, "verify(ms/b)": 43.07594381060607, "verify1(ms/b)": 38.484745597014935, "verify2(ms/b)": 45.69921511764706, "accept(ms/b)": 19.13324016666666, "accept1(ms/b)": 18.015503671641785, "accept2(ms/b)": 19.390425823529416, "tps": 58212.16928039311, "disk size (MB)": 0.002300262451171875}
[03-20|16:02:12.295] INFO load/load_test.go:335 block verification {"instance": 4, "t": "8ns", "parse(ms/b)": 2.937590643939393, "parse1(ms/b)": 2.7580491791044777, "parse2(ms/b)": 2.9848922058823524, "verify(ms/b)": 43.59862750000002, "verify1(ms/b)": 40.78226926865673, "verify2(ms/b)": 44.45009983823529, "accept(ms/b)": 19.611900560606056, "accept1(ms/b)": 19.02531843283582, "accept2(ms/b)": 19.32462557352941, "tps": 57263.59059125438, "disk size (MB)": 0.002300262451171875}
```