### PR TITLE
[tstate] change map[key] from string to fixed size byte array

### DIFF
--- a/tstate/tstate_test.go
+++ b/tstate/tstate_test.go
@@ -9,23 +9,14 @@ import (
 	"testing"
 
 	"github.com/ava-labs/avalanchego/database"
+	"github.com/ava-labs/hypersdk/trace"
 	"github.com/stretchr/testify/require"
 )
 
-// import (
-// 	"context"
-// 	"testing"
-
-// 	"github.com/ava-labs/avalanchego/database"
-// 	"github.com/ava-labs/hypersdk/trace"
-
-// 	"github.com/stretchr/testify/require"
-// )
-
-// var (
-// 	TestKey = []byte("key")
-// 	TestVal = []byte("value")
-// )
+var (
+	TestKey = []byte("key")
+	TestVal = []byte("value")
+)
 
 type TestDB struct {
 	storage map[string][]byte
@@ -55,307 +46,305 @@ func (db *TestDB) Remove(_ context.Context, key []byte) error {
 	return nil
 }
 
-// func TestGetValue(t *testing.T) {
-// 	require := require.New(t)
-// 	ctx := context.TODO()
-// 	ts := New(10)
-// 	// GetValue without Scope perm
-// 	_, err := ts.GetValue(ctx, TestKey)
-// 	require.ErrorIs(err, ErrKeyNotSpecified, "No error thrown.")
-// 	// SetScope
-// 	ts.SetScope(ctx, [][]byte{TestKey}, map[string][]byte{string(TestKey): TestVal})
-// 	val, err := ts.GetValue(ctx, TestKey)
-// 	require.NoError(err, "Error getting value.")
-// 	require.Equal(TestVal, val, "Value was not saved correctly.")
-// }
+func TestGetValue(t *testing.T) {
+	require := require.New(t)
+	ctx := context.TODO()
+	ts := New(10)
+	// GetValue without Scope perm
+	_, err := ts.GetValue(ctx, TestKey)
+	require.ErrorIs(err, ErrKeyNotSpecified, "No error thrown.")
+	// SetScope
+	ts.SetScope(ctx, [][]byte{TestKey}, map[[65]byte][]byte{newFixedSizeByteArray(TestKey): TestVal})
+	val, err := ts.GetValue(ctx, TestKey)
+	require.NoError(err, "Error getting value.")
+	require.Equal(TestVal, val, "Value was not saved correctly.")
+}
 
-// func TestGetValueNoStorage(t *testing.T) {
-// 	require := require.New(t)
-// 	ctx := context.TODO()
-// 	ts := New(10)
-// 	// SetScope but dont add to storage
-// 	ts.SetScope(ctx, [][]byte{TestKey}, map[string][]byte{})
-// 	_, err := ts.GetValue(ctx, TestKey)
-// 	require.ErrorIs(database.ErrNotFound, err, "No error thrown.")
-// }
+func TestGetValueNoStorage(t *testing.T) {
+	require := require.New(t)
+	ctx := context.TODO()
+	ts := New(10)
+	// SetScope but dont add to storage
+	ts.SetScope(ctx, [][]byte{TestKey}, map[[65]byte][]byte{})
+	_, err := ts.GetValue(ctx, TestKey)
+	require.ErrorIs(database.ErrNotFound, err, "No error thrown.")
+}
 
-// func TestInsertNew(t *testing.T) {
-// 	require := require.New(t)
-// 	ctx := context.TODO()
-// 	ts := New(10)
-// 	// Insert before SetScope
-// 	err := ts.Insert(ctx, TestKey, TestVal)
-// 	require.ErrorIs(ErrKeyNotSpecified, err, "No error thrown.")
-// 	// SetScope
-// 	ts.SetScope(ctx, [][]byte{TestKey}, map[string][]byte{})
-// 	// Insert key
-// 	err = ts.Insert(ctx, TestKey, TestVal)
-// 	require.NoError(err, "Error thrown.")
-// 	val, err := ts.GetValue(ctx, TestKey)
-// 	require.NoError(err, "Error thrown.")
-// 	require.Equal(1, ts.OpIndex(), "Insert operation was not added.")
-// 	require.Equal(TestVal, val, "Value was not set correctly.")
-// }
+func TestInsertNew(t *testing.T) {
+	require := require.New(t)
+	ctx := context.TODO()
+	ts := New(10)
+	// Insert before SetScope
+	err := ts.Insert(ctx, TestKey, TestVal)
+	require.ErrorIs(ErrKeyNotSpecified, err, "No error thrown.")
+	// SetScope
+	ts.SetScope(ctx, [][]byte{TestKey}, map[[65]byte][]byte{})
+	// Insert key
+	err = ts.Insert(ctx, TestKey, TestVal)
+	require.NoError(err, "Error thrown.")
+	val, err := ts.GetValue(ctx, TestKey)
+	require.NoError(err, "Error thrown.")
+	require.Equal(1, ts.OpIndex(), "Insert operation was not added.")
+	require.Equal(TestVal, val, "Value was not set correctly.")
+}
 
-// func TestInsertUpdate(t *testing.T) {
-// 	require := require.New(t)
-// 	ctx := context.TODO()
-// 	ts := New(10)
-// 	// SetScope and add
-// 	ts.SetScope(ctx, [][]byte{TestKey}, map[string][]byte{string(TestKey): TestVal})
-// 	require.Equal(0, ts.OpIndex(), "SetStorage operation was not added.")
-// 	// Insert key
-// 	newVal := []byte("newVal")
-// 	err := ts.Insert(ctx, TestKey, newVal)
-// 	require.NoError(err, "Error thrown.")
-// 	val, err := ts.GetValue(ctx, TestKey)
-// 	require.NoError(err, "Error thrown.")
-// 	require.Equal(1, ts.OpIndex(), "Insert operation was not added.")
-// 	require.Equal(newVal, val, "Value was not set correctly.")
-// 	require.Equal(TestVal, ts.ops[0].pastV, "PastVal was not set correctly.")
-// 	require.False(ts.ops[0].pastChanged, "PastVal was not set correctly.")
-// 	require.True(ts.ops[0].pastExists, "PastVal was not set correctly.")
-// }
+func TestInsertUpdate(t *testing.T) {
+	require := require.New(t)
+	ctx := context.TODO()
+	ts := New(10)
+	// SetScope and add
+	ts.SetScope(ctx, [][]byte{TestKey}, map[[65]byte][]byte{newFixedSizeByteArray(TestKey): TestVal})
+	require.Equal(0, ts.OpIndex(), "SetStorage operation was not added.")
+	// Insert key
+	newVal := []byte("newVal")
+	err := ts.Insert(ctx, TestKey, newVal)
+	require.NoError(err, "Error thrown.")
+	val, err := ts.GetValue(ctx, TestKey)
+	require.NoError(err, "Error thrown.")
+	require.Equal(1, ts.OpIndex(), "Insert operation was not added.")
+	require.Equal(newVal, val, "Value was not set correctly.")
+	require.Equal(TestVal, ts.ops[0].pastV, "PastVal was not set correctly.")
+	require.False(ts.ops[0].pastChanged, "PastVal was not set correctly.")
+	require.True(ts.ops[0].pastExists, "PastVal was not set correctly.")
+}
 
-// func TestFetchAndSetScope(t *testing.T) {
-// 	require := require.New(t)
-// 	ts := New(10)
-// 	db := NewTestDB()
-// 	ctx := context.TODO()
-// 	keys := [][]byte{[]byte("key1"), []byte("key2"), []byte("key3")}
-// 	vals := [][]byte{[]byte("val1"), []byte("val2"), []byte("val3")}
-// 	for i, key := range keys {
-// 		err := db.Insert(ctx, key, vals[i])
-// 		require.NoError(err, "Error during insert.")
-// 	}
-// 	err := ts.FetchAndSetScope(ctx, keys, db)
-// 	require.NoError(err, "Error thrown.")
-// 	require.Equal(0, ts.OpIndex(), "Opertions not updated correctly.")
-// 	require.Equal(keys, ts.scope, "Scope not updated correctly.")
-// 	// Check values
-// 	for i, key := range keys {
-// 		val, err := ts.GetValue(ctx, key)
-// 		require.NoError(err, "Error getting value.")
-// 		require.Equal(vals[i], val, "Value not set correctly.")
-// 	}
-// }
+func TestFetchAndSetScope(t *testing.T) {
+	require := require.New(t)
+	ts := New(10)
+	db := NewTestDB()
+	ctx := context.TODO()
+	keys := [][]byte{[]byte("key1"), []byte("key2"), []byte("key3")}
+	vals := [][]byte{[]byte("val1"), []byte("val2"), []byte("val3")}
+	for i, key := range keys {
+		err := db.Insert(ctx, key, vals[i])
+		require.NoError(err, "Error during insert.")
+	}
+	err := ts.FetchAndSetScope(ctx, keys, db)
+	require.NoError(err, "Error thrown.")
+	require.Equal(0, ts.OpIndex(), "Opertions not updated correctly.")
+	require.Equal(keys, ts.scope, "Scope not updated correctly.")
+	// Check values
+	for i, key := range keys {
+		val, err := ts.GetValue(ctx, key)
+		require.NoError(err, "Error getting value.")
+		require.Equal(vals[i], val, "Value not set correctly.")
+	}
+}
 
-// func TestFetchAndSetScopeMissingKey(t *testing.T) {
-// 	require := require.New(t)
-// 	ts := New(10)
-// 	db := NewTestDB()
-// 	ctx := context.TODO()
-// 	keys := [][]byte{[]byte("key1"), []byte("key2"), []byte("key3")}
-// 	vals := [][]byte{[]byte("val1"), []byte("val2"), []byte("val3")}
-// 	// Keys[3] not in db
-// 	for i, key := range keys[:len(keys)-1] {
-// 		err := db.Insert(ctx, key, vals[i])
-// 		require.NoError(err, "Error during insert.")
-// 	}
-// 	err := ts.FetchAndSetScope(ctx, keys, db)
-// 	require.NoError(err, "Error thrown.")
-// 	require.Equal(0, ts.OpIndex(), "Opertions not updated correctly.")
-// 	require.Equal(keys, ts.scope, "Scope not updated correctly.")
-// 	// Check values
-// 	for i, key := range keys[:len(keys)-1] {
-// 		val, err := ts.GetValue(ctx, key)
-// 		require.NoError(err, "Error getting value.")
-// 		require.Equal(vals[i], val, "Value not set correctly.")
-// 	}
-// 	_, err = ts.GetValue(ctx, keys[2])
-// 	require.ErrorIs(err, database.ErrNotFound, "Didn't throw correct erro.")
-// }
+func TestFetchAndSetScopeMissingKey(t *testing.T) {
+	require := require.New(t)
+	ts := New(10)
+	db := NewTestDB()
+	ctx := context.TODO()
+	keys := [][]byte{[]byte("key1"), []byte("key2"), []byte("key3")}
+	vals := [][]byte{[]byte("val1"), []byte("val2"), []byte("val3")}
+	// Keys[3] not in db
+	for i, key := range keys[:len(keys)-1] {
+		err := db.Insert(ctx, key, vals[i])
+		require.NoError(err, "Error during insert.")
+	}
+	err := ts.FetchAndSetScope(ctx, keys, db)
+	require.NoError(err, "Error thrown.")
+	require.Equal(0, ts.OpIndex(), "Opertions not updated correctly.")
+	require.Equal(keys, ts.scope, "Scope not updated correctly.")
+	// Check values
+	for i, key := range keys[:len(keys)-1] {
+		val, err := ts.GetValue(ctx, key)
+		require.NoError(err, "Error getting value.")
+		require.Equal(vals[i], val, "Value not set correctly.")
+	}
+	_, err = ts.GetValue(ctx, keys[2])
+	require.ErrorIs(err, database.ErrNotFound, "Didn't throw correct erro.")
+}
 
-// func TestSetScope(t *testing.T) {
-// 	require := require.New(t)
-// 	ts := New(10)
-// 	ctx := context.TODO()
-// 	keys := [][]byte{[]byte("key1"), []byte("key2"), []byte("key3")}
-// 	ts.SetScope(ctx, keys, map[string][]byte{})
-// 	require.Equal(keys, ts.scope, "Scope not updated correctly.")
-// }
+func TestSetScope(t *testing.T) {
+	require := require.New(t)
+	ts := New(10)
+	ctx := context.TODO()
+	keys := [][]byte{[]byte("key1"), []byte("key2"), []byte("key3")}
+	ts.SetScope(ctx, keys, map[[65]byte][]byte{})
+	require.Equal(keys, ts.scope, "Scope not updated correctly.")
+}
 
-// func TestRemoveInsertRollback(t *testing.T) {
-// 	require := require.New(t)
-// 	ts := New(10)
-// 	ctx := context.TODO()
-// 	ts.SetScope(ctx, [][]byte{TestKey}, map[string][]byte{})
-// 	// Insert
-// 	err := ts.Insert(ctx, TestKey, TestVal)
-// 	require.NoError(err, "Error from insert.")
-// 	v, err := ts.GetValue(ctx, TestKey)
-// 	require.NoError(err)
-// 	require.Equal(TestVal, v)
-// 	require.Equal(1, ts.OpIndex(), "Opertions not updated correctly.")
-// 	// Remove
-// 	err = ts.Remove(ctx, TestKey)
-// 	require.NoError(err, "Error from remove.")
-// 	_, err = ts.GetValue(ctx, TestKey)
-// 	require.ErrorIs(err, database.ErrNotFound, "Key not deleted from storage.")
-// 	require.Equal(2, ts.OpIndex(), "Opertions not updated correctly.")
-// 	// Insert
-// 	err = ts.Insert(ctx, TestKey, TestVal)
-// 	require.NoError(err, "Error from insert.")
-// 	v, err = ts.GetValue(ctx, TestKey)
-// 	require.NoError(err)
-// 	require.Equal(TestVal, v)
-// 	require.Equal(3, ts.OpIndex(), "Opertions not updated correctly.")
-// 	require.Equal(1, ts.PendingChanges())
-// 	// Rollback
-// 	ts.Rollback(ctx, 2)
-// 	_, err = ts.GetValue(ctx, TestKey)
-// 	require.ErrorIs(err, database.ErrNotFound, "Key not deleted from storage.")
-// 	// Rollback
-// 	ts.Rollback(ctx, 1)
-// 	v, err = ts.GetValue(ctx, TestKey)
-// 	require.NoError(err)
-// 	require.Equal(TestVal, v)
-// }
+func TestRemoveInsertRollback(t *testing.T) {
+	require := require.New(t)
+	ts := New(10)
+	ctx := context.TODO()
+	ts.SetScope(ctx, [][]byte{TestKey}, map[[65]byte][]byte{})
+	// Insert
+	err := ts.Insert(ctx, TestKey, TestVal)
+	require.NoError(err, "Error from insert.")
+	v, err := ts.GetValue(ctx, TestKey)
+	require.NoError(err)
+	require.Equal(TestVal, v)
+	require.Equal(1, ts.OpIndex(), "Opertions not updated correctly.")
+	// Remove
+	err = ts.Remove(ctx, TestKey)
+	require.NoError(err, "Error from remove.")
+	_, err = ts.GetValue(ctx, TestKey)
+	require.ErrorIs(err, database.ErrNotFound, "Key not deleted from storage.")
+	require.Equal(2, ts.OpIndex(), "Opertions not updated correctly.")
+	// Insert
+	err = ts.Insert(ctx, TestKey, TestVal)
+	require.NoError(err, "Error from insert.")
+	v, err = ts.GetValue(ctx, TestKey)
+	require.NoError(err)
+	require.Equal(TestVal, v)
+	require.Equal(3, ts.OpIndex(), "Opertions not updated correctly.")
+	require.Equal(1, ts.PendingChanges())
+	// Rollback
+	ts.Rollback(ctx, 2)
+	_, err = ts.GetValue(ctx, TestKey)
+	require.ErrorIs(err, database.ErrNotFound, "Key not deleted from storage.")
+	// Rollback
+	ts.Rollback(ctx, 1)
+	v, err = ts.GetValue(ctx, TestKey)
+	require.NoError(err)
+	require.Equal(TestVal, v)
+}
 
-// func TestRemoveNotInScope(t *testing.T) {
-// 	require := require.New(t)
-// 	ts := New(10)
-// 	ctx := context.TODO()
-// 	// Remove
-// 	err := ts.Remove(ctx, TestKey)
-// 	require.ErrorIs(err, ErrKeyNotSpecified, "ErrKeyNotSpecified should be thrown.")
-// }
+func TestRemoveNotInScope(t *testing.T) {
+	require := require.New(t)
+	ts := New(10)
+	ctx := context.TODO()
+	// Remove
+	err := ts.Remove(ctx, TestKey)
+	require.ErrorIs(err, ErrKeyNotSpecified, "ErrKeyNotSpecified should be thrown.")
+}
 
-// func TestRestoreInsert(t *testing.T) {
-// 	require := require.New(t)
-// 	ts := New(10)
-// 	ctx := context.TODO()
-// 	keys := [][]byte{[]byte("key1"), []byte("key2"), []byte("key3")}
-// 	vals := [][]byte{[]byte("val1"), []byte("val2"), []byte("val3")}
-// 	ts.SetScope(ctx, keys, map[string][]byte{})
-// 	for i, key := range keys {
-// 		err := ts.Insert(ctx, key, vals[i])
-// 		require.NoError(err, "Error inserting.")
-// 	}
-// 	updatedVal := []byte("newVal")
-// 	err := ts.Insert(ctx, keys[0], updatedVal)
-// 	require.NoError(err, "Error inserting.")
-// 	require.Equal(len(keys)+1, ts.OpIndex(), "Operations not added properly.")
-// 	val, err := ts.GetValue(ctx, keys[0])
-// 	require.NoError(err, "Error getting value.")
-// 	require.Equal(updatedVal, val, "Value not updated correctly.")
-// 	// Rollback inserting updatedVal and key[2]
-// 	ts.Rollback(ctx, 2)
-// 	require.Equal(2, ts.OpIndex(), "Operations not rolled back properly.")
-// 	// Keys[2] was removed
-// 	_, err = ts.GetValue(ctx, keys[2])
-// 	require.ErrorIs(err, database.ErrNotFound, "TState read op not rolled back properly.")
-// 	// Keys[0] was set to past value
-// 	val, err = ts.GetValue(ctx, keys[0])
-// 	require.NoError(err, "Error getting value.")
-// 	require.Equal(vals[0], val, "Value not rolled back properly.")
-// }
+func TestRestoreInsert(t *testing.T) {
+	require := require.New(t)
+	ts := New(10)
+	ctx := context.TODO()
+	keys := [][]byte{[]byte("key1"), []byte("key2"), []byte("key3")}
+	vals := [][]byte{[]byte("val1"), []byte("val2"), []byte("val3")}
+	ts.SetScope(ctx, keys, map[[65]byte][]byte{})
+	for i, key := range keys {
+		err := ts.Insert(ctx, key, vals[i])
+		require.NoError(err, "Error inserting.")
+	}
+	updatedVal := []byte("newVal")
+	err := ts.Insert(ctx, keys[0], updatedVal)
+	require.NoError(err, "Error inserting.")
+	require.Equal(len(keys)+1, ts.OpIndex(), "Operations not added properly.")
+	val, err := ts.GetValue(ctx, keys[0])
+	require.NoError(err, "Error getting value.")
+	require.Equal(updatedVal, val, "Value not updated correctly.")
+	// Rollback inserting updatedVal and key[2]
+	ts.Rollback(ctx, 2)
+	require.Equal(2, ts.OpIndex(), "Operations not rolled back properly.")
+	// Keys[2] was removed
+	_, err = ts.GetValue(ctx, keys[2])
+	require.ErrorIs(err, database.ErrNotFound, "TState read op not rolled back properly.")
+	// Keys[0] was set to past value
+	val, err = ts.GetValue(ctx, keys[0])
+	require.NoError(err, "Error getting value.")
+	require.Equal(vals[0], val, "Value not rolled back properly.")
+}
 
-// func TestRestoreDelete(t *testing.T) {
-// 	require := require.New(t)
-// 	ts := New(10)
-// 	ctx := context.TODO()
-// 	keys := [][]byte{[]byte("key1"), []byte("key2"), []byte("key3")}
-// 	vals := [][]byte{[]byte("val1"), []byte("val2"), []byte("val3")}
-// 	ts.SetScope(ctx, keys, map[string][]byte{
-// 		string(keys[0]): vals[0],
-// 		string(keys[1]): vals[1],
-// 		string(keys[2]): vals[2],
-// 	})
-// 	// Check scope
-// 	for i, key := range keys {
-// 		val, err := ts.GetValue(ctx, key)
-// 		require.NoError(err, "Error getting value.")
-// 		require.Equal(vals[i], val, "Value not set correctly.")
-// 	}
-// 	// Remove all
-// 	for _, key := range keys {
-// 		err := ts.Remove(ctx, key)
-// 		require.NoError(err, "Error removing from ts.")
-// 		_, err = ts.GetValue(ctx, key)
-// 		require.ErrorIs(err, database.ErrNotFound, "Value not removed.")
-// 	}
-// 	require.Equal(len(keys), ts.OpIndex(), "Operations not added properly.")
-// 	require.Equal(3, ts.PendingChanges())
-// 	// Roll back all removes
-// 	ts.Rollback(ctx, 0)
-// 	require.Equal(0, ts.OpIndex(), "Operations not rolled back properly.")
-// 	require.Equal(0, ts.PendingChanges())
-// 	for i, key := range keys {
-// 		val, err := ts.GetValue(ctx, key)
-// 		require.NoError(err, "Error getting value.")
-// 		require.Equal(vals[i], val, "Value not reset correctly.")
-// 	}
-// }
+func TestRestoreDelete(t *testing.T) {
+	require := require.New(t)
+	ts := New(10)
+	ctx := context.TODO()
+	keys := [][]byte{[]byte("key1"), []byte("key2"), []byte("key3")}
+	vals := [][]byte{[]byte("val1"), []byte("val2"), []byte("val3")}
+	ts.SetScope(ctx, keys, map[[65]byte][]byte{
+		newFixedSizeByteArray(keys[0]): vals[0],
+		newFixedSizeByteArray(keys[1]): vals[1],
+		newFixedSizeByteArray(keys[2]): vals[2],
+	})
+	// Check scope
+	for i, key := range keys {
+		val, err := ts.GetValue(ctx, key)
+		require.NoError(err, "Error getting value.")
+		require.Equal(vals[i], val, "Value not set correctly.")
+	}
+	// Remove all
+	for _, key := range keys {
+		err := ts.Remove(ctx, key)
+		require.NoError(err, "Error removing from ts.")
+		_, err = ts.GetValue(ctx, key)
+		require.ErrorIs(err, database.ErrNotFound, "Value not removed.")
+	}
+	require.Equal(len(keys), ts.OpIndex(), "Operations not added properly.")
+	require.Equal(3, ts.PendingChanges())
+	// Roll back all removes
+	ts.Rollback(ctx, 0)
+	require.Equal(0, ts.OpIndex(), "Operations not rolled back properly.")
+	require.Equal(0, ts.PendingChanges())
+	for i, key := range keys {
+		val, err := ts.GetValue(ctx, key)
+		require.NoError(err, "Error getting value.")
+		require.Equal(vals[i], val, "Value not reset correctly.")
+	}
+}
 
-// func TestWriteChanges(t *testing.T) {
-// 	require := require.New(t)
-// 	ts := New(10)
-// 	db := NewTestDB()
-// 	ctx := context.TODO()
-// 	tracer, _ := trace.New(&trace.Config{Enabled: false})
-// 	keys := [][]byte{[]byte("key1"), []byte("key2"), []byte("key3")}
-// 	vals := [][]byte{[]byte("val1"), []byte("val2"), []byte("val3")}
-// 	ts.SetScope(ctx, keys, map[string][]byte{})
-// 	// Add
-// 	for i, key := range keys {
-// 		err := ts.Insert(ctx, key, vals[i])
-// 		require.NoError(err, "Error inserting value.")
-// 		val, err := ts.GetValue(ctx, key)
-// 		require.NoError(err, "Error getting value.")
-// 		require.Equal(vals[i], val, "Value not set correctly.")
-// 	}
-// 	err := ts.WriteChanges(ctx, db, tracer)
-// 	require.NoError(err, "Error writing changes.")
-// 	// Check if db was updated correctly
-// 	for i, key := range keys {
-// 		val, _ := db.GetValue(ctx, key)
-// 		require.Equal(vals[i], val, "Value not updated in db.")
-// 	}
-// 	// Remove
-// 	ts = New(10)
-// 	ts.SetScope(ctx, keys, map[string][]byte{
-// 		string(keys[0]): vals[0],
-// 		string(keys[1]): vals[1],
-// 		string(keys[2]): vals[2],
-// 	})
-// 	for _, key := range keys {
-// 		err := ts.Remove(ctx, key)
-// 		require.NoError(err, "Error removing from ts.")
-// 		_, err = ts.GetValue(ctx, key)
-// 		require.ErrorIs(err, database.ErrNotFound, "Key not removed.")
-// 	}
-// 	err = ts.WriteChanges(ctx, db, tracer)
-// 	require.NoError(err, "Error writing changes.")
-// 	// Check if db was updated correctly
-// 	for _, key := range keys {
-// 		_, err := db.GetValue(ctx, key)
-// 		require.ErrorIs(err, database.ErrNotFound, "Value not removed from db.")
-// 	}
-// }
-
+func TestWriteChanges(t *testing.T) {
+	require := require.New(t)
+	ts := New(10)
+	db := NewTestDB()
+	ctx := context.TODO()
+	tracer, _ := trace.New(&trace.Config{Enabled: false})
+	keys := [][]byte{[]byte("key1"), []byte("key2"), []byte("key3")}
+	vals := [][]byte{[]byte("val1"), []byte("val2"), []byte("val3")}
+	ts.SetScope(ctx, keys, map[[65]byte][]byte{})
+	// Add
+	for i, key := range keys {
+		err := ts.Insert(ctx, key, vals[i])
+		require.NoError(err, "Error inserting value.")
+		val, err := ts.GetValue(ctx, key)
+		require.NoError(err, "Error getting value.")
+		require.Equal(vals[i], val, "Value not set correctly.")
+	}
+	err := ts.WriteChanges(ctx, db, tracer)
+	require.NoError(err, "Error writing changes.")
+	// Check if db was updated correctly
+	for i, key := range keys {
+		val, _ := db.GetValue(ctx, key)
+		require.Equal(vals[i], val, "Value not updated in db.")
+	}
+	// Remove
+	ts = New(10)
+	ts.SetScope(ctx, keys, map[[65]byte][]byte{
+		newFixedSizeByteArray(keys[0]): vals[0],
+		newFixedSizeByteArray(keys[1]): vals[1],
+		newFixedSizeByteArray(keys[2]): vals[2],
+	})
+	for _, key := range keys {
+		err := ts.Remove(ctx, key)
+		require.NoError(err, "Error removing from ts.")
+		_, err = ts.GetValue(ctx, key)
+		require.ErrorIs(err, database.ErrNotFound, "Key not removed.")
+	}
+	err = ts.WriteChanges(ctx, db, tracer)
+	require.NoError(err, "Error writing changes.")
+	// Check if db was updated correctly
+	for _, key := range keys {
+		_, err := db.GetValue(ctx, key)
+		require.ErrorIs(err, database.ErrNotFound, "Value not removed from db.")
+	}
+}
 
 func BenchmarkFetchAndSetScope(b *testing.B) {
 	for _, size := range []int{100, 1000, 10000} {
-		b.Run(fmt.Sprintf("get_validator_set_%d_validators", size), func(b *testing.B) {
-			benchmarkGetValidatorSet(b, size)
+		b.Run(fmt.Sprintf("fetch_and_set_scope_%d_keys", size), func(b *testing.B) {
+			benchmarkFetchAndSetScope(b, size)
 		})
 	}
 }
 
-func benchmarkGetValidatorSet(b *testing.B, size int) {
+func benchmarkFetchAndSetScope(b *testing.B, size int) {
 	require := require.New(b)
-	ts := New(1000)
+	ts := New(10)
 	db := NewTestDB()
 	ctx := context.TODO()
 
 	keys := [][]byte{}
 	vals := [][]byte{}
 
-	k := randomBytes(65);
-
+	// each k/v is unique to simulate worst case
 	for range "0..size" {
-		keys = append(keys, k)
+		keys = append(keys, randomBytes(65))
 		vals = append(vals, randomBytes(8))
 	}
 

--- a/tstate/tstate_test.go
+++ b/tstate/tstate_test.go
@@ -336,7 +336,7 @@ func (db *TestDB) Remove(_ context.Context, key []byte) error {
 
 
 func BenchmarkFetchAndSetScope(b *testing.B) {
-	for _, size := range []int{1, 5, 10, 15, 20} {
+	for _, size := range []int{100, 1000, 10000} {
 		b.Run(fmt.Sprintf("get_validator_set_%d_validators", size), func(b *testing.B) {
 			benchmarkGetValidatorSet(b, size)
 		})
@@ -345,14 +345,17 @@ func BenchmarkFetchAndSetScope(b *testing.B) {
 
 func benchmarkGetValidatorSet(b *testing.B, size int) {
 	require := require.New(b)
-	ts := New(10)
+	ts := New(1000)
 	db := NewTestDB()
 	ctx := context.TODO()
 
 	keys := [][]byte{}
 	vals := [][]byte{}
+
+	k := randomBytes(65);
+
 	for range "0..size" {
-		keys = append(keys, randomBytes(65))
+		keys = append(keys, k)
 		vals = append(vals, randomBytes(8))
 	}
 
@@ -366,6 +369,7 @@ func benchmarkGetValidatorSet(b *testing.B, size int) {
 		err := ts.FetchAndSetScope(ctx, keys, db)
 		require.NoError(err)
 	}
+	b.ReportAllocs()
 	b.StopTimer()
 }
 

--- a/tstate/tstate_test.go
+++ b/tstate/tstate_test.go
@@ -4,18 +4,28 @@ package tstate
 
 import (
 	"context"
+	"crypto/rand"
+	"fmt"
 	"testing"
 
 	"github.com/ava-labs/avalanchego/database"
-	"github.com/ava-labs/hypersdk/trace"
-
 	"github.com/stretchr/testify/require"
 )
 
-var (
-	TestKey = []byte("key")
-	TestVal = []byte("value")
-)
+// import (
+// 	"context"
+// 	"testing"
+
+// 	"github.com/ava-labs/avalanchego/database"
+// 	"github.com/ava-labs/hypersdk/trace"
+
+// 	"github.com/stretchr/testify/require"
+// )
+
+// var (
+// 	TestKey = []byte("key")
+// 	TestVal = []byte("value")
+// )
 
 type TestDB struct {
 	storage map[string][]byte
@@ -45,281 +55,322 @@ func (db *TestDB) Remove(_ context.Context, key []byte) error {
 	return nil
 }
 
-func TestGetValue(t *testing.T) {
-	require := require.New(t)
-	ctx := context.TODO()
-	ts := New(10)
-	// GetValue without Scope perm
-	_, err := ts.GetValue(ctx, TestKey)
-	require.ErrorIs(err, ErrKeyNotSpecified, "No error thrown.")
-	// SetScope
-	ts.SetScope(ctx, [][]byte{TestKey}, map[string][]byte{string(TestKey): TestVal})
-	val, err := ts.GetValue(ctx, TestKey)
-	require.NoError(err, "Error getting value.")
-	require.Equal(TestVal, val, "Value was not saved correctly.")
+// func TestGetValue(t *testing.T) {
+// 	require := require.New(t)
+// 	ctx := context.TODO()
+// 	ts := New(10)
+// 	// GetValue without Scope perm
+// 	_, err := ts.GetValue(ctx, TestKey)
+// 	require.ErrorIs(err, ErrKeyNotSpecified, "No error thrown.")
+// 	// SetScope
+// 	ts.SetScope(ctx, [][]byte{TestKey}, map[string][]byte{string(TestKey): TestVal})
+// 	val, err := ts.GetValue(ctx, TestKey)
+// 	require.NoError(err, "Error getting value.")
+// 	require.Equal(TestVal, val, "Value was not saved correctly.")
+// }
+
+// func TestGetValueNoStorage(t *testing.T) {
+// 	require := require.New(t)
+// 	ctx := context.TODO()
+// 	ts := New(10)
+// 	// SetScope but dont add to storage
+// 	ts.SetScope(ctx, [][]byte{TestKey}, map[string][]byte{})
+// 	_, err := ts.GetValue(ctx, TestKey)
+// 	require.ErrorIs(database.ErrNotFound, err, "No error thrown.")
+// }
+
+// func TestInsertNew(t *testing.T) {
+// 	require := require.New(t)
+// 	ctx := context.TODO()
+// 	ts := New(10)
+// 	// Insert before SetScope
+// 	err := ts.Insert(ctx, TestKey, TestVal)
+// 	require.ErrorIs(ErrKeyNotSpecified, err, "No error thrown.")
+// 	// SetScope
+// 	ts.SetScope(ctx, [][]byte{TestKey}, map[string][]byte{})
+// 	// Insert key
+// 	err = ts.Insert(ctx, TestKey, TestVal)
+// 	require.NoError(err, "Error thrown.")
+// 	val, err := ts.GetValue(ctx, TestKey)
+// 	require.NoError(err, "Error thrown.")
+// 	require.Equal(1, ts.OpIndex(), "Insert operation was not added.")
+// 	require.Equal(TestVal, val, "Value was not set correctly.")
+// }
+
+// func TestInsertUpdate(t *testing.T) {
+// 	require := require.New(t)
+// 	ctx := context.TODO()
+// 	ts := New(10)
+// 	// SetScope and add
+// 	ts.SetScope(ctx, [][]byte{TestKey}, map[string][]byte{string(TestKey): TestVal})
+// 	require.Equal(0, ts.OpIndex(), "SetStorage operation was not added.")
+// 	// Insert key
+// 	newVal := []byte("newVal")
+// 	err := ts.Insert(ctx, TestKey, newVal)
+// 	require.NoError(err, "Error thrown.")
+// 	val, err := ts.GetValue(ctx, TestKey)
+// 	require.NoError(err, "Error thrown.")
+// 	require.Equal(1, ts.OpIndex(), "Insert operation was not added.")
+// 	require.Equal(newVal, val, "Value was not set correctly.")
+// 	require.Equal(TestVal, ts.ops[0].pastV, "PastVal was not set correctly.")
+// 	require.False(ts.ops[0].pastChanged, "PastVal was not set correctly.")
+// 	require.True(ts.ops[0].pastExists, "PastVal was not set correctly.")
+// }
+
+// func TestFetchAndSetScope(t *testing.T) {
+// 	require := require.New(t)
+// 	ts := New(10)
+// 	db := NewTestDB()
+// 	ctx := context.TODO()
+// 	keys := [][]byte{[]byte("key1"), []byte("key2"), []byte("key3")}
+// 	vals := [][]byte{[]byte("val1"), []byte("val2"), []byte("val3")}
+// 	for i, key := range keys {
+// 		err := db.Insert(ctx, key, vals[i])
+// 		require.NoError(err, "Error during insert.")
+// 	}
+// 	err := ts.FetchAndSetScope(ctx, keys, db)
+// 	require.NoError(err, "Error thrown.")
+// 	require.Equal(0, ts.OpIndex(), "Opertions not updated correctly.")
+// 	require.Equal(keys, ts.scope, "Scope not updated correctly.")
+// 	// Check values
+// 	for i, key := range keys {
+// 		val, err := ts.GetValue(ctx, key)
+// 		require.NoError(err, "Error getting value.")
+// 		require.Equal(vals[i], val, "Value not set correctly.")
+// 	}
+// }
+
+// func TestFetchAndSetScopeMissingKey(t *testing.T) {
+// 	require := require.New(t)
+// 	ts := New(10)
+// 	db := NewTestDB()
+// 	ctx := context.TODO()
+// 	keys := [][]byte{[]byte("key1"), []byte("key2"), []byte("key3")}
+// 	vals := [][]byte{[]byte("val1"), []byte("val2"), []byte("val3")}
+// 	// Keys[3] not in db
+// 	for i, key := range keys[:len(keys)-1] {
+// 		err := db.Insert(ctx, key, vals[i])
+// 		require.NoError(err, "Error during insert.")
+// 	}
+// 	err := ts.FetchAndSetScope(ctx, keys, db)
+// 	require.NoError(err, "Error thrown.")
+// 	require.Equal(0, ts.OpIndex(), "Opertions not updated correctly.")
+// 	require.Equal(keys, ts.scope, "Scope not updated correctly.")
+// 	// Check values
+// 	for i, key := range keys[:len(keys)-1] {
+// 		val, err := ts.GetValue(ctx, key)
+// 		require.NoError(err, "Error getting value.")
+// 		require.Equal(vals[i], val, "Value not set correctly.")
+// 	}
+// 	_, err = ts.GetValue(ctx, keys[2])
+// 	require.ErrorIs(err, database.ErrNotFound, "Didn't throw correct erro.")
+// }
+
+// func TestSetScope(t *testing.T) {
+// 	require := require.New(t)
+// 	ts := New(10)
+// 	ctx := context.TODO()
+// 	keys := [][]byte{[]byte("key1"), []byte("key2"), []byte("key3")}
+// 	ts.SetScope(ctx, keys, map[string][]byte{})
+// 	require.Equal(keys, ts.scope, "Scope not updated correctly.")
+// }
+
+// func TestRemoveInsertRollback(t *testing.T) {
+// 	require := require.New(t)
+// 	ts := New(10)
+// 	ctx := context.TODO()
+// 	ts.SetScope(ctx, [][]byte{TestKey}, map[string][]byte{})
+// 	// Insert
+// 	err := ts.Insert(ctx, TestKey, TestVal)
+// 	require.NoError(err, "Error from insert.")
+// 	v, err := ts.GetValue(ctx, TestKey)
+// 	require.NoError(err)
+// 	require.Equal(TestVal, v)
+// 	require.Equal(1, ts.OpIndex(), "Opertions not updated correctly.")
+// 	// Remove
+// 	err = ts.Remove(ctx, TestKey)
+// 	require.NoError(err, "Error from remove.")
+// 	_, err = ts.GetValue(ctx, TestKey)
+// 	require.ErrorIs(err, database.ErrNotFound, "Key not deleted from storage.")
+// 	require.Equal(2, ts.OpIndex(), "Opertions not updated correctly.")
+// 	// Insert
+// 	err = ts.Insert(ctx, TestKey, TestVal)
+// 	require.NoError(err, "Error from insert.")
+// 	v, err = ts.GetValue(ctx, TestKey)
+// 	require.NoError(err)
+// 	require.Equal(TestVal, v)
+// 	require.Equal(3, ts.OpIndex(), "Opertions not updated correctly.")
+// 	require.Equal(1, ts.PendingChanges())
+// 	// Rollback
+// 	ts.Rollback(ctx, 2)
+// 	_, err = ts.GetValue(ctx, TestKey)
+// 	require.ErrorIs(err, database.ErrNotFound, "Key not deleted from storage.")
+// 	// Rollback
+// 	ts.Rollback(ctx, 1)
+// 	v, err = ts.GetValue(ctx, TestKey)
+// 	require.NoError(err)
+// 	require.Equal(TestVal, v)
+// }
+
+// func TestRemoveNotInScope(t *testing.T) {
+// 	require := require.New(t)
+// 	ts := New(10)
+// 	ctx := context.TODO()
+// 	// Remove
+// 	err := ts.Remove(ctx, TestKey)
+// 	require.ErrorIs(err, ErrKeyNotSpecified, "ErrKeyNotSpecified should be thrown.")
+// }
+
+// func TestRestoreInsert(t *testing.T) {
+// 	require := require.New(t)
+// 	ts := New(10)
+// 	ctx := context.TODO()
+// 	keys := [][]byte{[]byte("key1"), []byte("key2"), []byte("key3")}
+// 	vals := [][]byte{[]byte("val1"), []byte("val2"), []byte("val3")}
+// 	ts.SetScope(ctx, keys, map[string][]byte{})
+// 	for i, key := range keys {
+// 		err := ts.Insert(ctx, key, vals[i])
+// 		require.NoError(err, "Error inserting.")
+// 	}
+// 	updatedVal := []byte("newVal")
+// 	err := ts.Insert(ctx, keys[0], updatedVal)
+// 	require.NoError(err, "Error inserting.")
+// 	require.Equal(len(keys)+1, ts.OpIndex(), "Operations not added properly.")
+// 	val, err := ts.GetValue(ctx, keys[0])
+// 	require.NoError(err, "Error getting value.")
+// 	require.Equal(updatedVal, val, "Value not updated correctly.")
+// 	// Rollback inserting updatedVal and key[2]
+// 	ts.Rollback(ctx, 2)
+// 	require.Equal(2, ts.OpIndex(), "Operations not rolled back properly.")
+// 	// Keys[2] was removed
+// 	_, err = ts.GetValue(ctx, keys[2])
+// 	require.ErrorIs(err, database.ErrNotFound, "TState read op not rolled back properly.")
+// 	// Keys[0] was set to past value
+// 	val, err = ts.GetValue(ctx, keys[0])
+// 	require.NoError(err, "Error getting value.")
+// 	require.Equal(vals[0], val, "Value not rolled back properly.")
+// }
+
+// func TestRestoreDelete(t *testing.T) {
+// 	require := require.New(t)
+// 	ts := New(10)
+// 	ctx := context.TODO()
+// 	keys := [][]byte{[]byte("key1"), []byte("key2"), []byte("key3")}
+// 	vals := [][]byte{[]byte("val1"), []byte("val2"), []byte("val3")}
+// 	ts.SetScope(ctx, keys, map[string][]byte{
+// 		string(keys[0]): vals[0],
+// 		string(keys[1]): vals[1],
+// 		string(keys[2]): vals[2],
+// 	})
+// 	// Check scope
+// 	for i, key := range keys {
+// 		val, err := ts.GetValue(ctx, key)
+// 		require.NoError(err, "Error getting value.")
+// 		require.Equal(vals[i], val, "Value not set correctly.")
+// 	}
+// 	// Remove all
+// 	for _, key := range keys {
+// 		err := ts.Remove(ctx, key)
+// 		require.NoError(err, "Error removing from ts.")
+// 		_, err = ts.GetValue(ctx, key)
+// 		require.ErrorIs(err, database.ErrNotFound, "Value not removed.")
+// 	}
+// 	require.Equal(len(keys), ts.OpIndex(), "Operations not added properly.")
+// 	require.Equal(3, ts.PendingChanges())
+// 	// Roll back all removes
+// 	ts.Rollback(ctx, 0)
+// 	require.Equal(0, ts.OpIndex(), "Operations not rolled back properly.")
+// 	require.Equal(0, ts.PendingChanges())
+// 	for i, key := range keys {
+// 		val, err := ts.GetValue(ctx, key)
+// 		require.NoError(err, "Error getting value.")
+// 		require.Equal(vals[i], val, "Value not reset correctly.")
+// 	}
+// }
+
+// func TestWriteChanges(t *testing.T) {
+// 	require := require.New(t)
+// 	ts := New(10)
+// 	db := NewTestDB()
+// 	ctx := context.TODO()
+// 	tracer, _ := trace.New(&trace.Config{Enabled: false})
+// 	keys := [][]byte{[]byte("key1"), []byte("key2"), []byte("key3")}
+// 	vals := [][]byte{[]byte("val1"), []byte("val2"), []byte("val3")}
+// 	ts.SetScope(ctx, keys, map[string][]byte{})
+// 	// Add
+// 	for i, key := range keys {
+// 		err := ts.Insert(ctx, key, vals[i])
+// 		require.NoError(err, "Error inserting value.")
+// 		val, err := ts.GetValue(ctx, key)
+// 		require.NoError(err, "Error getting value.")
+// 		require.Equal(vals[i], val, "Value not set correctly.")
+// 	}
+// 	err := ts.WriteChanges(ctx, db, tracer)
+// 	require.NoError(err, "Error writing changes.")
+// 	// Check if db was updated correctly
+// 	for i, key := range keys {
+// 		val, _ := db.GetValue(ctx, key)
+// 		require.Equal(vals[i], val, "Value not updated in db.")
+// 	}
+// 	// Remove
+// 	ts = New(10)
+// 	ts.SetScope(ctx, keys, map[string][]byte{
+// 		string(keys[0]): vals[0],
+// 		string(keys[1]): vals[1],
+// 		string(keys[2]): vals[2],
+// 	})
+// 	for _, key := range keys {
+// 		err := ts.Remove(ctx, key)
+// 		require.NoError(err, "Error removing from ts.")
+// 		_, err = ts.GetValue(ctx, key)
+// 		require.ErrorIs(err, database.ErrNotFound, "Key not removed.")
+// 	}
+// 	err = ts.WriteChanges(ctx, db, tracer)
+// 	require.NoError(err, "Error writing changes.")
+// 	// Check if db was updated correctly
+// 	for _, key := range keys {
+// 		_, err := db.GetValue(ctx, key)
+// 		require.ErrorIs(err, database.ErrNotFound, "Value not removed from db.")
+// 	}
+// }
+
+
+func BenchmarkFetchAndSetScope(b *testing.B) {
+	for _, size := range []int{1, 5, 10, 15, 20} {
+		b.Run(fmt.Sprintf("get_validator_set_%d_validators", size), func(b *testing.B) {
+			benchmarkGetValidatorSet(b, size)
+		})
+	}
 }
 
-func TestGetValueNoStorage(t *testing.T) {
-	require := require.New(t)
-	ctx := context.TODO()
-	ts := New(10)
-	// SetScope but dont add to storage
-	ts.SetScope(ctx, [][]byte{TestKey}, map[string][]byte{})
-	_, err := ts.GetValue(ctx, TestKey)
-	require.ErrorIs(database.ErrNotFound, err, "No error thrown.")
-}
-
-func TestInsertNew(t *testing.T) {
-	require := require.New(t)
-	ctx := context.TODO()
-	ts := New(10)
-	// Insert before SetScope
-	err := ts.Insert(ctx, TestKey, TestVal)
-	require.ErrorIs(ErrKeyNotSpecified, err, "No error thrown.")
-	// SetScope
-	ts.SetScope(ctx, [][]byte{TestKey}, map[string][]byte{})
-	// Insert key
-	err = ts.Insert(ctx, TestKey, TestVal)
-	require.NoError(err, "Error thrown.")
-	val, err := ts.GetValue(ctx, TestKey)
-	require.NoError(err, "Error thrown.")
-	require.Equal(1, ts.OpIndex(), "Insert operation was not added.")
-	require.Equal(TestVal, val, "Value was not set correctly.")
-}
-
-func TestInsertUpdate(t *testing.T) {
-	require := require.New(t)
-	ctx := context.TODO()
-	ts := New(10)
-	// SetScope and add
-	ts.SetScope(ctx, [][]byte{TestKey}, map[string][]byte{string(TestKey): TestVal})
-	require.Equal(0, ts.OpIndex(), "SetStorage operation was not added.")
-	// Insert key
-	newVal := []byte("newVal")
-	err := ts.Insert(ctx, TestKey, newVal)
-	require.NoError(err, "Error thrown.")
-	val, err := ts.GetValue(ctx, TestKey)
-	require.NoError(err, "Error thrown.")
-	require.Equal(1, ts.OpIndex(), "Insert operation was not added.")
-	require.Equal(newVal, val, "Value was not set correctly.")
-	require.Equal(TestVal, ts.ops[0].pastV, "PastVal was not set correctly.")
-	require.False(ts.ops[0].pastChanged, "PastVal was not set correctly.")
-	require.True(ts.ops[0].pastExists, "PastVal was not set correctly.")
-}
-
-func TestFetchAndSetScope(t *testing.T) {
-	require := require.New(t)
+func benchmarkGetValidatorSet(b *testing.B, size int) {
+	require := require.New(b)
 	ts := New(10)
 	db := NewTestDB()
 	ctx := context.TODO()
-	keys := [][]byte{[]byte("key1"), []byte("key2"), []byte("key3")}
-	vals := [][]byte{[]byte("val1"), []byte("val2"), []byte("val3")}
+
+	keys := [][]byte{}
+	vals := [][]byte{}
+	for range "0..size" {
+		keys = append(keys, randomBytes(65))
+		vals = append(vals, randomBytes(8))
+	}
+
 	for i, key := range keys {
 		err := db.Insert(ctx, key, vals[i])
 		require.NoError(err, "Error during insert.")
 	}
-	err := ts.FetchAndSetScope(ctx, keys, db)
-	require.NoError(err, "Error thrown.")
-	require.Equal(0, ts.OpIndex(), "Opertions not updated correctly.")
-	require.Equal(keys, ts.scope, "Scope not updated correctly.")
-	// Check values
-	for i, key := range keys {
-		val, err := ts.GetValue(ctx, key)
-		require.NoError(err, "Error getting value.")
-		require.Equal(vals[i], val, "Value not set correctly.")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := ts.FetchAndSetScope(ctx, keys, db)
+		require.NoError(err)
 	}
+	b.StopTimer()
 }
 
-func TestFetchAndSetScopeMissingKey(t *testing.T) {
-	require := require.New(t)
-	ts := New(10)
-	db := NewTestDB()
-	ctx := context.TODO()
-	keys := [][]byte{[]byte("key1"), []byte("key2"), []byte("key3")}
-	vals := [][]byte{[]byte("val1"), []byte("val2"), []byte("val3")}
-	// Keys[3] not in db
-	for i, key := range keys[:len(keys)-1] {
-		err := db.Insert(ctx, key, vals[i])
-		require.NoError(err, "Error during insert.")
-	}
-	err := ts.FetchAndSetScope(ctx, keys, db)
-	require.NoError(err, "Error thrown.")
-	require.Equal(0, ts.OpIndex(), "Opertions not updated correctly.")
-	require.Equal(keys, ts.scope, "Scope not updated correctly.")
-	// Check values
-	for i, key := range keys[:len(keys)-1] {
-		val, err := ts.GetValue(ctx, key)
-		require.NoError(err, "Error getting value.")
-		require.Equal(vals[i], val, "Value not set correctly.")
-	}
-	_, err = ts.GetValue(ctx, keys[2])
-	require.ErrorIs(err, database.ErrNotFound, "Didn't throw correct erro.")
-}
-
-func TestSetScope(t *testing.T) {
-	require := require.New(t)
-	ts := New(10)
-	ctx := context.TODO()
-	keys := [][]byte{[]byte("key1"), []byte("key2"), []byte("key3")}
-	ts.SetScope(ctx, keys, map[string][]byte{})
-	require.Equal(keys, ts.scope, "Scope not updated correctly.")
-}
-
-func TestRemoveInsertRollback(t *testing.T) {
-	require := require.New(t)
-	ts := New(10)
-	ctx := context.TODO()
-	ts.SetScope(ctx, [][]byte{TestKey}, map[string][]byte{})
-	// Insert
-	err := ts.Insert(ctx, TestKey, TestVal)
-	require.NoError(err, "Error from insert.")
-	v, err := ts.GetValue(ctx, TestKey)
-	require.NoError(err)
-	require.Equal(TestVal, v)
-	require.Equal(1, ts.OpIndex(), "Opertions not updated correctly.")
-	// Remove
-	err = ts.Remove(ctx, TestKey)
-	require.NoError(err, "Error from remove.")
-	_, err = ts.GetValue(ctx, TestKey)
-	require.ErrorIs(err, database.ErrNotFound, "Key not deleted from storage.")
-	require.Equal(2, ts.OpIndex(), "Opertions not updated correctly.")
-	// Insert
-	err = ts.Insert(ctx, TestKey, TestVal)
-	require.NoError(err, "Error from insert.")
-	v, err = ts.GetValue(ctx, TestKey)
-	require.NoError(err)
-	require.Equal(TestVal, v)
-	require.Equal(3, ts.OpIndex(), "Opertions not updated correctly.")
-	require.Equal(1, ts.PendingChanges())
-	// Rollback
-	ts.Rollback(ctx, 2)
-	_, err = ts.GetValue(ctx, TestKey)
-	require.ErrorIs(err, database.ErrNotFound, "Key not deleted from storage.")
-	// Rollback
-	ts.Rollback(ctx, 1)
-	v, err = ts.GetValue(ctx, TestKey)
-	require.NoError(err)
-	require.Equal(TestVal, v)
-}
-
-func TestRemoveNotInScope(t *testing.T) {
-	require := require.New(t)
-	ts := New(10)
-	ctx := context.TODO()
-	// Remove
-	err := ts.Remove(ctx, TestKey)
-	require.ErrorIs(err, ErrKeyNotSpecified, "ErrKeyNotSpecified should be thrown.")
-}
-
-func TestRestoreInsert(t *testing.T) {
-	require := require.New(t)
-	ts := New(10)
-	ctx := context.TODO()
-	keys := [][]byte{[]byte("key1"), []byte("key2"), []byte("key3")}
-	vals := [][]byte{[]byte("val1"), []byte("val2"), []byte("val3")}
-	ts.SetScope(ctx, keys, map[string][]byte{})
-	for i, key := range keys {
-		err := ts.Insert(ctx, key, vals[i])
-		require.NoError(err, "Error inserting.")
-	}
-	updatedVal := []byte("newVal")
-	err := ts.Insert(ctx, keys[0], updatedVal)
-	require.NoError(err, "Error inserting.")
-	require.Equal(len(keys)+1, ts.OpIndex(), "Operations not added properly.")
-	val, err := ts.GetValue(ctx, keys[0])
-	require.NoError(err, "Error getting value.")
-	require.Equal(updatedVal, val, "Value not updated correctly.")
-	// Rollback inserting updatedVal and key[2]
-	ts.Rollback(ctx, 2)
-	require.Equal(2, ts.OpIndex(), "Operations not rolled back properly.")
-	// Keys[2] was removed
-	_, err = ts.GetValue(ctx, keys[2])
-	require.ErrorIs(err, database.ErrNotFound, "TState read op not rolled back properly.")
-	// Keys[0] was set to past value
-	val, err = ts.GetValue(ctx, keys[0])
-	require.NoError(err, "Error getting value.")
-	require.Equal(vals[0], val, "Value not rolled back properly.")
-}
-
-func TestRestoreDelete(t *testing.T) {
-	require := require.New(t)
-	ts := New(10)
-	ctx := context.TODO()
-	keys := [][]byte{[]byte("key1"), []byte("key2"), []byte("key3")}
-	vals := [][]byte{[]byte("val1"), []byte("val2"), []byte("val3")}
-	ts.SetScope(ctx, keys, map[string][]byte{
-		string(keys[0]): vals[0],
-		string(keys[1]): vals[1],
-		string(keys[2]): vals[2],
-	})
-	// Check scope
-	for i, key := range keys {
-		val, err := ts.GetValue(ctx, key)
-		require.NoError(err, "Error getting value.")
-		require.Equal(vals[i], val, "Value not set correctly.")
-	}
-	// Remove all
-	for _, key := range keys {
-		err := ts.Remove(ctx, key)
-		require.NoError(err, "Error removing from ts.")
-		_, err = ts.GetValue(ctx, key)
-		require.ErrorIs(err, database.ErrNotFound, "Value not removed.")
-	}
-	require.Equal(len(keys), ts.OpIndex(), "Operations not added properly.")
-	require.Equal(3, ts.PendingChanges())
-	// Roll back all removes
-	ts.Rollback(ctx, 0)
-	require.Equal(0, ts.OpIndex(), "Operations not rolled back properly.")
-	require.Equal(0, ts.PendingChanges())
-	for i, key := range keys {
-		val, err := ts.GetValue(ctx, key)
-		require.NoError(err, "Error getting value.")
-		require.Equal(vals[i], val, "Value not reset correctly.")
-	}
-}
-
-func TestWriteChanges(t *testing.T) {
-	require := require.New(t)
-	ts := New(10)
-	db := NewTestDB()
-	ctx := context.TODO()
-	tracer, _ := trace.New(&trace.Config{Enabled: false})
-	keys := [][]byte{[]byte("key1"), []byte("key2"), []byte("key3")}
-	vals := [][]byte{[]byte("val1"), []byte("val2"), []byte("val3")}
-	ts.SetScope(ctx, keys, map[string][]byte{})
-	// Add
-	for i, key := range keys {
-		err := ts.Insert(ctx, key, vals[i])
-		require.NoError(err, "Error inserting value.")
-		val, err := ts.GetValue(ctx, key)
-		require.NoError(err, "Error getting value.")
-		require.Equal(vals[i], val, "Value not set correctly.")
-	}
-	err := ts.WriteChanges(ctx, db, tracer)
-	require.NoError(err, "Error writing changes.")
-	// Check if db was updated correctly
-	for i, key := range keys {
-		val, _ := db.GetValue(ctx, key)
-		require.Equal(vals[i], val, "Value not updated in db.")
-	}
-	// Remove
-	ts = New(10)
-	ts.SetScope(ctx, keys, map[string][]byte{
-		string(keys[0]): vals[0],
-		string(keys[1]): vals[1],
-		string(keys[2]): vals[2],
-	})
-	for _, key := range keys {
-		err := ts.Remove(ctx, key)
-		require.NoError(err, "Error removing from ts.")
-		_, err = ts.GetValue(ctx, key)
-		require.ErrorIs(err, database.ErrNotFound, "Key not removed.")
-	}
-	err = ts.WriteChanges(ctx, db, tracer)
-	require.NoError(err, "Error writing changes.")
-	// Check if db was updated correctly
-	for _, key := range keys {
-		_, err := db.GetValue(ctx, key)
-		require.ErrorIs(err, database.ErrNotFound, "Value not removed from db.")
-	}
+func randomBytes(size int) []byte {
+	bytes := make([]byte, size)
+	rand.Read(bytes)
+	return bytes
 }


### PR DESCRIPTION
This is an experimentation with replacing the current internal maps from `map[string][]byte` to `map[[65]byte][]byte`. In benchmarks I found that using a byte array was much faster than using string as a key.

```
goos: linux
goarch: amd64
pkg: byte-slice-indexed-maps/byte-slice-indexed-maps
cpu: Intel(R) Core(TM) i7-10750H CPU @ 2.60GHz
=== RUN   BenchmarkArrayKeyed
BenchmarkArrayKeyed
BenchmarkArrayKeyed-12
 4196601               313.0 ns/op             0 B/op          0 allocs/op
=== RUN   BenchmarkOptimizedStringKeyed
BenchmarkOptimizedStringKeyed
BenchmarkOptimizedStringKeyed-12
 3048964               453.4 ns/op            16 B/op          1 allocs/op
=== RUN   BenchmarkStringKeyed
BenchmarkStringKeyed
BenchmarkStringKeyed-12                  2209490               505.6 ns/op            48 B/op          3 allocs/op
=== RUN   BenchmarkHexKeyed
BenchmarkHexKeyed
BenchmarkHexKeyed-12                     1739541               778.4 ns/op            96 B/op          4 allocs/op
```

ref. https://gitlab.com/pthevenet/go-small-answers/-/blob/29c03407006a269f8f6ba27fa3123fb9742ddf7c/byte-slice-indexed-maps/benchmark_test.go

This reduces the allocations for `FetchAndSetScope` from 9 to 2. and provides much cleaner profile (will upload soon).


```
goos: linux
goarch: amd64
pkg: github.com/ava-labs/hypersdk/tstate
cpu: Intel(R) Core(TM) i7-10750H CPU @ 2.60GHz
BenchmarkFetchAndSetScope/fetch_and_set_scope_100_keys-12         	  192068	      2374 ns/op	     816 B/op	       2 allocs/op
BenchmarkFetchAndSetScope/fetch_and_set_scope_1000_keys-12        	  221142	      2540 ns/op	     816 B/op	       2 allocs/op
BenchmarkFetchAndSetScope/fetch_and_set_scope_10000_keys-12       	  195196	      2321 ns/op	     816 B/op	       2 allocs/op
PASS
ok  	github.com/ava-labs/hypersdk/tstate	4.474s
```