### PR TITLE
Add `osxcross` to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ dist/
 tmp-storage-testing
 .token-cli*
 *.html
+osxcross/


### PR DESCRIPTION
<img width="612" alt="image" src="https://user-images.githubusercontent.com/13023275/228334548-7ae38f28-e95b-475a-a8b3-64c955b3e484.png">

https://github.com/ava-labs/hypersdk/actions/runs/4546318585/jobs/8014930771

We must ignore `osxcross/` to build tagged releases for some reason.