### PR TITLE
Avoid `tstate` copy + distinguish between empty/non-existent values

### DIFF
--- a/chain/block.go
+++ b/chain/block.go
@@ -526,7 +526,7 @@ func (b *StatelessBlock) innerVerify(ctx context.Context) (merkledb.TrieView, er
 	if err != nil {
 		return nil, err
 	}
-	newState, err := parent.childState(ctx, 2048)
+	newState, err := parent.childState(ctx, len(b.Txs)*2)
 	if err != nil {
 		return nil, err
 	}

--- a/chain/builder.go
+++ b/chain/builder.go
@@ -71,12 +71,12 @@ func BuildBlock(
 		log.Warn("block building failed: couldn't get parent db", zap.Error(err))
 		return nil, err
 	}
-	newState, err := parent.childState(ctx, 2048)
+	newState, err := parent.childState(ctx, r.GetMaxBlockTxs())
 	if err != nil {
 		log.Warn("block building failed: couldn't get parent db", zap.Error(err))
 		return nil, err
 	}
-	ts := tstate.New(newState, 2048)
+	ts := tstate.New(newState, r.GetMaxBlockTxs())
 
 	// Restorable txs after block attempt finishes
 	b.Txs = []*Transaction{}

--- a/chain/processor.go
+++ b/chain/processor.go
@@ -83,7 +83,7 @@ func (p *Processor) Execute(
 	var (
 		unitsConsumed = uint64(0)
 		surplusFee    = uint64(0)
-		ts            = tstate.New(newState, 2048) // TODO: tune this heuristic
+		ts            = tstate.New(newState, len(p.blk.Txs)*2) // TODO: tune this heuristic
 		t             = p.blk.GetTimestamp()
 		blkUnitPrice  = p.blk.GetUnitPrice()
 		results       = []*Result{}

--- a/tstate/tstate.go
+++ b/tstate/tstate.go
@@ -9,29 +9,25 @@ import (
 	"errors"
 
 	"github.com/ava-labs/avalanchego/database"
-	"github.com/ava-labs/avalanchego/trace"
-	"go.opentelemetry.io/otel/attribute"
-	oteltrace "go.opentelemetry.io/otel/trace"
+	"github.com/ava-labs/avalanchego/utils/set"
 )
 
 type opAction int
 
 const (
-	read opAction = iota
-	insert
+	insert opAction = iota
 	remove
 )
 
 type op struct {
 	action opAction
-	k      []byte
-	v      []byte
-	pastV  *tempStorage
-}
 
-type tempStorage struct {
-	v      []byte
-	fromDB bool
+	k []byte
+	v []byte
+
+	pastExists  bool
+	pastV       []byte
+	pastChanged bool
 }
 
 type cacheItem struct {
@@ -41,18 +37,16 @@ type cacheItem struct {
 
 // TState defines a struct for storing temporary state.
 type TState struct {
-	// We use pointers here because tempStorage objects may be added/removed from
-	// ops frequently. It is more efficient to avoid reallocating state each time
-	// this happens.
-	storage     map[string]*tempStorage
-	changedKeys map[string]bool // Stores if key in [storage] was ever changed.
+	state       Database
+	changedKeys set.Set[string] // Stores if key in [storage] was ever changed.
 
 	fetchCache map[string]*cacheItem // in case we evict and want to re-fetch
 
 	// We don't differentiate between read and write scope because it is very
 	// uncommon for a user to write something without first reading what is
 	// there.
-	scope [][]byte // Stores a list of managed keys in the TState struct.
+	scope   [][]byte // Stores a list of managed keys in the TState struct.
+	storage map[string][]byte
 
 	// Ops is a record of all operations performed on [TState]. Tracking
 	// operations allows for reverting state to a certain point-in-time.
@@ -61,10 +55,10 @@ type TState struct {
 
 // New returns a new instance of TState. Initializes the storage and changedKeys
 // maps to have an initial size of [storageSize] and [changedSize] respectively.
-func New(storageSize int, changedSize int) *TState {
+func New(state Database, changedSize int) *TState {
 	return &TState{
-		storage:     make(map[string]*tempStorage, storageSize),
-		changedKeys: make(map[string]bool, changedSize),
+		state:       state,
+		changedKeys: set.NewSet[string](changedSize),
 
 		fetchCache: map[string]*cacheItem{},
 
@@ -79,26 +73,35 @@ func (ts *TState) GetValue(ctx context.Context, key []byte) ([]byte, error) {
 	if !ts.checkScope(ctx, key) {
 		return nil, ErrKeyNotSpecified
 	}
-	v, ok := ts.storage[string(key)]
-	if ok {
-		return v.v, nil
+	return ts.getValue(ctx, key)
+}
+
+func (ts *TState) getValue(ctx context.Context, key []byte) ([]byte, error) {
+	k := string(key)
+	if !ts.changedKeys.Contains(k) {
+		v, ok := ts.storage[k]
+		if ok {
+			return v, nil
+		}
+		return nil, database.ErrNotFound
 	}
-	return nil, database.ErrNotFound
+	return ts.state.GetValue(ctx, key)
 }
 
 // FetchAndSetScope updates ts to include the [db] values associated with [keys].
 // FetchAndSetScope then sets the scope of ts to [keys]. If a key exists in
 // ts.fetchCache set the key's value to the value from cache.
-func (ts *TState) FetchAndSetScope(ctx context.Context, db Database, keys [][]byte) error {
+func (ts *TState) FetchAndSetScope(ctx context.Context, keys [][]byte, parentState Database) error {
+	ts.storage = map[string][]byte{}
 	for _, key := range keys {
 		k := string(key)
 		if val, ok := ts.fetchCache[k]; ok {
 			if val.Exists {
-				ts.SetStorage(ctx, key, val.Value)
+				ts.storage[k] = val.Value
 			}
 			continue
 		}
-		v, err := db.GetValue(ctx, key)
+		v, err := parentState.GetValue(ctx, key)
 		if errors.Is(err, database.ErrNotFound) {
 			ts.fetchCache[k] = &cacheItem{Exists: false}
 			continue
@@ -107,37 +110,15 @@ func (ts *TState) FetchAndSetScope(ctx context.Context, db Database, keys [][]by
 			return err
 		}
 		ts.fetchCache[k] = &cacheItem{Value: v, Exists: true}
-		ts.SetStorage(ctx, key, v)
+		ts.storage[k] = v
 	}
-	ts.SetScope(ctx, keys)
+	ts.scope = keys
 	return nil
 }
 
-// SetStorage sets ts.storage[key] = {value, true}. Does not add to storage if
-// ts already stores a mapping with key, or that key was previously modified.
-func (ts *TState) SetStorage(_ context.Context, key []byte, value []byte) {
-	k := string(key)
-	if _, ok := ts.storage[k]; ok {
-		// Don't double store info (2 txs could've reference)
-		return
-	}
-	if _, ok := ts.changedKeys[k]; ok {
-		// Don't overwrite if previously modified (tx could've deleted value
-		// previously)
-		return
-	}
-
-	// Populate rollback (note, we only care if an item was placed in storage
-	// initially)
-	ts.ops = append(ts.ops, &op{
-		action: read,
-		k:      key,
-	})
-	ts.storage[k] = &tempStorage{value, true}
-}
-
 // SetReadScope sets the readscope of ts to [keys].
-func (ts *TState) SetScope(_ context.Context, keys [][]byte) {
+func (ts *TState) SetScope(_ context.Context, keys [][]byte, storage map[string][]byte) {
+	ts.storage = storage
 	ts.scope = keys
 }
 
@@ -157,38 +138,47 @@ func (ts *TState) Insert(ctx context.Context, key []byte, value []byte) error {
 	if !ts.checkScope(ctx, key) {
 		return ErrKeyNotSpecified
 	}
+	past, err := ts.getValue(ctx, key)
+	if err != nil && !errors.Is(err, database.ErrNotFound) {
+		return err
+	}
 	k := string(key)
-
-	// Populate rollback
 	ts.ops = append(ts.ops, &op{
 		action: insert,
-		k:      key,
-		v:      value,
-		pastV:  ts.storage[k],
-	})
 
-	ts.storage[k] = &tempStorage{value, false}
-	ts.changedKeys[k] = true
-	return nil
+		k: key,
+		v: value,
+
+		pastExists:  err == nil,
+		pastV:       past,
+		pastChanged: ts.changedKeys.Contains(k),
+	})
+	delete(ts.storage, k)
+	ts.changedKeys.Add(k)
+	return ts.state.Insert(ctx, key, value)
 }
 
-// Renove deletes a key-value pair from ts.storage.
 func (ts *TState) Remove(ctx context.Context, key []byte) error {
 	if !ts.checkScope(ctx, key) {
 		return ErrKeyNotSpecified
 	}
+	past, err := ts.getValue(ctx, key)
+	if err != nil && !errors.Is(err, database.ErrNotFound) {
+		return err
+	}
 	k := string(key)
-
-	// Populate rollback
 	ts.ops = append(ts.ops, &op{
 		action: remove,
-		k:      key,
-		pastV:  ts.storage[k],
-	})
 
+		k: key,
+
+		pastExists:  err == nil,
+		pastV:       past,
+		pastChanged: ts.changedKeys.Contains(k),
+	})
 	delete(ts.storage, k)
-	ts.changedKeys[k] = false
-	return nil
+	ts.changedKeys.Add(k)
+	return ts.state.Remove(ctx, key)
 }
 
 // OpIndex returns the number of operations done on ts.
@@ -197,70 +187,48 @@ func (ts *TState) OpIndex() int {
 }
 
 // Rollback restores the TState to before the ts.op[restorePoint] operation.
-func (ts *TState) Rollback(_ context.Context, restorePoint int) {
+func (ts *TState) Rollback(ctx context.Context, restorePoint int) error {
 	for i := len(ts.ops) - 1; i >= restorePoint; i-- {
 		op := ts.ops[i]
 		k := string(op.k)
 		switch op.action {
-		case read:
-			delete(ts.storage, k)
-			delete(ts.changedKeys, k)
 		case insert:
-			if pv := op.pastV; pv != nil {
-				// Key previously inserted
-				if pv.fromDB {
-					delete(ts.changedKeys, k)
+			// Created key during insert
+			if !op.pastExists {
+				ts.changedKeys.Remove(k)
+				if err := ts.state.Remove(ctx, op.k); err != nil {
+					return err
 				}
+				break
+			}
+			// Modified previous key
+			pv := op.pastV
+			if !op.pastChanged {
+				ts.changedKeys.Remove(k)
 				ts.storage[k] = pv
-			} else {
-				// Key inserted for the first time
-				delete(ts.storage, k)
-				delete(ts.changedKeys, k)
+			}
+			if err := ts.state.Insert(ctx, op.k, pv); err != nil {
+				return err
 			}
 		case remove:
-			if pv := op.pastV; pv != nil {
-				// Key previously inserted
-				if pv.fromDB {
-					delete(ts.changedKeys, k)
-				}
+			// Deleted non-existent key
+			if !op.pastExists {
+				ts.changedKeys.Remove(k)
+				break
+			}
+			// Deleted key that existed
+			pv := op.pastV
+			if !op.pastChanged {
+				ts.changedKeys.Remove(k)
 				ts.storage[k] = pv
-			} else {
-				// Key deleted for the first time
-				delete(ts.changedKeys, k)
+			}
+			if err := ts.state.Insert(ctx, op.k, pv); err != nil {
+				return err
 			}
 		default:
 			panic("invalid op")
 		}
 	}
 	ts.ops = ts.ops[:restorePoint]
-}
-
-// WriteChanges updates [db] to reflect changes in ts. Insert to [db] if
-// key was added, or remove key if otherwise.
-func (ts *TState) WriteChanges(
-	ctx context.Context,
-	db Database,
-	t trace.Tracer, //nolint:interfacer
-) error {
-	ctx, span := t.Start(
-		ctx, "TState.WriteChanges",
-		oteltrace.WithAttributes(
-			attribute.Int("items", len(ts.changedKeys)),
-		),
-	)
-	defer span.End()
-
-	for key, added := range ts.changedKeys {
-		if added {
-			v := ts.storage[key]
-			if err := db.Insert(ctx, []byte(key), v.v); err != nil {
-				return err
-			}
-		} else {
-			if err := db.Remove(ctx, []byte(key)); err != nil {
-				return err
-			}
-		}
-	}
 	return nil
 }

--- a/tstate/tstate_test.go
+++ b/tstate/tstate_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/ava-labs/avalanchego/database"
-	"github.com/ava-labs/hypersdk/trace"
 
 	"github.com/stretchr/testify/require"
 )
@@ -41,81 +40,41 @@ func (db *TestDB) Insert(_ context.Context, key []byte, value []byte) error {
 }
 
 func (db *TestDB) Remove(_ context.Context, key []byte) error {
-	if _, ok := db.storage[string(key)]; !ok {
-		return database.ErrNotFound
-	}
 	delete(db.storage, string(key))
 	return nil
 }
 
-func TestSetStorage(t *testing.T) {
+func TestSetGetValue(t *testing.T) {
 	require := require.New(t)
 	ctx := context.TODO()
+	tdb := NewTestDB()
+	ts := New(tdb, 10)
 
-	ts := New(10, 10)
-	// Adds key/value
-	ts.SetStorage(ctx, TestKey, TestVal)
-	require.Equal(1, ts.OpIndex(), "Operation not added.")
-	// require.False(ts.storage[string(TestKey)].fromDB, "Value not from a DB.")
-	require.Equal(TestVal, ts.storage[string(TestKey)].v, "Value was not saved correctly.")
-}
+	// Sets scope
+	ts.SetScope(ctx, [][]byte{TestKey}, map[string][]byte{string(TestKey): TestVal})
+	v, err := ts.GetValue(ctx, []byte("other"))
+	require.ErrorIs(err, ErrKeyNotSpecified)
+	require.Nil(v)
 
-func TestSetStorageKeyExists(t *testing.T) {
-	require := require.New(t)
-	ctx := context.TODO()
-	ts := New(10, 10)
 	// Adds key/value
-	ts.SetStorage(ctx, TestKey, TestVal)
-	require.Equal(1, ts.OpIndex(), "Operation not added.")
-	require.Equal(TestVal, ts.storage[string(TestKey)].v, "Value was not saved correctly.")
-	// Set a value with a different key.
-	ts.SetStorage(ctx, TestKey, []byte("DifferentValue"))
-	require.Equal(1, ts.OpIndex(), "Read operation was not added.")
-	require.Equal(TestVal, ts.storage[string(TestKey)].v, "Value was not saved correctly.")
-}
-
-func TestSetStorageKeyModified(t *testing.T) {
-	require := require.New(t)
-	ctx := context.TODO()
-	ts := New(10, 10)
-	// Adds key/value
-	ts.SetScope(ctx, [][]byte{TestKey})
-	ts.SetStorage(ctx, TestKey, TestVal)
-	// ChangedKey = true
 	difVal := []byte("difVal")
-	err := ts.Insert(ctx, TestKey, difVal)
-	require.NoError(err, "Error during insert.")
+	require.NoError(ts.Insert(ctx, TestKey, difVal), "error during insert")
 
-	require.Equal(2, ts.OpIndex(), "Operation not added.")
-	// Otherval should not be saved
-	ts.SetStorage(ctx, TestKey, []byte("OtherValue"))
-	require.Equal(difVal, ts.storage[string(TestKey)].v, "Value was not saved correctly.")
-}
-
-func TestGetValue(t *testing.T) {
-	require := require.New(t)
-	ctx := context.TODO()
-	ts := New(10, 10)
-	// Adds key/value
-	ts.SetStorage(ctx, TestKey, TestVal)
-	require.Equal(1, ts.OpIndex(), "Operation not added.")
-	require.Equal(TestVal, ts.storage[string(TestKey)].v, "Value was not saved correctly.")
-	_, err := ts.GetValue(ctx, TestKey)
-	// GetValue without Scope perm
-	require.ErrorIs(err, ErrKeyNotSpecified, "No error thrown.")
-	// SetScope
-	ts.SetScope(ctx, [][]byte{TestKey})
-	val, err := ts.GetValue(ctx, TestKey)
-	require.NoError(err, "Error getting value.")
-	require.Equal(TestVal, val, "Value was not saved correctly.")
+	// Ensure value added to database
+	require.Equal(1, ts.OpIndex(), "operation not added")
+	v, err = tdb.GetValue(ctx, TestKey)
+	require.NoError(err)
+	require.Equal(difVal, v)
+	require.Nil(ts.storage[string(TestKey)], "original value was not deleted from storage")
 }
 
 func TestGetValueNoStorage(t *testing.T) {
 	require := require.New(t)
 	ctx := context.TODO()
-	ts := New(10, 10)
+	ts := New(nil, 10) // db should not be needed
+
 	// SetScope but dont add to storage
-	ts.SetScope(ctx, [][]byte{TestKey})
+	ts.SetScope(ctx, [][]byte{TestKey}, map[string][]byte{})
 	_, err := ts.GetValue(ctx, TestKey)
 	require.ErrorIs(database.ErrNotFound, err, "No error thrown.")
 }
@@ -123,12 +82,16 @@ func TestGetValueNoStorage(t *testing.T) {
 func TestInsertNew(t *testing.T) {
 	require := require.New(t)
 	ctx := context.TODO()
-	ts := New(10, 10)
+	tdb := NewTestDB()
+	ts := New(tdb, 10)
+
 	// Insert before SetScope
 	err := ts.Insert(ctx, TestKey, TestVal)
 	require.ErrorIs(ErrKeyNotSpecified, err, "No error thrown.")
+
 	// SetScope
-	ts.SetScope(ctx, [][]byte{TestKey})
+	ts.SetScope(ctx, [][]byte{TestKey}, map[string][]byte{})
+
 	// Insert key
 	err = ts.Insert(ctx, TestKey, TestVal)
 	require.NoError(err, "Error thrown.")
@@ -141,37 +104,43 @@ func TestInsertNew(t *testing.T) {
 func TestInsertUpdate(t *testing.T) {
 	require := require.New(t)
 	ctx := context.TODO()
-	ts := New(10, 10)
+	tdb := NewTestDB()
+	ts := New(tdb, 10)
+
 	// SetScope and add
-	ts.SetScope(ctx, [][]byte{TestKey})
-	ts.SetStorage(ctx, TestKey, TestVal)
-	require.Equal(1, ts.OpIndex(), "SetStorage operation was not added.")
+	ts.SetScope(ctx, [][]byte{TestKey}, map[string][]byte{string(TestKey): TestVal})
+	require.Equal(0, ts.OpIndex(), "SetStorage operation was not added.")
+
 	// Insert key
 	newVal := []byte("newVal")
 	err := ts.Insert(ctx, TestKey, newVal)
 	require.NoError(err, "Error thrown.")
 	val, err := ts.GetValue(ctx, TestKey)
 	require.NoError(err, "Error thrown.")
-	require.Equal(2, ts.OpIndex(), "Insert operation was not added.")
+	require.Equal(1, ts.OpIndex(), "Insert operation was not added.")
 	require.Equal(newVal, val, "Value was not set correctly.")
-	require.Equal(TestVal, ts.ops[1].pastV.v, "PastVal was not set correctly.")
+	require.Equal(TestVal, ts.ops[0].pastV, "PastVal was not set correctly.")
 }
 
 func TestFetchAndSetScope(t *testing.T) {
 	require := require.New(t)
-	ts := New(10, 10)
-	db := NewTestDB()
+	tdb := NewTestDB()
+	ts := New(tdb, 10)
+
+	// Add keys to parent
+	pdb := NewTestDB()
 	ctx := context.TODO()
 	keys := [][]byte{[]byte("key1"), []byte("key2"), []byte("key3")}
 	vals := [][]byte{[]byte("val1"), []byte("val2"), []byte("val3")}
 	for i, key := range keys {
-		err := db.Insert(ctx, key, vals[i])
+		err := pdb.Insert(ctx, key, vals[i])
 		require.NoError(err, "Error during insert.")
 	}
-	err := ts.FetchAndSetScope(ctx, db, keys)
+	err := ts.FetchAndSetScope(ctx, keys, pdb)
 	require.NoError(err, "Error thrown.")
-	require.Equal(len(keys), ts.OpIndex(), "Opertions not updated correctly.")
+	require.Equal(0, ts.OpIndex(), "Opertions not updated correctly.")
 	require.Equal(keys, ts.scope, "Scope not updated correctly.")
+
 	// Check values
 	for i, key := range keys {
 		val, err := ts.GetValue(ctx, key)
@@ -182,19 +151,21 @@ func TestFetchAndSetScope(t *testing.T) {
 
 func TestFetchAndSetScopeMissingKey(t *testing.T) {
 	require := require.New(t)
-	ts := New(10, 10)
-	db := NewTestDB()
+	tdb := NewTestDB()
+	ts := New(tdb, 10)
+
+	pdb := NewTestDB()
 	ctx := context.TODO()
 	keys := [][]byte{[]byte("key1"), []byte("key2"), []byte("key3")}
 	vals := [][]byte{[]byte("val1"), []byte("val2"), []byte("val3")}
 	// Keys[3] not in db
 	for i, key := range keys[:len(keys)-1] {
-		err := db.Insert(ctx, key, vals[i])
+		err := pdb.Insert(ctx, key, vals[i])
 		require.NoError(err, "Error during insert.")
 	}
-	err := ts.FetchAndSetScope(ctx, db, keys)
+	err := ts.FetchAndSetScope(ctx, keys, pdb)
 	require.NoError(err, "Error thrown.")
-	require.Equal(len(keys)-1, ts.OpIndex(), "Opertions not updated correctly.")
+	require.Equal(0, ts.OpIndex(), "Opertions not updated correctly.")
 	require.Equal(keys, ts.scope, "Scope not updated correctly.")
 	// Check values
 	for i, key := range keys[:len(keys)-1] {
@@ -206,85 +177,62 @@ func TestFetchAndSetScopeMissingKey(t *testing.T) {
 	require.ErrorIs(err, database.ErrNotFound, "Didn't throw correct erro.")
 }
 
-func TestSetScope(t *testing.T) {
-	require := require.New(t)
-	ts := New(10, 10)
-	ctx := context.TODO()
-	keys := [][]byte{[]byte("key1"), []byte("key2"), []byte("key3")}
-	ts.SetScope(ctx, keys)
-	require.Equal(keys, ts.scope, "Scope not updated correctly.")
-}
-
 func TestRemove(t *testing.T) {
 	require := require.New(t)
-	ts := New(10, 10)
+	tdb := NewTestDB()
+	ts := New(tdb, 10)
 	ctx := context.TODO()
-	ts.SetScope(ctx, [][]byte{TestKey})
+
 	// Insert
+	ts.SetScope(ctx, [][]byte{TestKey}, map[string][]byte{})
 	err := ts.Insert(ctx, TestKey, TestVal)
 	require.NoError(err, "Error from insert.")
 	require.Equal(1, ts.OpIndex(), "Opertions not updated correctly.")
+
 	// Remove
 	err = ts.Remove(ctx, TestKey)
 	require.NoError(err, "Error from remove.")
 	_, ok := ts.storage[string(TestKey)]
 	require.False(ok, "Key not deleted from storage.")
 	require.Equal(2, ts.OpIndex(), "Opertions not updated correctly.")
-	require.Equal(TestVal, ts.ops[1].pastV.v, "Past value not set correctly.")
+	require.Equal(TestVal, ts.ops[1].pastV, "Past value not set correctly.")
 	require.Equal(remove, ts.ops[1].action, "Action not set correctly.")
 	require.Equal(TestKey, ts.ops[1].k, "Action not set correctly.")
 }
 
 func TestRemoveNotInScope(t *testing.T) {
 	require := require.New(t)
-	ts := New(10, 10)
+	tdb := NewTestDB()
+	ts := New(tdb, 10)
 	ctx := context.TODO()
+
 	// Remove
 	err := ts.Remove(ctx, TestKey)
 	require.ErrorIs(err, ErrKeyNotSpecified, "ErrKeyNotSpecified should be thrown.")
 }
 
 func TestRemoveNotInStorage(t *testing.T) {
-	require := require.New(t)
-	ts := New(10, 10)
 	ctx := context.TODO()
-	ts.SetScope(ctx, [][]byte{TestKey})
+	require := require.New(t)
+	tdb := NewTestDB()
+	ts := New(tdb, 10)
+
 	// Remove a key that is not in storage
+	ts.SetScope(ctx, [][]byte{TestKey}, map[string][]byte{})
 	err := ts.Remove(ctx, TestKey)
 	require.NoError(err, "Error from remove.")
 }
 
-func TestRestoreReads(t *testing.T) {
-	require := require.New(t)
-	ts := New(10, 10)
-	ctx := context.TODO()
-	keys := [][]byte{[]byte("key1"), []byte("key2"), []byte("key3")}
-	vals := [][]byte{[]byte("val1"), []byte("val2"), []byte("val3")}
-	ts.SetScope(ctx, keys)
-	// Keys[3] not in db
-	for i, key := range keys {
-		ts.SetStorage(ctx, key, vals[i])
-	}
-	require.Equal(len(keys), ts.OpIndex(), "Operations not added properly.")
-	// Roll back last two reads
-	ts.Rollback(ctx, 1)
-	require.Equal(1, ts.OpIndex(), "Operations not rolled back properly.")
-	for _, key := range keys[1:] {
-		_, ok := ts.storage[string(key)]
-		require.False(ok, "TState read op not rolled back properly.")
-	}
-	_, ok := ts.storage[string(keys[0])]
-	require.True(ok, "Rollbacked too far.")
-}
-
 func TestRestoreInsert(t *testing.T) {
-	require := require.New(t)
-	ts := New(10, 10)
 	ctx := context.TODO()
+	require := require.New(t)
+	tdb := NewTestDB()
+	ts := New(tdb, 10)
+
+	// Add values
 	keys := [][]byte{[]byte("key1"), []byte("key2"), []byte("key3")}
 	vals := [][]byte{[]byte("val1"), []byte("val2"), []byte("val3")}
-	ts.SetScope(ctx, keys)
-	// Keys[3] not in db
+	ts.SetScope(ctx, keys, map[string][]byte{})
 	for i, key := range keys {
 		err := ts.Insert(ctx, key, vals[i])
 		require.NoError(err, "Error inserting.")
@@ -294,9 +242,11 @@ func TestRestoreInsert(t *testing.T) {
 	require.NoError(err, "Error inserting.")
 	require.Equal(len(keys)+1, ts.OpIndex(), "Operations not added properly.")
 
+	// Check value of first key
 	val, err := ts.GetValue(ctx, keys[0])
 	require.NoError(err, "Error getting value.")
 	require.Equal(updatedVal, val, "Value not updated correctly.")
+
 	// Rollback inserting updatedVal and key[2]
 	ts.Rollback(ctx, 2)
 	require.Equal(2, ts.OpIndex(), "Operations not rolled back properly.")
@@ -312,77 +262,39 @@ func TestRestoreInsert(t *testing.T) {
 
 func TestRestoreDelete(t *testing.T) {
 	require := require.New(t)
-	ts := New(10, 10)
+	tdb := NewTestDB()
+	ts := New(tdb, 10)
 	ctx := context.TODO()
+
+	// Add
 	keys := [][]byte{[]byte("key1"), []byte("key2"), []byte("key3")}
 	vals := [][]byte{[]byte("val1"), []byte("val2"), []byte("val3")}
-	ts.SetScope(ctx, keys)
-	// Add
+	ts.SetScope(ctx, keys, map[string][]byte{
+		string(keys[0]): vals[0],
+		string(keys[1]): vals[1],
+		string(keys[2]): vals[2],
+	})
 	for i, key := range keys {
-		ts.SetStorage(ctx, key, vals[i])
 		val, err := ts.GetValue(ctx, key)
 		require.NoError(err, "Error getting value.")
 		require.Equal(vals[i], val, "Value not set correctly.")
 	}
+
 	// Remove all
 	for _, key := range keys {
 		err := ts.Remove(ctx, key)
 		require.NoError(err, "Error removing from ts.")
-
 		_, err = ts.GetValue(ctx, key)
 		require.ErrorIs(err, database.ErrNotFound, "Value not removed.")
 	}
-	require.Equal(len(keys)*2, ts.OpIndex(), "Operations not added properly.")
+	require.Equal(3, ts.OpIndex(), "Operations not added properly.")
+
 	// Roll back all removes
-	ts.Rollback(ctx, 3)
-	require.Equal(3, ts.OpIndex(), "Operations not rolled back properly.")
+	ts.Rollback(ctx, 0)
+	require.Equal(0, ts.OpIndex(), "Operations not rolled back properly.")
 	for i, key := range keys {
 		val, err := ts.GetValue(ctx, key)
 		require.NoError(err, "Error getting value.")
 		require.Equal(vals[i], val, "Value not reset correctly.")
-	}
-}
-
-func TestWriteChanges(t *testing.T) {
-	require := require.New(t)
-	ts := New(10, 10)
-	db := NewTestDB()
-	ctx := context.TODO()
-	tracer, _ := trace.New(&trace.Config{Enabled: false})
-	keys := [][]byte{[]byte("key1"), []byte("key2"), []byte("key3")}
-	vals := [][]byte{[]byte("val1"), []byte("val2"), []byte("val3")}
-	ts.SetScope(ctx, keys)
-
-	// Add
-	for i, key := range keys {
-		err := ts.Insert(ctx, key, vals[i])
-		require.NoError(err, "Error inserting value.")
-		val, err := ts.GetValue(ctx, key)
-		require.NoError(err, "Error getting value.")
-		require.Equal(vals[i], val, "Value not set correctly.")
-	}
-	err := ts.WriteChanges(ctx, db, tracer)
-	require.NoError(err, "Error writing changes.")
-
-	// Check if db was updated correctly
-	for i, key := range keys {
-		val, _ := db.GetValue(ctx, key)
-		require.Equal(vals[i], val, "Value not updated in db.")
-	}
-	// Remove
-	for _, key := range keys {
-		err := ts.Remove(ctx, key)
-		require.NoError(err, "Error removing from ts.")
-
-		_, err = ts.GetValue(ctx, key)
-		require.ErrorIs(err, database.ErrNotFound, "Key not removed.")
-	}
-
-	err = ts.WriteChanges(ctx, db, tracer)
-	require.NoError(err, "Error writing changes.")
-	// Check if db was updated correctly
-	for _, key := range keys {
-		_, err := db.GetValue(ctx, key)
-		require.ErrorIs(err, database.ErrNotFound, "Value not removed from db.")
 	}
 }


### PR DESCRIPTION
Before:
```
[04-14|16:35:46.445] INFO load/load_test.go:318 block generation {"t": "9.360166417s", "avg(ms)": 70, "tps": 53417.85367105188}
[04-14|16:35:46.445] INFO load/load_test.go:335 block verification {"instance": 1, "t": "8ns", "parse(ms/b)": 4.240934666666665, "parse1(ms/b)": 4.029236970149253, "parse2(ms/b)": 4.262419102941177, "verify(ms/b)": 39.5683263712121, "verify1(ms/b)": 38.22929161194029, "verify2(ms/b)": 39.142007985294114, "accept(ms/b)": 18.10627963636363, "accept1(ms/b)": 17.664332656716418, "accept2(ms/b)": 17.742920941176475, "tps": 61178.15893441096, "disk size (MB)": 0.002300262451171875}
[04-14|16:35:46.445] INFO load/load_test.go:335 block verification {"instance": 2, "t": "8ns", "parse(ms/b)": 4.2713797045454545, "parse1(ms/b)": 3.9824048656716413, "parse2(ms/b)": 4.367661691176473, "verify(ms/b)": 39.2485176590909, "verify1(ms/b)": 39.90108456716419, "verify2(ms/b)": 36.87399507352941, "accept(ms/b)": 18.525795522727268, "accept1(ms/b)": 18.65175256716417, "accept2(ms/b)": 17.584376279411767, "tps": 61049.826533749394, "disk size (MB)": 0.002300262451171875}
[04-14|16:35:46.445] INFO load/load_test.go:335 block verification {"instance": 3, "t": "8ns", "parse(ms/b)": 4.263570984848487, "parse1(ms/b)": 4.075228208955223, "parse2(ms/b)": 4.261045294117647, "verify(ms/b)": 40.78824023484848, "verify1(ms/b)": 40.40833086567164, "verify2(ms/b)": 39.36308151470587, "accept(ms/b)": 18.831947575757585, "accept1(ms/b)": 18.573730761194042, "accept2(ms/b)": 18.255545867647065, "tps": 59293.29863020369, "disk size (MB)": 0.002300262451171875}
[04-14|16:35:46.445] INFO load/load_test.go:335 block verification {"instance": 4, "t": "7ns", "parse(ms/b)": 4.238021204545455, "parse1(ms/b)": 3.979563552238806, "parse2(ms/b)": 4.305706485294118, "verify(ms/b)": 37.490303606060614, "verify1(ms/b)": 36.34277111940299, "verify2(ms/b)": 36.966976632352946, "accept(ms/b)": 18.163811863636365, "accept1(ms/b)": 17.775760582089553, "accept2(ms/b)": 17.744811867647055, "tps": 63245.01008339924, "disk size (MB)": 0.002300262451171875}
```

After (~20% slower):
```
[04-14|16:38:02.753] INFO load/load_test.go:318 block generation {"t": "9.836097125s", "avg(ms)": 74, "tps": 50833.17027534943}
[04-14|16:38:02.753] INFO load/load_test.go:335 block verification {"instance": 1, "t": "10ns", "parse(ms/b)": 4.311548310606062, "parse1(ms/b)": 3.946376268656718, "parse2(ms/b)": 4.481134808823529, "verify(ms/b)": 54.74347165909088, "verify1(ms/b)": 52.74422391044776, "verify2(ms/b)": 54.29816554411765, "accept(ms/b)": 18.416132878787874, "accept1(ms/b)": 17.906733164179098, "accept2(ms/b)": 18.105564970588237, "tps": 48894.05473656729, "disk size (MB)": 0.002300262451171875}
[04-14|16:38:02.753] INFO load/load_test.go:335 block verification {"instance": 2, "t": "10ns", "parse(ms/b)": 4.312231386363635, "parse1(ms/b)": 4.142308492537313, "parse2(ms/b)": 4.289409911764705, "verify(ms/b)": 55.51764552272727, "verify1(ms/b)": 52.93503182089551, "verify2(ms/b)": 55.61297172058825, "accept(ms/b)": 19.180657431818187, "accept1(ms/b)": 18.644698298507468, "accept2(ms/b)": 18.862529338235294, "tps": 47941.43995451436, "disk size (MB)": 0.002300262451171875}
[04-14|16:38:02.753] INFO load/load_test.go:335 block verification {"instance": 3, "t": "10ns", "parse(ms/b)": 4.242467765151517, "parse1(ms/b)": 4.016359999999998, "parse2(ms/b)": 4.278082720588236, "verify(ms/b)": 55.91182675757575, "verify1(ms/b)": 56.90566485074627, "verify2(ms/b)": 52.46590569117648, "accept(ms/b)": 18.96370833333333, "accept1(ms/b)": 19.39340549253731, "accept2(ms/b)": 17.70369605882353, "tps": 47876.31956243988, "disk size (MB)": 0.002300262451171875}
[04-14|16:38:02.753] INFO load/load_test.go:335 block verification {"instance": 4, "t": "10ns", "parse(ms/b)": 4.132102325757576, "parse1(ms/b)": 3.881102089552238, "parse2(ms/b)": 4.1971127500000005, "verify(ms/b)": 57.248463742424256, "verify1(ms/b)": 57.205584014925385, "verify2(ms/b)": 54.76504536764703, "accept(ms/b)": 19.401820378787882, "accept1(ms/b)": 19.838218925373138, "accept2(ms/b)": 18.115876794117646, "tps": 46889.90947754896, "disk size (MB)": 0.002300262451171875}
```
_Current theory is that de-deupping changes before they get to the MerkleDB improves performance_