### PR TITLE
reduce `tstate` map copies + distinguish between empty/non-existent values

### DIFF
--- a/.github/workflows/tokenvm-load-tests.yml
+++ b/.github/workflows/tokenvm-load-tests.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   tests:
     runs-on:
-      labels: ubuntu-latest-16-cores
+      labels: ubuntu-20.04-32
     timeout-minutes: 30
     steps:
       - name: Checkout

--- a/.github/workflows/tokenvm-load-tests.yml
+++ b/.github/workflows/tokenvm-load-tests.yml
@@ -13,7 +13,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        level: [v1, v2, v3. v4]
+        level: [v1, v2, v3, v4]
     runs-on:
       labels: ubuntu-20.04-32
     timeout-minutes: 30

--- a/.github/workflows/tokenvm-load-tests.yml
+++ b/.github/workflows/tokenvm-load-tests.yml
@@ -11,10 +11,10 @@ on:
 
 jobs:
   tests:
-    continue-on-error: true
     strategy:
       matrix:
         level: [v1, v2, v3, v4]
+        experimental: [true] # continue on error
     runs-on:
       labels: ubuntu-20.04-32
     timeout-minutes: 30

--- a/.github/workflows/tokenvm-load-tests.yml
+++ b/.github/workflows/tokenvm-load-tests.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   tests:
+    continue-on-error: true
     strategy:
       matrix:
         level: [v1, v2, v3, v4]

--- a/.github/workflows/tokenvm-load-tests.yml
+++ b/.github/workflows/tokenvm-load-tests.yml
@@ -11,10 +11,10 @@ on:
 
 jobs:
   tests:
+    continue-on-error: true
     strategy:
       matrix:
         level: [v1, v2, v3, v4]
-        experimental: [true] # continue on error
     runs-on:
       labels: ubuntu-20.04-32
     timeout-minutes: 30

--- a/.github/workflows/tokenvm-load-tests.yml
+++ b/.github/workflows/tokenvm-load-tests.yml
@@ -11,6 +11,9 @@ on:
 
 jobs:
   tests:
+    strategy:
+      matrix:
+        level: [v1, v2, v3. v4]
     runs-on:
       labels: ubuntu-20.04-32
     timeout-minutes: 30
@@ -31,7 +34,7 @@ jobs:
       - name: Run load tests
         working-directory: ./examples/tokenvm
         shell: bash
-        run: scripts/tests.load.sh
+        run: GOAMD64=${{ matrix.level }} scripts/tests.load.sh
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/tokenvm-release.yml
+++ b/.github/workflows/tokenvm-release.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   release:
     # We build with 20.04 to maintain max compatibility: https://github.com/golang/go/issues/57328
-    runs-on: ubuntu-20.04-16-cores
+    runs-on: ubuntu-20.04-32
     steps:
       - name: Git checkout
         uses: actions/checkout@v3

--- a/.github/workflows/tokenvm-sync-tests.yml
+++ b/.github/workflows/tokenvm-sync-tests.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   tests:
     runs-on:
-      labels: ubuntu-latest-16-cores
+      labels: ubuntu-20.04-32
     timeout-minutes: 45
     steps:
       - name: Checkout

--- a/.github/workflows/tokenvm-unit-tests.yml
+++ b/.github/workflows/tokenvm-unit-tests.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   tests:
     runs-on:
-      labels: ubuntu-latest-16-cores
+      labels: ubuntu-20.04-32
     timeout-minutes: 30
     steps:
       - name: Checkout

--- a/chain/block.go
+++ b/chain/block.go
@@ -532,11 +532,13 @@ func (b *StatelessBlock) innerVerify(ctx context.Context) (merkledb.TrieView, er
 	processor.Prefetch(ctx, state)
 
 	// Process new transactions
-	unitsConsumed, surplusFee, results, err := processor.Execute(ctx, ectx, r)
+	unitsConsumed, surplusFee, results, stateChanges, stateOps, err := processor.Execute(ctx, ectx, r)
 	if err != nil {
 		log.Error("failed to execute block", zap.Error(err))
 		return nil, err
 	}
+	b.vm.RecordStateChanges(stateChanges)
+	b.vm.RecordStateOperations(stateOps)
 	b.results = results
 	if b.UnitsConsumed != unitsConsumed {
 		return nil, fmt.Errorf(

--- a/chain/builder.go
+++ b/chain/builder.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/ava-labs/avalanchego/ids"
 	smblock "github.com/ava-labs/avalanchego/snow/engine/snowman/block"
+	"github.com/ava-labs/avalanchego/utils/math"
 	"go.opentelemetry.io/otel/attribute"
 	"go.uber.org/zap"
 
@@ -66,12 +67,13 @@ func BuildBlock(
 	}
 	b := NewBlock(ectx, vm, parent, nextTime)
 
-	state, err := parent.childState(ctx, r.GetMaxBlockTxs())
+	changesEstimate := math.Min(vm.Mempool().Len(ctx), r.GetMaxBlockTxs())
+	state, err := parent.childState(ctx, changesEstimate)
 	if err != nil {
 		log.Warn("block building failed: couldn't get parent db", zap.Error(err))
 		return nil, err
 	}
-	ts := tstate.New(r.GetMaxBlockTxs())
+	ts := tstate.New(changesEstimate)
 
 	// Restorable txs after block attempt finishes
 	b.Txs = []*Transaction{}

--- a/chain/builder.go
+++ b/chain/builder.go
@@ -280,6 +280,8 @@ func BuildBlock(
 		zap.Int("mempool size", b.vm.Mempool().Len(ctx)),
 		zap.Duration("mempool lock wait", lockWait),
 		zap.Bool("context", blockContext != nil),
+		zap.Int("state changes", ts.PendingChanges()),
+		zap.Int("state operations", ts.OpIndex()),
 	)
 	return b, nil
 }

--- a/chain/builder.go
+++ b/chain/builder.go
@@ -71,7 +71,7 @@ func BuildBlock(
 		log.Warn("block building failed: couldn't get parent db", zap.Error(err))
 		return nil, err
 	}
-	ts := tstate.New(r.GetMaxBlockTxs(), r.GetMaxBlockTxs())
+	ts := tstate.New(r.GetMaxBlockTxs())
 
 	// Restorable txs after block attempt finishes
 	b.Txs = []*Transaction{}
@@ -155,7 +155,7 @@ func BuildBlock(
 			// TODO: prefetch state of upcoming txs that we will pull (should make much
 			// faster)
 			txStart := ts.OpIndex()
-			if err := ts.FetchAndSetScope(ctx, state, next.StateKeys(sm)); err != nil {
+			if err := ts.FetchAndSetScope(ctx, next.StateKeys(sm), state); err != nil {
 				return false, true, false, err
 			}
 

--- a/chain/dependencies.go
+++ b/chain/dependencies.go
@@ -64,12 +64,13 @@ type VM interface {
 	UpdateSyncTarget(*StatelessBlock) (bool, error)
 	StateReady() bool
 
-	// Record the duration of various operations to populate chain metrics
+	// Collect useful metrics
 	//
-	// If there was a long-lived [Chain] struct, we would store metrics for chain
-	// there.
-	RecordRootCalculated(t time.Duration) // only called in Verify
-	RecordWaitSignatures(t time.Duration) // only called in Verify
+	// TODO: break out into own interface
+	RecordRootCalculated(time.Duration) // only called in Verify
+	RecordWaitSignatures(time.Duration) // only called in Verify
+	RecordStateChanges(int)
+	RecordStateOperations(int)
 }
 
 type Mempool interface {

--- a/tstate/tstate.go
+++ b/tstate/tstate.go
@@ -75,7 +75,7 @@ func (ts *TState) GetValue(ctx context.Context, key []byte) ([]byte, error) {
 	return v, nil
 }
 
-func (ts *TState) getValue(ctx context.Context, key string) ([]byte, bool, bool) {
+func (ts *TState) getValue(_ context.Context, key string) ([]byte, bool, bool) {
 	if v, ok := ts.changedKeys[key]; ok {
 		if v.removed {
 			return nil, true, false
@@ -174,6 +174,10 @@ func (ts *TState) Remove(ctx context.Context, key []byte) error {
 // OpIndex returns the number of operations done on ts.
 func (ts *TState) OpIndex() int {
 	return len(ts.ops)
+}
+
+func (ts *TState) PendingChanges() int {
+	return len(ts.changedKeys)
 }
 
 // Rollback restores the TState to before the ts.op[restorePoint] operation.

--- a/tstate/tstate.go
+++ b/tstate/tstate.go
@@ -185,7 +185,7 @@ func (ts *TState) Rollback(_ context.Context, restorePoint int) {
 		// remove: Removed key that was modified for first time in run
 		if !op.pastChanged {
 			delete(ts.changedKeys, op.k)
-			break
+			continue
 		}
 		// insert: Modified key for the nth time
 		//

--- a/tstate/tstate_test.go
+++ b/tstate/tstate_test.go
@@ -190,6 +190,7 @@ func TestRemoveInsertRollback(t *testing.T) {
 	require.NoError(err)
 	require.Equal(TestVal, v)
 	require.Equal(3, ts.OpIndex(), "Opertions not updated correctly.")
+	require.Equal(1, ts.PendingChanges())
 	// Rollback
 	ts.Rollback(ctx, 2)
 	_, err = ts.GetValue(ctx, TestKey)
@@ -265,10 +266,11 @@ func TestRestoreDelete(t *testing.T) {
 		require.ErrorIs(err, database.ErrNotFound, "Value not removed.")
 	}
 	require.Equal(len(keys), ts.OpIndex(), "Operations not added properly.")
+	require.Equal(3, ts.PendingChanges())
 	// Roll back all removes
 	ts.Rollback(ctx, 0)
 	require.Equal(0, ts.OpIndex(), "Operations not rolled back properly.")
-	require.Equal(0, len(ts.changedKeys))
+	require.Equal(0, ts.PendingChanges())
 	for i, key := range keys {
 		val, err := ts.GetValue(ctx, key)
 		require.NoError(err, "Error getting value.")

--- a/tstate/tstate_test.go
+++ b/tstate/tstate_test.go
@@ -41,70 +41,19 @@ func (db *TestDB) Insert(_ context.Context, key []byte, value []byte) error {
 }
 
 func (db *TestDB) Remove(_ context.Context, key []byte) error {
-	if _, ok := db.storage[string(key)]; !ok {
-		return database.ErrNotFound
-	}
 	delete(db.storage, string(key))
 	return nil
-}
-
-func TestSetStorage(t *testing.T) {
-	require := require.New(t)
-	ctx := context.TODO()
-
-	ts := New(10, 10)
-	// Adds key/value
-	ts.SetStorage(ctx, TestKey, TestVal)
-	require.Equal(1, ts.OpIndex(), "Operation not added.")
-	// require.False(ts.storage[string(TestKey)].fromDB, "Value not from a DB.")
-	require.Equal(TestVal, ts.storage[string(TestKey)].v, "Value was not saved correctly.")
-}
-
-func TestSetStorageKeyExists(t *testing.T) {
-	require := require.New(t)
-	ctx := context.TODO()
-	ts := New(10, 10)
-	// Adds key/value
-	ts.SetStorage(ctx, TestKey, TestVal)
-	require.Equal(1, ts.OpIndex(), "Operation not added.")
-	require.Equal(TestVal, ts.storage[string(TestKey)].v, "Value was not saved correctly.")
-	// Set a value with a different key.
-	ts.SetStorage(ctx, TestKey, []byte("DifferentValue"))
-	require.Equal(1, ts.OpIndex(), "Read operation was not added.")
-	require.Equal(TestVal, ts.storage[string(TestKey)].v, "Value was not saved correctly.")
-}
-
-func TestSetStorageKeyModified(t *testing.T) {
-	require := require.New(t)
-	ctx := context.TODO()
-	ts := New(10, 10)
-	// Adds key/value
-	ts.SetScope(ctx, [][]byte{TestKey})
-	ts.SetStorage(ctx, TestKey, TestVal)
-	// ChangedKey = true
-	difVal := []byte("difVal")
-	err := ts.Insert(ctx, TestKey, difVal)
-	require.NoError(err, "Error during insert.")
-
-	require.Equal(2, ts.OpIndex(), "Operation not added.")
-	// Otherval should not be saved
-	ts.SetStorage(ctx, TestKey, []byte("OtherValue"))
-	require.Equal(difVal, ts.storage[string(TestKey)].v, "Value was not saved correctly.")
 }
 
 func TestGetValue(t *testing.T) {
 	require := require.New(t)
 	ctx := context.TODO()
-	ts := New(10, 10)
-	// Adds key/value
-	ts.SetStorage(ctx, TestKey, TestVal)
-	require.Equal(1, ts.OpIndex(), "Operation not added.")
-	require.Equal(TestVal, ts.storage[string(TestKey)].v, "Value was not saved correctly.")
-	_, err := ts.GetValue(ctx, TestKey)
+	ts := New(10)
 	// GetValue without Scope perm
+	_, err := ts.GetValue(ctx, TestKey)
 	require.ErrorIs(err, ErrKeyNotSpecified, "No error thrown.")
 	// SetScope
-	ts.SetScope(ctx, [][]byte{TestKey})
+	ts.SetScope(ctx, [][]byte{TestKey}, map[string][]byte{string(TestKey): TestVal})
 	val, err := ts.GetValue(ctx, TestKey)
 	require.NoError(err, "Error getting value.")
 	require.Equal(TestVal, val, "Value was not saved correctly.")
@@ -113,9 +62,9 @@ func TestGetValue(t *testing.T) {
 func TestGetValueNoStorage(t *testing.T) {
 	require := require.New(t)
 	ctx := context.TODO()
-	ts := New(10, 10)
+	ts := New(10)
 	// SetScope but dont add to storage
-	ts.SetScope(ctx, [][]byte{TestKey})
+	ts.SetScope(ctx, [][]byte{TestKey}, map[string][]byte{})
 	_, err := ts.GetValue(ctx, TestKey)
 	require.ErrorIs(database.ErrNotFound, err, "No error thrown.")
 }
@@ -123,12 +72,12 @@ func TestGetValueNoStorage(t *testing.T) {
 func TestInsertNew(t *testing.T) {
 	require := require.New(t)
 	ctx := context.TODO()
-	ts := New(10, 10)
+	ts := New(10)
 	// Insert before SetScope
 	err := ts.Insert(ctx, TestKey, TestVal)
 	require.ErrorIs(ErrKeyNotSpecified, err, "No error thrown.")
 	// SetScope
-	ts.SetScope(ctx, [][]byte{TestKey})
+	ts.SetScope(ctx, [][]byte{TestKey}, map[string][]byte{})
 	// Insert key
 	err = ts.Insert(ctx, TestKey, TestVal)
 	require.NoError(err, "Error thrown.")
@@ -141,25 +90,26 @@ func TestInsertNew(t *testing.T) {
 func TestInsertUpdate(t *testing.T) {
 	require := require.New(t)
 	ctx := context.TODO()
-	ts := New(10, 10)
+	ts := New(10)
 	// SetScope and add
-	ts.SetScope(ctx, [][]byte{TestKey})
-	ts.SetStorage(ctx, TestKey, TestVal)
-	require.Equal(1, ts.OpIndex(), "SetStorage operation was not added.")
+	ts.SetScope(ctx, [][]byte{TestKey}, map[string][]byte{string(TestKey): TestVal})
+	require.Equal(0, ts.OpIndex(), "SetStorage operation was not added.")
 	// Insert key
 	newVal := []byte("newVal")
 	err := ts.Insert(ctx, TestKey, newVal)
 	require.NoError(err, "Error thrown.")
 	val, err := ts.GetValue(ctx, TestKey)
 	require.NoError(err, "Error thrown.")
-	require.Equal(2, ts.OpIndex(), "Insert operation was not added.")
+	require.Equal(1, ts.OpIndex(), "Insert operation was not added.")
 	require.Equal(newVal, val, "Value was not set correctly.")
-	require.Equal(TestVal, ts.ops[1].pastV.v, "PastVal was not set correctly.")
+	require.Equal(TestVal, ts.ops[0].pastV, "PastVal was not set correctly.")
+	require.False(ts.ops[0].pastChanged, "PastVal was not set correctly.")
+	require.True(ts.ops[0].pastExists, "PastVal was not set correctly.")
 }
 
 func TestFetchAndSetScope(t *testing.T) {
 	require := require.New(t)
-	ts := New(10, 10)
+	ts := New(10)
 	db := NewTestDB()
 	ctx := context.TODO()
 	keys := [][]byte{[]byte("key1"), []byte("key2"), []byte("key3")}
@@ -168,9 +118,9 @@ func TestFetchAndSetScope(t *testing.T) {
 		err := db.Insert(ctx, key, vals[i])
 		require.NoError(err, "Error during insert.")
 	}
-	err := ts.FetchAndSetScope(ctx, db, keys)
+	err := ts.FetchAndSetScope(ctx, keys, db)
 	require.NoError(err, "Error thrown.")
-	require.Equal(len(keys), ts.OpIndex(), "Opertions not updated correctly.")
+	require.Equal(0, ts.OpIndex(), "Opertions not updated correctly.")
 	require.Equal(keys, ts.scope, "Scope not updated correctly.")
 	// Check values
 	for i, key := range keys {
@@ -182,7 +132,7 @@ func TestFetchAndSetScope(t *testing.T) {
 
 func TestFetchAndSetScopeMissingKey(t *testing.T) {
 	require := require.New(t)
-	ts := New(10, 10)
+	ts := New(10)
 	db := NewTestDB()
 	ctx := context.TODO()
 	keys := [][]byte{[]byte("key1"), []byte("key2"), []byte("key3")}
@@ -192,9 +142,9 @@ func TestFetchAndSetScopeMissingKey(t *testing.T) {
 		err := db.Insert(ctx, key, vals[i])
 		require.NoError(err, "Error during insert.")
 	}
-	err := ts.FetchAndSetScope(ctx, db, keys)
+	err := ts.FetchAndSetScope(ctx, keys, db)
 	require.NoError(err, "Error thrown.")
-	require.Equal(len(keys)-1, ts.OpIndex(), "Opertions not updated correctly.")
+	require.Equal(0, ts.OpIndex(), "Opertions not updated correctly.")
 	require.Equal(keys, ts.scope, "Scope not updated correctly.")
 	// Check values
 	for i, key := range keys[:len(keys)-1] {
@@ -208,83 +158,65 @@ func TestFetchAndSetScopeMissingKey(t *testing.T) {
 
 func TestSetScope(t *testing.T) {
 	require := require.New(t)
-	ts := New(10, 10)
+	ts := New(10)
 	ctx := context.TODO()
 	keys := [][]byte{[]byte("key1"), []byte("key2"), []byte("key3")}
-	ts.SetScope(ctx, keys)
+	ts.SetScope(ctx, keys, map[string][]byte{})
 	require.Equal(keys, ts.scope, "Scope not updated correctly.")
 }
 
-func TestRemove(t *testing.T) {
+func TestRemoveInsertRollback(t *testing.T) {
 	require := require.New(t)
-	ts := New(10, 10)
+	ts := New(10)
 	ctx := context.TODO()
-	ts.SetScope(ctx, [][]byte{TestKey})
+	ts.SetScope(ctx, [][]byte{TestKey}, map[string][]byte{})
 	// Insert
 	err := ts.Insert(ctx, TestKey, TestVal)
 	require.NoError(err, "Error from insert.")
+	v, err := ts.GetValue(ctx, TestKey)
+	require.NoError(err)
+	require.Equal(TestVal, v)
 	require.Equal(1, ts.OpIndex(), "Opertions not updated correctly.")
 	// Remove
 	err = ts.Remove(ctx, TestKey)
 	require.NoError(err, "Error from remove.")
-	_, ok := ts.storage[string(TestKey)]
-	require.False(ok, "Key not deleted from storage.")
+	_, err = ts.GetValue(ctx, TestKey)
+	require.ErrorIs(err, database.ErrNotFound, "Key not deleted from storage.")
 	require.Equal(2, ts.OpIndex(), "Opertions not updated correctly.")
-	require.Equal(TestVal, ts.ops[1].pastV.v, "Past value not set correctly.")
-	require.Equal(remove, ts.ops[1].action, "Action not set correctly.")
-	require.Equal(TestKey, ts.ops[1].k, "Action not set correctly.")
+	// Insert
+	err = ts.Insert(ctx, TestKey, TestVal)
+	require.NoError(err, "Error from insert.")
+	v, err = ts.GetValue(ctx, TestKey)
+	require.NoError(err)
+	require.Equal(TestVal, v)
+	require.Equal(3, ts.OpIndex(), "Opertions not updated correctly.")
+	// Rollback
+	ts.Rollback(ctx, 2)
+	_, err = ts.GetValue(ctx, TestKey)
+	require.ErrorIs(err, database.ErrNotFound, "Key not deleted from storage.")
+	// Rollback
+	ts.Rollback(ctx, 1)
+	v, err = ts.GetValue(ctx, TestKey)
+	require.NoError(err)
+	require.Equal(TestVal, v)
 }
 
 func TestRemoveNotInScope(t *testing.T) {
 	require := require.New(t)
-	ts := New(10, 10)
+	ts := New(10)
 	ctx := context.TODO()
 	// Remove
 	err := ts.Remove(ctx, TestKey)
 	require.ErrorIs(err, ErrKeyNotSpecified, "ErrKeyNotSpecified should be thrown.")
 }
 
-func TestRemoveNotInStorage(t *testing.T) {
-	require := require.New(t)
-	ts := New(10, 10)
-	ctx := context.TODO()
-	ts.SetScope(ctx, [][]byte{TestKey})
-	// Remove a key that is not in storage
-	err := ts.Remove(ctx, TestKey)
-	require.NoError(err, "Error from remove.")
-}
-
-func TestRestoreReads(t *testing.T) {
-	require := require.New(t)
-	ts := New(10, 10)
-	ctx := context.TODO()
-	keys := [][]byte{[]byte("key1"), []byte("key2"), []byte("key3")}
-	vals := [][]byte{[]byte("val1"), []byte("val2"), []byte("val3")}
-	ts.SetScope(ctx, keys)
-	// Keys[3] not in db
-	for i, key := range keys {
-		ts.SetStorage(ctx, key, vals[i])
-	}
-	require.Equal(len(keys), ts.OpIndex(), "Operations not added properly.")
-	// Roll back last two reads
-	ts.Rollback(ctx, 1)
-	require.Equal(1, ts.OpIndex(), "Operations not rolled back properly.")
-	for _, key := range keys[1:] {
-		_, ok := ts.storage[string(key)]
-		require.False(ok, "TState read op not rolled back properly.")
-	}
-	_, ok := ts.storage[string(keys[0])]
-	require.True(ok, "Rollbacked too far.")
-}
-
 func TestRestoreInsert(t *testing.T) {
 	require := require.New(t)
-	ts := New(10, 10)
+	ts := New(10)
 	ctx := context.TODO()
 	keys := [][]byte{[]byte("key1"), []byte("key2"), []byte("key3")}
 	vals := [][]byte{[]byte("val1"), []byte("val2"), []byte("val3")}
-	ts.SetScope(ctx, keys)
-	// Keys[3] not in db
+	ts.SetScope(ctx, keys, map[string][]byte{})
 	for i, key := range keys {
 		err := ts.Insert(ctx, key, vals[i])
 		require.NoError(err, "Error inserting.")
@@ -293,7 +225,6 @@ func TestRestoreInsert(t *testing.T) {
 	err := ts.Insert(ctx, keys[0], updatedVal)
 	require.NoError(err, "Error inserting.")
 	require.Equal(len(keys)+1, ts.OpIndex(), "Operations not added properly.")
-
 	val, err := ts.GetValue(ctx, keys[0])
 	require.NoError(err, "Error getting value.")
 	require.Equal(updatedVal, val, "Value not updated correctly.")
@@ -301,25 +232,27 @@ func TestRestoreInsert(t *testing.T) {
 	ts.Rollback(ctx, 2)
 	require.Equal(2, ts.OpIndex(), "Operations not rolled back properly.")
 	// Keys[2] was removed
-	_, ok := ts.storage[string(keys[2])]
-	require.False(ok, "TState read op not rolled back properly.")
+	_, err = ts.GetValue(ctx, keys[2])
+	require.ErrorIs(err, database.ErrNotFound, "TState read op not rolled back properly.")
 	// Keys[0] was set to past value
 	val, err = ts.GetValue(ctx, keys[0])
-	require.False(ok, "TState read op not rolled back properly.")
 	require.NoError(err, "Error getting value.")
 	require.Equal(vals[0], val, "Value not rolled back properly.")
 }
 
 func TestRestoreDelete(t *testing.T) {
 	require := require.New(t)
-	ts := New(10, 10)
+	ts := New(10)
 	ctx := context.TODO()
 	keys := [][]byte{[]byte("key1"), []byte("key2"), []byte("key3")}
 	vals := [][]byte{[]byte("val1"), []byte("val2"), []byte("val3")}
-	ts.SetScope(ctx, keys)
-	// Add
+	ts.SetScope(ctx, keys, map[string][]byte{
+		string(keys[0]): vals[0],
+		string(keys[1]): vals[1],
+		string(keys[2]): vals[2],
+	})
+	// Check scope
 	for i, key := range keys {
-		ts.SetStorage(ctx, key, vals[i])
 		val, err := ts.GetValue(ctx, key)
 		require.NoError(err, "Error getting value.")
 		require.Equal(vals[i], val, "Value not set correctly.")
@@ -328,14 +261,14 @@ func TestRestoreDelete(t *testing.T) {
 	for _, key := range keys {
 		err := ts.Remove(ctx, key)
 		require.NoError(err, "Error removing from ts.")
-
 		_, err = ts.GetValue(ctx, key)
 		require.ErrorIs(err, database.ErrNotFound, "Value not removed.")
 	}
-	require.Equal(len(keys)*2, ts.OpIndex(), "Operations not added properly.")
+	require.Equal(len(keys), ts.OpIndex(), "Operations not added properly.")
 	// Roll back all removes
-	ts.Rollback(ctx, 3)
-	require.Equal(3, ts.OpIndex(), "Operations not rolled back properly.")
+	ts.Rollback(ctx, 0)
+	require.Equal(0, ts.OpIndex(), "Operations not rolled back properly.")
+	require.Equal(0, len(ts.changedKeys))
 	for i, key := range keys {
 		val, err := ts.GetValue(ctx, key)
 		require.NoError(err, "Error getting value.")
@@ -345,14 +278,13 @@ func TestRestoreDelete(t *testing.T) {
 
 func TestWriteChanges(t *testing.T) {
 	require := require.New(t)
-	ts := New(10, 10)
+	ts := New(10)
 	db := NewTestDB()
 	ctx := context.TODO()
 	tracer, _ := trace.New(&trace.Config{Enabled: false})
 	keys := [][]byte{[]byte("key1"), []byte("key2"), []byte("key3")}
 	vals := [][]byte{[]byte("val1"), []byte("val2"), []byte("val3")}
-	ts.SetScope(ctx, keys)
-
+	ts.SetScope(ctx, keys, map[string][]byte{})
 	// Add
 	for i, key := range keys {
 		err := ts.Insert(ctx, key, vals[i])
@@ -363,7 +295,6 @@ func TestWriteChanges(t *testing.T) {
 	}
 	err := ts.WriteChanges(ctx, db, tracer)
 	require.NoError(err, "Error writing changes.")
-
 	// Check if db was updated correctly
 	for i, key := range keys {
 		val, _ := db.GetValue(ctx, key)
@@ -373,11 +304,9 @@ func TestWriteChanges(t *testing.T) {
 	for _, key := range keys {
 		err := ts.Remove(ctx, key)
 		require.NoError(err, "Error removing from ts.")
-
 		_, err = ts.GetValue(ctx, key)
 		require.ErrorIs(err, database.ErrNotFound, "Key not removed.")
 	}
-
 	err = ts.WriteChanges(ctx, db, tracer)
 	require.NoError(err, "Error writing changes.")
 	// Check if db was updated correctly

--- a/tstate/tstate_test.go
+++ b/tstate/tstate_test.go
@@ -303,6 +303,12 @@ func TestWriteChanges(t *testing.T) {
 		require.Equal(vals[i], val, "Value not updated in db.")
 	}
 	// Remove
+	ts = New(10)
+	ts.SetScope(ctx, keys, map[string][]byte{
+		string(keys[0]): vals[0],
+		string(keys[1]): vals[1],
+		string(keys[2]): vals[2],
+	})
 	for _, key := range keys {
 		err := ts.Remove(ctx, key)
 		require.NoError(err, "Error removing from ts.")

--- a/vm/metrics.go
+++ b/vm/metrics.go
@@ -15,6 +15,8 @@ type Metrics struct {
 	txsSubmitted            prometheus.Counter // includes gossip
 	txsVerified             prometheus.Counter
 	txsAccepted             prometheus.Counter
+	stateChanges            prometheus.Counter
+	stateOperations         prometheus.Counter
 	decisionsRPCConnections prometheus.Gauge
 	blocksRPCConnections    prometheus.Gauge
 	rootCalculated          metric.Averager
@@ -69,6 +71,16 @@ func newMetrics() (*prometheus.Registry, *Metrics, error) {
 			Name:      "txs_accepted",
 			Help:      "number of txs accepted by vm",
 		}),
+		stateChanges: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: "chain",
+			Name:      "state_changes",
+			Help:      "number of state changes",
+		}),
+		stateOperations: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: "chain",
+			Name:      "state_operations",
+			Help:      "number of state operations",
+		}),
 		decisionsRPCConnections: prometheus.NewGauge(prometheus.GaugeOpts{
 			Namespace: "vm",
 			Name:      "decisions_rpc_connections",
@@ -89,6 +101,8 @@ func newMetrics() (*prometheus.Registry, *Metrics, error) {
 		r.Register(m.txsSubmitted),
 		r.Register(m.txsVerified),
 		r.Register(m.txsAccepted),
+		r.Register(m.stateChanges),
+		r.Register(m.stateOperations),
 		r.Register(m.decisionsRPCConnections),
 		r.Register(m.blocksRPCConnections),
 	)

--- a/vm/resolutions.go
+++ b/vm/resolutions.go
@@ -329,3 +329,11 @@ func (vm *VM) RecordRootCalculated(t time.Duration) {
 func (vm *VM) RecordWaitSignatures(t time.Duration) {
 	vm.metrics.waitSignatures.Observe(float64(t))
 }
+
+func (vm *VM) RecordStateChanges(c int) {
+	vm.metrics.stateChanges.Add(float64(c))
+}
+
+func (vm *VM) RecordStateOperations(c int) {
+	vm.metrics.stateOperations.Add(float64(c))
+}


### PR DESCRIPTION
## TODO
- [x] log how many changes are being written to merkledb + how many ops were done (to get a ratio of savings)
- [x] pre-allocate ops capacity to avoid re-sizing during execution 
- [x] save previously generated state key array
- [x] add tests for each `GOAMD64` mode
- [x] improve changes estimate during block construction