### PR TITLE
Mempool Usage Overhaul

### DIFF
--- a/.github/workflows/tokenvm-release.yml
+++ b/.github/workflows/tokenvm-release.yml
@@ -58,8 +58,8 @@ jobs:
       - name: Archive Builds
         uses: actions/upload-artifact@v3
         with:
-          name: dist
-          path: ./examples/tokenvm/dist
+          name: tokenvm
+          path: ./examples/tokenvm/dist/tokenvm_linux_amd64_v1/tokenvm
  main-release:
     # We build with 20.04 to maintain max compatibility: https://github.com/golang/go/issues/57328
     runs-on: ubuntu-20.04-32

--- a/.github/workflows/tokenvm-release.yml
+++ b/.github/workflows/tokenvm-release.yml
@@ -26,7 +26,9 @@ jobs:
           go-version: "1.20"
           check-latest: true
       - name: Set up arm64 cross compiler
-        run: sudo apt-get -y install gcc-aarch64-linux-gnu
+        run: |
+          sudo apt-get -y update
+          sudo apt-get -y install gcc-aarch64-linux-gnu
       - name: Checkout osxcross
         uses: actions/checkout@v2
         with:

--- a/chain/builder.go
+++ b/chain/builder.go
@@ -271,7 +271,7 @@ func BuildBlock(
 					execErr = err
 					continue
 				}
-				txBlock = NewTxBlock(tectx, vm, txBlock, nextTime)
+				txBlock = NewTxBlock(tectx, vm, parentTxBlock, nextTime)
 				results = []*Result{}
 			}
 

--- a/chain/builder.go
+++ b/chain/builder.go
@@ -130,10 +130,11 @@ func BuildBlock(
 		// TODO: move this to a function
 		readyTxs := make(chan *txData, len(txs))
 		stopIndex := -1
+		var timeExceeded bool
 		go func() {
 			// Store required keys for each set
 			for i, tx := range txs {
-				if txBlock == nil {
+				if txBlock == nil || timeExceeded {
 					// This happens when at last tx block
 					stopIndex = i
 					close(readyTxs)
@@ -183,6 +184,7 @@ func BuildBlock(
 
 			// Avoid building for too long
 			if time.Since(start) > vm.GetMaxBuildTime() {
+				timeExceeded = true
 				restorable = append(restorable, next)
 				continue
 			}

--- a/chain/dependencies.go
+++ b/chain/dependencies.go
@@ -81,6 +81,7 @@ type VM interface {
 	RecordVerifyWait(time.Duration)
 	RecordTxBlockIssuanceDiff(time.Duration)
 	RecordRootBlockIssuanceDiff(time.Duration)
+	RecordRootBlockAcceptanceDiff(time.Duration)
 	RecordStateChanges(int)
 	RecordStateOperations(int)
 	RecordTxBlocksMissing(int)

--- a/chain/dependencies.go
+++ b/chain/dependencies.go
@@ -53,7 +53,7 @@ type VM interface {
 	StateReady() bool
 	IsBootstrapped() bool
 
-	State() (*merkledb.Database, error)
+	State() (merkledb.MerkleDB, error)
 	StateManager() StateManager
 	ValidatorState() validators.State
 	IsRepeat(context.Context, []*Transaction) bool

--- a/chain/dependencies.go
+++ b/chain/dependencies.go
@@ -95,6 +95,8 @@ type Mempool interface {
 		context.Context,
 		func(context.Context, *Transaction) (bool /* continue */, bool /* restore */, bool /* remove account */, error),
 	) error
+	LeaseItems(context.Context, int) []*Transaction
+	ClearLease(context.Context, []*Transaction)
 }
 
 type Database interface {

--- a/chain/dependencies.go
+++ b/chain/dependencies.go
@@ -95,8 +95,10 @@ type Mempool interface {
 		context.Context,
 		func(context.Context, *Transaction) (bool /* continue */, bool /* restore */, bool /* remove account */, error),
 	) error
+	StartBuild(context.Context)
 	LeaseItems(context.Context, int) []*Transaction
-	ClearLease(context.Context, []*Transaction)
+	ClearLease(context.Context, []*Transaction, []*Transaction)
+	FinishBuild(context.Context)
 }
 
 type Database interface {

--- a/chain/execution_context.go
+++ b/chain/execution_context.go
@@ -100,7 +100,7 @@ func GenerateRootExecutionContext(
 	ctx context.Context,
 	chainID ids.ID,
 	currTime int64,
-	parent *StatelessRootBlock,
+	parent *StatelessRootBlock, // TODO: doesn't need stateless
 	tracer trace.Tracer, //nolint:interfacer
 	r Rules,
 ) (*RootExecutionContext, error) {
@@ -131,7 +131,7 @@ func GenerateTxExecutionContext(
 	ctx context.Context,
 	chainID ids.ID,
 	currTime int64,
-	parent *StatelessTxBlock,
+	parent *StatelessTxBlock, // TODO: doesn't need stateless
 	tracer trace.Tracer, //nolint:interfacer
 	r Rules,
 ) (*TxExecutionContext, error) {

--- a/chain/root_block.go
+++ b/chain/root_block.go
@@ -59,7 +59,8 @@ type StatelessRootBlock struct {
 	t     time.Time
 	bytes []byte
 
-	bctx     *block.Context
+	bctx *block.Context
+	// These will only be populated if block was verified and still in cache
 	txBlocks []*StatelessTxBlock
 
 	firstVerify    time.Time
@@ -503,12 +504,13 @@ func (b *StatelessRootBlock) State() (Database, error) {
 	return nil, ErrBlockNotProcessed
 }
 
-func (b *StatelessRootBlock) LastTxBlock() *StatelessTxBlock {
+func (b *StatelessRootBlock) LastTxBlock() (*StatelessTxBlock, error) {
 	l := len(b.txBlocks)
-	if l == 0 {
-		return nil
+	if l > 0 {
+		return b.txBlocks[l-1], nil
 	}
-	return b.txBlocks[l-1]
+	lid := b.Txs[len(b.Txs)-1]
+	return b.vm.GetStatelessTxBlock(context.TODO(), lid, b.MinTxHght+uint64(len(b.Txs)-1))
 }
 
 func (b *StatelessRootBlock) GetTxs() []ids.ID {

--- a/chain/root_block.go
+++ b/chain/root_block.go
@@ -512,6 +512,7 @@ func (b *StatelessRootBlock) LastTxBlock() (*StatelessTxBlock, error) {
 		return b.txBlocks[l-1], nil
 	}
 	lid := b.Txs[len(b.Txs)-1]
+	// 10 + [10, 11, 12, 13]
 	return b.vm.GetStatelessTxBlock(context.TODO(), lid, b.MinTxHght+uint64(len(b.Txs)-1))
 }
 

--- a/chain/root_block.go
+++ b/chain/root_block.go
@@ -408,6 +408,8 @@ func (b *StatelessRootBlock) Accept(ctx context.Context) error {
 	ctx, span := b.vm.Tracer().Start(ctx, "StatelessRootBlock.Accept")
 	defer span.End()
 
+	b.vm.RecordRootBlockAcceptanceDiff(time.Since(time.UnixMilli(b.Issued)))
+
 	// Consider verifying the a block if it is not processed and we are no longer
 	// syncing.
 	state := b.txBlockState()

--- a/chain/tx_block.go
+++ b/chain/tx_block.go
@@ -582,6 +582,9 @@ func (b *StatelessTxBlock) ChildState(
 	}
 
 	// Process block if not yet processed and not yet accepted.
+	//
+	// We don't need to handle the case where the tx block is loaded from disk
+	// because that will hit the first if check here.
 	if b.state == nil {
 		return nil, errors.New("not implemented")
 	}

--- a/chain/tx_block.go
+++ b/chain/tx_block.go
@@ -336,7 +336,7 @@ func (b *StatelessTxBlock) Verify(ctx context.Context) error {
 	case b.UnitPrice != ectx.NextUnitPrice:
 		return ErrInvalidUnitPrice
 	case b.UnitWindow != ectx.NextUnitWindow:
-		b.vm.Logger().Warn("unit window mismatch", zap.Uint64("height", b.Hght), zap.Bool("parent", parent != nil), zap.Binary("found", b.UnitWindow[:]), zap.Binary("expected", ectx.NextUnitWindow[:]))
+		b.vm.Logger().Warn("unit window mismatch", zap.Uint64("height", b.Hght), zap.Stringer("parent", parent.ID()), zap.Binary("found", b.UnitWindow[:]), zap.Binary("expected", ectx.NextUnitWindow[:]))
 		return ErrInvalidUnitWindow
 	}
 	log.Info(

--- a/config/config.go
+++ b/config/config.go
@@ -39,7 +39,8 @@ func (c *Config) GetTraceConfig() *trace.Config          { return &trace.Config{
 func (c *Config) GetStateSyncParallelism() int           { return 4 }
 func (c *Config) GetStateSyncMinBlocks() uint64          { return 256 }
 func (c *Config) GetStateSyncServerDelay() time.Duration { return 0 } // used for testing
-func (c *Config) GetBlockLRUSize() int                   { return 128 }
+func (c *Config) GetParsedBlockCacheSize() int           { return 128 }
+func (c *Config) GetAcceptedBlockCacheSize() int         { return 128 }
 
 func (c *Config) GetContinuousProfilerConfig() *profiler.Config {
 	return &profiler.Config{Enabled: false}

--- a/config/config.go
+++ b/config/config.go
@@ -48,5 +48,5 @@ func (c *Config) GetContinuousProfilerConfig() *profiler.Config {
 
 func (c *Config) GetRootBlockPruneDiff() uint64  { return 1024 }
 func (c *Config) GetVerifySignatures() bool      { return true }
-func (c *Config) GetMinBuildTime() time.Duration { return 250 * time.Millisecond } // still need to limit with units to avoid DoS on verify
-func (c *Config) GetMaxBuildTime() time.Duration { return 750 * time.Millisecond } // still need to limit with units to avoid DoS on verify
+func (c *Config) GetMinBuildTime() time.Duration { return 256 * time.Millisecond } // still need to limit with units to avoid DoS on verify
+func (c *Config) GetMaxBuildTime() time.Duration { return 512 * time.Millisecond } // still need to limit with units to avoid DoS on verify

--- a/examples/tokenvm/DEVNETS.md
+++ b/examples/tokenvm/DEVNETS.md
@@ -83,7 +83,7 @@ TODO: add support for `keep-resources-except-asg-ssm` and
 ```bash
 /tmp/avalancheup-aws default-spec \
 --arch-type amd64 \
---rust-os-type ubuntu20.04 \
+--os-type ubuntu20.04 \
 --anchor-nodes 3 \
 --non-anchor-nodes 3 \
 --regions us-west-2 \
@@ -92,7 +92,7 @@ TODO: add support for `keep-resources-except-asg-ssm` and
 --ip-mode=ephemeral \
 --metrics-fetch-interval-seconds 60 \
 --network-name custom \
---avalanchego-release-tag v1.10.1 \
+--avalanchego-release-tag v1.10.2 \
 --create-dev-machine \
 --keep-resources-except-asg-ssm \
 --keys-to-generate 5

--- a/examples/tokenvm/DEVNETS.md
+++ b/examples/tokenvm/DEVNETS.md
@@ -267,11 +267,13 @@ cat <<EOF > /tmp/avalanche-ops/tokenvm-chain-config.json
   "streamingBacklogSize": 10000000,
   "gossipMaxSize": 32768,
   "gossipProposerDepth": 1,
-  "buildProposerDiff": 10,
+  "buildProposerDiff": 1,
   "verifyTimeout": 5,
+  "verifySignatures": true,
+  "storeTransactions": false,
   "trackedPairs":["*"],
   "logLevel": "info",
-  "preferredBlocksPerSecond": 3
+  "preferredBlocksPerSecond": 5
 }
 EOF
 cat /tmp/avalanche-ops/tokenvm-chain-config.json

--- a/examples/tokenvm/cmd/token-cli/cmd/prometheus.go
+++ b/examples/tokenvm/cmd/token-cli/cmd/prometheus.go
@@ -97,6 +97,12 @@ var generatePrometheusCmd = &cobra.Command{
 		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_vm_txs_accepted[5s])/5", chainID))
 		utils.Outf("{{yellow}}transactions per second:{{/}} %s\n", panels[len(panels)-1])
 
+		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_vm_tx_blocks_verified_failed[5s])", chainID))
+		utils.Outf("{{yellow}}failed tx block verifications:{{/}} %s\n", panels[len(panels)-1])
+
+		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_vm_tx_blocks_verified_failed_manager[5s])", chainID))
+		utils.Outf("{{yellow}}failed tx block verifications in manager:{{/}} %s\n", panels[len(panels)-1])
+
 		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_chain_state_operations[5s])/5", chainID))
 		utils.Outf("{{yellow}}state operations per second:{{/}} %s\n", panels[len(panels)-1])
 

--- a/examples/tokenvm/cmd/token-cli/cmd/prometheus.go
+++ b/examples/tokenvm/cmd/token-cli/cmd/prometheus.go
@@ -62,8 +62,8 @@ var generatePrometheusCmd = &cobra.Command{
 
 		// Create Prometheus YAML
 		var prometheusConfig PrometheusConfig
-		prometheusConfig.Global.ScrapeInterval = "15s"
-		prometheusConfig.Global.EvaluationInterval = "15s"
+		prometheusConfig.Global.ScrapeInterval = "1s"
+		prometheusConfig.Global.EvaluationInterval = "1s"
 		prometheusConfig.ScrapeConfigs = []*PrometheusScrapeConfig{
 			{
 				JobName: "prometheus",
@@ -88,52 +88,52 @@ var generatePrometheusCmd = &cobra.Command{
 		panels = append(panels, fmt.Sprintf("avalanche_%s_blks_processing", chainID))
 		utils.Outf("{{yellow}}blocks processing:{{/}} %s\n", panels[len(panels)-1])
 
-		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_blks_accepted_count[30s])/30", chainID))
+		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_blks_accepted_count[5s])/5", chainID))
 		utils.Outf("{{yellow}}blocks accepted per second:{{/}} %s\n", panels[len(panels)-1])
 
-		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_blks_rejected_count[30s])/30", chainID))
+		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_blks_rejected_count[5s])/5", chainID))
 		utils.Outf("{{yellow}}blocks rejected per second:{{/}} %s\n", panels[len(panels)-1])
 
-		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_vm_txs_accepted[30s])/30", chainID))
+		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_vm_txs_accepted[5s])/5", chainID))
 		utils.Outf("{{yellow}}transactions per second:{{/}} %s\n", panels[len(panels)-1])
 
-		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_chain_state_operations[30s])/30", chainID))
+		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_chain_state_operations[5s])/5", chainID))
 		utils.Outf("{{yellow}}state operations per second:{{/}} %s\n", panels[len(panels)-1])
 
-		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_chain_state_changes[30s])/30", chainID))
+		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_chain_state_changes[5s])/5", chainID))
 		utils.Outf("{{yellow}}state changes per second:{{/}} %s\n", panels[len(panels)-1])
 
-		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_chain_root_calculated_sum[30s])/1000000/30", chainID))
+		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_chain_root_calculated_sum[5s])/1000000/5", chainID))
 		utils.Outf("{{yellow}}root calcuation wait (ms/s):{{/}} %s\n", panels[len(panels)-1])
 
-		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_chain_commit_state_sum[30s])/1000000/30", chainID))
+		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_chain_commit_state_sum[5s])/1000000/5", chainID))
 		utils.Outf("{{yellow}}commit state wait (ms/s):{{/}} %s\n", panels[len(panels)-1])
 
-		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_chain_wait_signatures_sum[30s])/1000000/30", chainID))
+		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_chain_wait_signatures_sum[5s])/1000000/5", chainID))
 		utils.Outf("{{yellow}}signature verification wait (ms/s):{{/}} %s\n", panels[len(panels)-1])
 
-		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_chain_build_block_sum[30s])/increase(avalanche_%s_vm_hyper_sdk_chain_build_block_count[30s])/1000000", chainID, chainID))
+		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_chain_build_block_sum[5s])/increase(avalanche_%s_vm_hyper_sdk_chain_build_block_count[5s])/1000000", chainID, chainID))
 		utils.Outf("{{yellow}}build block (ms):{{/}} %s\n", panels[len(panels)-1])
 
-		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_chain_early_build_stop[30s])", chainID))
+		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_chain_early_build_stop[5s])", chainID))
 		utils.Outf("{{yellow}}early build stop:{{/}} %s\n", panels[len(panels)-1])
 
-		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_chain_tx_block_verify_sum[30s])/increase(avalanche_%s_vm_hyper_sdk_chain_tx_block_verify_count[30s])/1000000", chainID, chainID))
+		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_chain_tx_block_verify_sum[5s])/increase(avalanche_%s_vm_hyper_sdk_chain_tx_block_verify_count[5s])/1000000", chainID, chainID))
 		utils.Outf("{{yellow}}verify tx block (ms):{{/}} %s\n", panels[len(panels)-1])
 
-		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_chain_verify_wait_sum[30s])/increase(avalanche_%s_vm_hyper_sdk_chain_verify_wait_count[30s])/1000000", chainID, chainID))
+		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_chain_verify_wait_sum[5s])/increase(avalanche_%s_vm_hyper_sdk_chain_verify_wait_count[5s])/1000000", chainID, chainID))
 		utils.Outf("{{yellow}}verify wait (ms):{{/}} %s\n", panels[len(panels)-1])
 
-		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_chain_tx_block_issuance_diff_sum[30s])/increase(avalanche_%s_vm_hyper_sdk_chain_tx_block_issuance_diff_count[30s])/1000000", chainID, chainID))
+		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_chain_tx_block_issuance_diff_sum[5s])/increase(avalanche_%s_vm_hyper_sdk_chain_tx_block_issuance_diff_count[5s])/1000000", chainID, chainID))
 		utils.Outf("{{yellow}}tx block issuance diff (ms):{{/}} %s\n", panels[len(panels)-1])
 
-		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_chain_root_block_issuance_diff_sum[30s])/increase(avalanche_%s_vm_hyper_sdk_chain_root_block_issuance_diff_count[30s])/1000000", chainID, chainID))
+		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_chain_root_block_issuance_diff_sum[5s])/increase(avalanche_%s_vm_hyper_sdk_chain_root_block_issuance_diff_count[5s])/1000000", chainID, chainID))
 		utils.Outf("{{yellow}}root block issuance diff (ms):{{/}} %s\n", panels[len(panels)-1])
 
-		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_chain_tx_blocks_missing[30s])", chainID))
+		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_chain_tx_blocks_missing[5s])", chainID))
 		utils.Outf("{{yellow}}missing tx blocks:{{/}} %s\n", panels[len(panels)-1])
 
-		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_chain_deleted_tx_blocks[30s])", chainID))
+		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_chain_deleted_tx_blocks[5s])", chainID))
 		utils.Outf("{{yellow}}deleted tx blocks:{{/}} %s\n", panels[len(panels)-1])
 
 		panels = append(panels, fmt.Sprintf("avalanche_%s_vm_hyper_sdk_chain_mempool_size", chainID))
@@ -142,31 +142,34 @@ var generatePrometheusCmd = &cobra.Command{
 		panels = append(panels, fmt.Sprintf("avalanche_%s_vm_hyper_sdk_chain_mempool_size_after_build", chainID))
 		utils.Outf("{{yellow}}mempool size after build:{{/}} %s\n", panels[len(panels)-1])
 
-		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_mempool_mempool_build_overhead_sum[30s])/increase(avalanche_%s_vm_mempool_mempool_build_overhead_count[30s])/1000000", chainID, chainID))
+		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_mempool_mempool_build_overhead_sum[5s])/increase(avalanche_%s_vm_mempool_mempool_build_overhead_count[5s])/1000000", chainID, chainID))
 		utils.Outf("{{yellow}}mempool build overhead (ms):{{/}} %s\n", panels[len(panels)-1])
+
+		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_mempool_mempool_lease_create_sum[5s])/increase(avalanche_%s_vm_mempool_mempool_lease_create_count[5s])/1000000", chainID, chainID))
+		utils.Outf("{{yellow}}mempool lease creation (ms):{{/}} %s\n", panels[len(panels)-1])
 
 		panels = append(panels, fmt.Sprintf("avalanche_%s_vm_hyper_sdk_chain_acceptor_drift", chainID))
 		utils.Outf("{{yellow}}acceptor drift:{{/}} %s\n", panels[len(panels)-1])
 
-		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_chain_tx_block_bytes_sent[30s])/30", chainID))
+		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_chain_tx_block_bytes_sent[5s])/5", chainID))
 		utils.Outf("{{yellow}}block bytes sent (B/s):{{/}} %s\n", panels[len(panels)-1])
 
-		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_chain_tx_block_bytes_received[30s])/30", chainID))
+		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_chain_tx_block_bytes_received[5s])/5", chainID))
 		utils.Outf("{{yellow}}block bytes received (B/s):{{/}} %s\n", panels[len(panels)-1])
 
 		panels = append(panels, "avalanche_resource_tracker_cpu_usage")
 		utils.Outf("{{yellow}}CPU usage:{{/}} %s\n", panels[len(panels)-1])
 
-		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_blockdb_pebble_l0_compactions[30s]) + increase(avalanche_%s_vm_blockdb_pebble_other_compactions[30s])", chainID, chainID))
+		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_blockdb_pebble_l0_compactions[5s]) + increase(avalanche_%s_vm_blockdb_pebble_other_compactions[5s])", chainID, chainID))
 		utils.Outf("{{yellow}}blockdb compactions:{{/}} %s\n", panels[len(panels)-1])
 
-		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_statedb_pebble_l0_compactions[30s]) + increase(avalanche_%s_vm_statedb_pebble_other_compactions[30s])", chainID, chainID))
+		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_statedb_pebble_l0_compactions[5s]) + increase(avalanche_%s_vm_statedb_pebble_other_compactions[5s])", chainID, chainID))
 		utils.Outf("{{yellow}}statedb compactions:{{/}} %s\n", panels[len(panels)-1])
 
-		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_metadb_pebble_l0_compactions[30s]) + increase(avalanche_%s_vm_metadb_pebble_other_compactions[30s])", chainID, chainID))
+		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_metadb_pebble_l0_compactions[5s]) + increase(avalanche_%s_vm_metadb_pebble_other_compactions[5s])", chainID, chainID))
 		utils.Outf("{{yellow}}metadb compactions:{{/}} %s\n", panels[len(panels)-1])
 
-		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_handler_chits_sum[30s])/1000000/30 + increase(avalanche_%s_handler_notify_sum[30s])/1000000/30 + increase(avalanche_%s_handler_get_sum[30s])/1000000/30 + increase(avalanche_%s_handler_push_query_sum[30s])/1000000/30 + increase(avalanche_%s_handler_put_sum[30s])/1000000/30 + increase(avalanche_%s_handler_pull_query_sum[30s])/1000000/30 + increase(avalanche_%s_handler_query_failed_sum[30s])/1000000/30", chainID, chainID, chainID, chainID, chainID, chainID, chainID))
+		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_handler_chits_sum[5s])/1000000/5 + increase(avalanche_%s_handler_notify_sum[5s])/1000000/5 + increase(avalanche_%s_handler_get_sum[5s])/1000000/5 + increase(avalanche_%s_handler_push_query_sum[5s])/1000000/5 + increase(avalanche_%s_handler_put_sum[5s])/1000000/5 + increase(avalanche_%s_handler_pull_query_sum[5s])/1000000/5 + increase(avalanche_%s_handler_query_failed_sum[5s])/1000000/5", chainID, chainID, chainID, chainID, chainID, chainID, chainID))
 		utils.Outf("{{yellow}}consensus engine processing (ms/s):{{/}} %s\n", panels[len(panels)-1])
 
 		// Generated dashboard link
@@ -180,7 +183,7 @@ var generatePrometheusCmd = &cobra.Command{
 			if i == 0 {
 				appendChar = "?"
 			}
-			dashboard = fmt.Sprintf("%s%sg%d.expr=%s&g%d.tab=0", dashboard, appendChar, i, url.QueryEscape(panel), i)
+			dashboard = fmt.Sprintf("%s%sg%d.expr=%s&g%d.tab=0&g%d.step_input=1&g%d.range_input=5m", dashboard, appendChar, i, url.QueryEscape(panel), i, i, i)
 		}
 		utils.Outf("{{orange}}pre-built dashboard:{{/}} %s\n", dashboard)
 

--- a/examples/tokenvm/cmd/token-cli/cmd/prometheus.go
+++ b/examples/tokenvm/cmd/token-cli/cmd/prometheus.go
@@ -142,6 +142,9 @@ var generatePrometheusCmd = &cobra.Command{
 		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_chain_tx_blocks_missing[5s])", chainID))
 		utils.Outf("{{yellow}}missing tx blocks:{{/}} %s\n", panels[len(panels)-1])
 
+		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_chain_tx_blocks_dropped[5s])", chainID))
+		utils.Outf("{{yellow}}dropped tx blocks:{{/}} %s\n", panels[len(panels)-1])
+
 		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_chain_deleted_tx_blocks[5s])", chainID))
 		utils.Outf("{{yellow}}deleted tx blocks:{{/}} %s\n", panels[len(panels)-1])
 

--- a/examples/tokenvm/cmd/token-cli/cmd/prometheus.go
+++ b/examples/tokenvm/cmd/token-cli/cmd/prometheus.go
@@ -136,6 +136,9 @@ var generatePrometheusCmd = &cobra.Command{
 		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_chain_root_block_issuance_diff_sum[5s])/increase(avalanche_%s_vm_hyper_sdk_chain_root_block_issuance_diff_count[5s])/1000000", chainID, chainID))
 		utils.Outf("{{yellow}}root block issuance diff (ms):{{/}} %s\n", panels[len(panels)-1])
 
+		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_chain_root_block_acceptance_diff_sum[5s])/increase(avalanche_%s_vm_hyper_sdk_chain_root_block_acceptance_diff_count[5s])/1000000", chainID, chainID))
+		utils.Outf("{{yellow}}root block acceptance diff (ms):{{/}} %s\n", panels[len(panels)-1])
+
 		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_chain_tx_blocks_missing[5s])", chainID))
 		utils.Outf("{{yellow}}missing tx blocks:{{/}} %s\n", panels[len(panels)-1])
 

--- a/examples/tokenvm/go.mod
+++ b/examples/tokenvm/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/ava-labs/avalanche-network-runner v1.4.1
-	github.com/ava-labs/avalanchego v1.10.2-0.20230519230054-b45966175ae8
+	github.com/ava-labs/avalanchego v1.10.2
 	github.com/ava-labs/hypersdk v0.0.1
 	github.com/fatih/color v1.13.0
 	github.com/manifoldco/promptui v0.9.0
@@ -22,7 +22,7 @@ require (
 	github.com/Microsoft/go-winio v0.5.2 // indirect
 	github.com/NYTimes/gziphandler v1.1.1 // indirect
 	github.com/VictoriaMetrics/fastcache v1.10.0 // indirect
-	github.com/ava-labs/coreth v0.12.1-rc.0 // indirect
+	github.com/ava-labs/coreth v0.12.2-rc.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/btcsuite/btcd/btcec/v2 v2.3.2 // indirect
 	github.com/btcsuite/btcd/btcutil v1.1.3 // indirect

--- a/examples/tokenvm/go.sum
+++ b/examples/tokenvm/go.sum
@@ -67,10 +67,10 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/ava-labs/avalanche-network-runner v1.4.1 h1:S4dS/Sef3O2XdN04NRO9Tk9xijYpkv1Y1Iwj8B+bH+8=
 github.com/ava-labs/avalanche-network-runner v1.4.1/go.mod h1:SOUom+OuOYwm9CUev09IeG3P4JS4mh0OiwsPhfboLJ8=
-github.com/ava-labs/avalanchego v1.10.2-0.20230519230054-b45966175ae8 h1:8c/mKi4DnQbP+9BADAXE4fwgSLA+hCRE6jDRJH0fTcU=
-github.com/ava-labs/avalanchego v1.10.2-0.20230519230054-b45966175ae8/go.mod h1:OVfGwebZT9fD7gAT6t242xQteGSDyFar2SC4hMiVwBA=
-github.com/ava-labs/coreth v0.12.1-rc.0 h1:Zv9mJqddI28BZ5eT0SRgRrzl0sdRCdA/Mm+qZrHAhOs=
-github.com/ava-labs/coreth v0.12.1-rc.0/go.mod h1:ZGhoIZTWbIaTmzEbprXu0hLtLdoE2PSTEFnCTYr0BRk=
+github.com/ava-labs/avalanchego v1.10.2 h1:kDM2xfQDaewueUCxJUujPlbNQ91gtJfXY9Z0CYthdRc=
+github.com/ava-labs/avalanchego v1.10.2/go.mod h1:PsNLfOc9FnsnoJ8CjauclvFy6BCSVZmT05I4c9rm4a4=
+github.com/ava-labs/coreth v0.12.2-rc.0 h1:nGhGN4bYqid5EgqH/GFky2ybY8bGRxto6Bo7nes1V+Y=
+github.com/ava-labs/coreth v0.12.2-rc.0/go.mod h1:/5x54QlIKjlPebkdzTA5ic9wXdejbWOnQosztkv9jxo=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/examples/tokenvm/scripts/run.sh
+++ b/examples/tokenvm/scripts/run.sh
@@ -17,7 +17,7 @@ if ! [[ "$0" =~ scripts/run.sh ]]; then
   exit 255
 fi
 
-VERSION=b45966175ae88273e7a5915d17d9ac99b8db8546
+VERSION=v1.10.2
 MODE=${MODE:-run}
 LOGLEVEL=${LOGLEVEL:-info}
 AVALANCHE_LOG_LEVEL=${AVALANCHE_LOG_LEVEL:-INFO}
@@ -135,6 +135,7 @@ cat <<EOF > /tmp/tokenvm.config
   "preferredBlocksPerSecond": 3,
   "verifySignatures": true,
   "storeTransactions": false,
+  "continuousProfilerDir": "",
   "logLevel": "${LOGLEVEL}",
   "stateSyncServerDelay": ${STATESYNC_DELAY}
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ava-labs/hypersdk
 go 1.20
 
 require (
-	github.com/ava-labs/avalanchego v1.10.2-0.20230519230054-b45966175ae8
+	github.com/ava-labs/avalanchego v1.10.2
 	github.com/cockroachdb/pebble v0.0.0-20230224221607-fccb83b60d5c
 	github.com/golang/mock v1.6.0
 	github.com/gorilla/rpc v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -52,8 +52,8 @@ github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/ava-labs/avalanchego v1.10.2-0.20230519230054-b45966175ae8 h1:8c/mKi4DnQbP+9BADAXE4fwgSLA+hCRE6jDRJH0fTcU=
-github.com/ava-labs/avalanchego v1.10.2-0.20230519230054-b45966175ae8/go.mod h1:OVfGwebZT9fD7gAT6t242xQteGSDyFar2SC4hMiVwBA=
+github.com/ava-labs/avalanchego v1.10.2 h1:kDM2xfQDaewueUCxJUujPlbNQ91gtJfXY9Z0CYthdRc=
+github.com/ava-labs/avalanchego v1.10.2/go.mod h1:PsNLfOc9FnsnoJ8CjauclvFy6BCSVZmT05I4c9rm4a4=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/gossiper/proposer.go
+++ b/gossiper/proposer.go
@@ -169,6 +169,10 @@ func (g *Proposer) TriggerGossip(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	txBlk, err := blk.LastTxBlock()
+	if err != nil {
+		return err
+	}
 	state, err := blk.State()
 	if err != nil {
 		return err
@@ -177,7 +181,7 @@ func (g *Proposer) TriggerGossip(ctx context.Context) error {
 		ctx,
 		g.vm.ChainID(),
 		now,
-		blk.LastTxBlock(),
+		txBlk,
 		g.vm.Tracer(),
 		g.vm.Rules(now),
 	)

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -320,6 +320,10 @@ func (th *Mempool[T]) SetMinTimestamp(ctx context.Context, t int64) []T {
 	return removed
 }
 
+// TODO: break build apart into:
+// * fetch of X txs (kept in pending map to avoid duplicate entry)
+// * pre-fetch state, iterate repeatedly until max time has elapsed our out of
+// txs
 func (th *Mempool[T]) Build(
 	ctx context.Context,
 	f func(context.Context, T) (cont bool, restore bool, removeAcct bool, err error),

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -322,6 +322,8 @@ func (th *Mempool[T]) SetMinTimestamp(ctx context.Context, t int64) []T {
 
 // TODO: break build apart into:
 // * fetch of X txs (kept in pending map to avoid duplicate entry)
+//   - could use MaxUnits to determine and try to build 1 tx block at a time
+//
 // * pre-fetch state, iterate repeatedly until max time has elapsed our out of
 // txs
 func (th *Mempool[T]) Build(

--- a/vm/dependencies.go
+++ b/vm/dependencies.go
@@ -35,7 +35,8 @@ type Config interface {
 	GetStateSyncParallelism() int
 	GetStateSyncMinBlocks() uint64
 	GetStateSyncServerDelay() time.Duration
-	GetBlockLRUSize() int
+	GetParsedBlockCacheSize() int
+	GetAcceptedBlockCacheSize() int
 	GetContinuousProfilerConfig() *profiler.Config
 	GetRootBlockPruneDiff() uint64
 	GetVerifySignatures() bool

--- a/vm/fees.go
+++ b/vm/fees.go
@@ -24,7 +24,10 @@ func (vm *VM) SuggestedFee(ctx context.Context) (uint64, error) {
 		return 0, err
 	}
 	preferred := rpreferred.(*chain.StatelessRootBlock)
-	txBlk := preferred.LastTxBlock()
+	txBlk, err := preferred.LastTxBlock()
+	if err != nil {
+		return 0, err
+	}
 
 	// We scale down unit price to prevent a spiral up in price
 	r := vm.c.Rules(time.Now().Unix())

--- a/vm/metrics.go
+++ b/vm/metrics.go
@@ -22,6 +22,7 @@ type Metrics struct {
 	stateChanges                  prometheus.Counter
 	stateOperations               prometheus.Counter
 	txBlocksMissing               prometheus.Counter
+	txBlocksDropped               prometheus.Counter
 	deletedTxBlocks               prometheus.Counter
 	earlyBuildStop                prometheus.Counter
 	txBlockBytesSent              prometheus.Counter
@@ -186,6 +187,11 @@ func newMetrics() (*prometheus.Registry, *Metrics, error) {
 			Name:      "tx_blocks_missing",
 			Help:      "number of tx blocks missing when root block is parsed",
 		}),
+		txBlocksDropped: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: "chain",
+			Name:      "tx_blocks_dropped",
+			Help:      "number of tx blocks dropped without being verified when root block is accepted",
+		}),
 		deletedTxBlocks: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: "chain",
 			Name:      "deleted_tx_blocks",
@@ -245,6 +251,7 @@ func newMetrics() (*prometheus.Registry, *Metrics, error) {
 		r.Register(m.stateChanges),
 		r.Register(m.stateOperations),
 		r.Register(m.txBlocksMissing),
+		r.Register(m.txBlocksDropped),
 		r.Register(m.deletedTxBlocks),
 		r.Register(m.mempoolSize),
 		r.Register(m.mempoolSizeAfterBuild),

--- a/vm/metrics.go
+++ b/vm/metrics.go
@@ -37,6 +37,7 @@ type Metrics struct {
 	txBlockVerify                 metric.Averager
 	txBlockIssuanceDiff           metric.Averager
 	rootBlockIssuanceDiff         metric.Averager
+	rootBlockAcceptanceDiff       metric.Averager
 }
 
 func newMetrics() (*prometheus.Registry, *Metrics, error) {
@@ -108,6 +109,15 @@ func newMetrics() (*prometheus.Registry, *Metrics, error) {
 	rootBlockIssuanceDiff, err := metric.NewAverager(
 		"chain",
 		"root_block_issuance_diff",
+		"delay for root block to be received after issuance",
+		r,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	rootBlockAcceptanceDiff, err := metric.NewAverager(
+		"chain",
+		"root_block_acceptance_diff",
 		"delay for root block to be received after issuance",
 		r,
 	)
@@ -211,14 +221,15 @@ func newMetrics() (*prometheus.Registry, *Metrics, error) {
 			Name:      "tx_block_bytes_received",
 			Help:      "tx block bytes received",
 		}),
-		rootCalculated:        rootCalculated,
-		commitState:           commitState,
-		waitSignatures:        waitSignatures,
-		buildBlock:            buildBlock,
-		verifyWait:            verifyWait,
-		txBlockVerify:         txBlockVerify,
-		txBlockIssuanceDiff:   txBlockIssuanceDiff,
-		rootBlockIssuanceDiff: rootBlockIssuanceDiff,
+		rootCalculated:          rootCalculated,
+		commitState:             commitState,
+		waitSignatures:          waitSignatures,
+		buildBlock:              buildBlock,
+		verifyWait:              verifyWait,
+		txBlockVerify:           txBlockVerify,
+		txBlockIssuanceDiff:     txBlockIssuanceDiff,
+		rootBlockIssuanceDiff:   rootBlockIssuanceDiff,
+		rootBlockAcceptanceDiff: rootBlockAcceptanceDiff,
 	}
 	errs := wrappers.Errs{}
 	errs.Add(

--- a/vm/metrics.go
+++ b/vm/metrics.go
@@ -10,31 +10,33 @@ import (
 )
 
 type Metrics struct {
-	unitsVerified         prometheus.Counter
-	unitsAccepted         prometheus.Counter
-	txsSubmitted          prometheus.Counter // includes gossip
-	txsVerified           prometheus.Counter
-	txBlocksVerified      prometheus.Counter
-	txsAccepted           prometheus.Counter
-	txBlocksAccepted      prometheus.Counter
-	stateChanges          prometheus.Counter
-	stateOperations       prometheus.Counter
-	txBlocksMissing       prometheus.Counter
-	deletedTxBlocks       prometheus.Counter
-	earlyBuildStop        prometheus.Counter
-	txBlockBytesSent      prometheus.Counter
-	txBlockBytesReceived  prometheus.Counter
-	mempoolSize           prometheus.Gauge
-	mempoolSizeAfterBuild prometheus.Gauge
-	acceptorDrift         prometheus.Gauge
-	rootCalculated        metric.Averager
-	commitState           metric.Averager
-	waitSignatures        metric.Averager
-	buildBlock            metric.Averager
-	verifyWait            metric.Averager
-	txBlockVerify         metric.Averager
-	txBlockIssuanceDiff   metric.Averager
-	rootBlockIssuanceDiff metric.Averager
+	unitsVerified                 prometheus.Counter
+	unitsAccepted                 prometheus.Counter
+	txsSubmitted                  prometheus.Counter // includes gossip
+	txsVerified                   prometheus.Counter
+	txBlocksVerified              prometheus.Counter
+	txBlocksVerifiedFailed        prometheus.Counter
+	txBlocksVerifiedFailedManager prometheus.Counter
+	txsAccepted                   prometheus.Counter
+	txBlocksAccepted              prometheus.Counter
+	stateChanges                  prometheus.Counter
+	stateOperations               prometheus.Counter
+	txBlocksMissing               prometheus.Counter
+	deletedTxBlocks               prometheus.Counter
+	earlyBuildStop                prometheus.Counter
+	txBlockBytesSent              prometheus.Counter
+	txBlockBytesReceived          prometheus.Counter
+	mempoolSize                   prometheus.Gauge
+	mempoolSizeAfterBuild         prometheus.Gauge
+	acceptorDrift                 prometheus.Gauge
+	rootCalculated                metric.Averager
+	commitState                   metric.Averager
+	waitSignatures                metric.Averager
+	buildBlock                    metric.Averager
+	verifyWait                    metric.Averager
+	txBlockVerify                 metric.Averager
+	txBlockIssuanceDiff           metric.Averager
+	rootBlockIssuanceDiff         metric.Averager
 }
 
 func newMetrics() (*prometheus.Registry, *Metrics, error) {
@@ -139,6 +141,16 @@ func newMetrics() (*prometheus.Registry, *Metrics, error) {
 			Name:      "tx_blocks_verified",
 			Help:      "number of tx blocks verified by vm",
 		}),
+		txBlocksVerifiedFailed: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: "vm",
+			Name:      "tx_blocks_verified_failed",
+			Help:      "number of tx blocks that fail verification",
+		}),
+		txBlocksVerifiedFailedManager: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: "vm",
+			Name:      "tx_blocks_verified_failed_manager",
+			Help:      "number of tx blocks that fail verification in manager",
+		}),
 		txsAccepted: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: "vm",
 			Name:      "txs_accepted",
@@ -215,6 +227,8 @@ func newMetrics() (*prometheus.Registry, *Metrics, error) {
 		r.Register(m.txsSubmitted),
 		r.Register(m.txsVerified),
 		r.Register(m.txBlocksVerified),
+		r.Register(m.txBlocksVerifiedFailed),
+		r.Register(m.txBlocksVerifiedFailedManager),
 		r.Register(m.txsAccepted),
 		r.Register(m.txBlocksAccepted),
 		r.Register(m.stateChanges),

--- a/vm/resolutions.go
+++ b/vm/resolutions.go
@@ -83,7 +83,7 @@ func (vm *VM) IsBootstrapped() bool {
 	return vm.bootstrapped.Get()
 }
 
-func (vm *VM) State() (*merkledb.Database, error) {
+func (vm *VM) State() (merkledb.MerkleDB, error) {
 	// As soon as synced (before ready), we can safely request data from the db.
 	if !vm.StateReady() {
 		return nil, ErrStateMissing

--- a/vm/resolutions.go
+++ b/vm/resolutions.go
@@ -429,6 +429,10 @@ func (vm *VM) RecordRootBlockIssuanceDiff(t time.Duration) {
 	vm.metrics.rootBlockIssuanceDiff.Observe(float64(t))
 }
 
+func (vm *VM) RecordRootBlockAcceptanceDiff(t time.Duration) {
+	vm.metrics.rootBlockAcceptanceDiff.Observe(float64(t))
+}
+
 func (vm *VM) RecordStateChanges(c int) {
 	vm.metrics.stateChanges.Add(float64(c))
 }

--- a/vm/tx_block_manager.go
+++ b/vm/tx_block_manager.go
@@ -605,6 +605,7 @@ func (c *TxBlockManager) handleBlock(ctx context.Context, msg []byte, expected *
 }
 
 // TODO: add lock to ensure only one async verify job happens at once
+// TODO: also grab lock when issuing blocks?
 func (c *TxBlockManager) VerifyAll(blkID ids.ID) {
 	next := []ids.ID{blkID}
 	for len(next) > 0 {

--- a/vm/tx_block_manager.go
+++ b/vm/tx_block_manager.go
@@ -197,6 +197,10 @@ func (c *TxBlockMap) SetMin(h uint64) []ids.ID {
 		}
 		c.bh.Pop()
 		for chunkID := range b.Item.items {
+			item := c.items[chunkID]
+			if !item.verified.Load() {
+				c.vm.metrics.txBlocksDropped.Inc()
+			}
 			delete(c.items, chunkID)
 			evicted = append(evicted, chunkID)
 		}

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -62,7 +62,7 @@ type VM struct {
 
 	gossiper       gossiper.Gossiper
 	rawStateDB     database.Database
-	stateDB        *merkledb.Database
+	stateDB        merkledb.MerkleDB
 	vmDB           database.Database
 	handlers       Handlers
 	actionRegistry chain.ActionRegistry


### PR DESCRIPTION
- [ ] Ensure we do sanity checks before prefetching state
- [ ] Clear all verification state when block is accepted to free memory faster
- [ ] change verify block gossip check to be build instead (need to gossip even if will build soon if low activity)
- [ ] ensure that we only verify a block once at a time
- [x] add metric for invalid tx block
- [x] add metric for root block issuance -> accept
- [ ] Add hash checksum to gossip 
- [ ] If can't fetch block in root, try to trigger verify (stopgap)