### PR TITLE
Rewrite verify loop

### DIFF
--- a/chain/dependencies.go
+++ b/chain/dependencies.go
@@ -61,6 +61,7 @@ type VM interface {
 	IssueTxBlock(context.Context, *StatelessTxBlock)
 	RequireTxBlocks(context.Context, uint64, []ids.ID) int
 	GetStatelessTxBlock(context.Context, ids.ID, uint64) (*StatelessTxBlock, error)
+	RetryVerify(context.Context, []ids.ID)
 
 	LastAcceptedBlock() *StatelessRootBlock
 	GetStatelessRootBlock(context.Context, ids.ID) (*StatelessRootBlock, error)

--- a/chain/root_block.go
+++ b/chain/root_block.go
@@ -300,6 +300,9 @@ func (b *StatelessRootBlock) innerVerify(ctx context.Context) error {
 	for i, blkID := range b.Txs {
 		blk, err := b.vm.GetStatelessTxBlock(ctx, blkID, b.MinTxHght+uint64(i))
 		if err != nil {
+			// TODO: stopgap that should be removed
+			b.vm.Logger().Warn("missing tx block when starting verify", zap.Stringer("blkID", blkID))
+			b.vm.RetryVerify(ctx, b.Txs)
 			return err
 		}
 		if blk.Tmstmp != b.Tmstmp {

--- a/chain/root_block.go
+++ b/chain/root_block.go
@@ -533,6 +533,7 @@ func (b *StatelessRootBlock) MaxTxHght() uint64 {
 	if l == 0 {
 		return b.MinTxHght
 	}
+	// 10 + [10,11,12,13]
 	return b.MinTxHght + uint64(l-1)
 }
 

--- a/examples/tokenvm/cmd/token-cli/cmd/prometheus.go
+++ b/examples/tokenvm/cmd/token-cli/cmd/prometheus.go
@@ -127,6 +127,9 @@ var generatePrometheusCmd = &cobra.Command{
 		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_chain_tx_block_verify_sum[5s])/increase(avalanche_%s_vm_hyper_sdk_chain_tx_block_verify_count[5s])/1000000", chainID, chainID))
 		utils.Outf("{{yellow}}verify tx block (ms):{{/}} %s\n", panels[len(panels)-1])
 
+		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_vm_add_verify_diff_sum[5s])/increase(avalanche_%s_vm_hyper_sdk_vm_add_verify_diff_count[5s])/1000000", chainID, chainID))
+		utils.Outf("{{yellow}}add verify diff (ms):{{/}} %s\n", panels[len(panels)-1])
+
 		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_chain_verify_wait_sum[5s])/increase(avalanche_%s_vm_hyper_sdk_chain_verify_wait_count[5s])/1000000", chainID, chainID))
 		utils.Outf("{{yellow}}verify wait (ms):{{/}} %s\n", panels[len(panels)-1])
 

--- a/vm/metrics.go
+++ b/vm/metrics.go
@@ -39,6 +39,7 @@ type Metrics struct {
 	txBlockIssuanceDiff           metric.Averager
 	rootBlockIssuanceDiff         metric.Averager
 	rootBlockAcceptanceDiff       metric.Averager
+	addVerifyDiff                 metric.Averager
 }
 
 func newMetrics() (*prometheus.Registry, *Metrics, error) {
@@ -120,6 +121,15 @@ func newMetrics() (*prometheus.Registry, *Metrics, error) {
 		"chain",
 		"root_block_acceptance_diff",
 		"delay for root block to be received after issuance",
+		r,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	addVerifyDiff, err := metric.NewAverager(
+		"vm",
+		"add_verify_diff",
+		"time spent waiting to verify a tx block",
 		r,
 	)
 	if err != nil {
@@ -236,6 +246,7 @@ func newMetrics() (*prometheus.Registry, *Metrics, error) {
 		txBlockIssuanceDiff:     txBlockIssuanceDiff,
 		rootBlockIssuanceDiff:   rootBlockIssuanceDiff,
 		rootBlockAcceptanceDiff: rootBlockAcceptanceDiff,
+		addVerifyDiff:           addVerifyDiff,
 	}
 	errs := wrappers.Errs{}
 	errs.Add(

--- a/vm/resolutions.go
+++ b/vm/resolutions.go
@@ -464,7 +464,7 @@ func (vm *VM) RetryVerify(ctx context.Context, blks []ids.ID) {
 func (vm *VM) GetStatelessTxBlock(ctx context.Context, blkID ids.ID, hght uint64) (*chain.StatelessTxBlock, error) {
 	blk := vm.txBlockManager.txBlocks.Get(blkID)
 	if blk != nil {
-		if !blk.verified.Load() {
+		if !blk.verified {
 			return nil, fmt.Errorf("blk not verified; height=%d id=%s", blk.blk.Hght, blkID)
 		}
 		return blk.blk, nil

--- a/vm/resolutions.go
+++ b/vm/resolutions.go
@@ -457,6 +457,10 @@ func (vm *VM) RequireTxBlocks(ctx context.Context, minHght uint64, blks []ids.ID
 	return vm.txBlockManager.RequireTxBlocks(ctx, minHght, blks)
 }
 
+func (vm *VM) RetryVerify(ctx context.Context, blks []ids.ID) {
+	vm.txBlockManager.RetryVerify(ctx, blks)
+}
+
 func (vm *VM) GetStatelessTxBlock(ctx context.Context, blkID ids.ID, hght uint64) (*chain.StatelessTxBlock, error) {
 	blk := vm.txBlockManager.txBlocks.Get(blkID)
 	if blk != nil {

--- a/vm/tx_block_manager.go
+++ b/vm/tx_block_manager.go
@@ -3,6 +3,7 @@ package vm
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math/rand"
 	"sync"
 	"sync/atomic"
@@ -346,9 +347,9 @@ func (c *TxBlockManager) SetMin(min uint64) {
 //
 // Ensure chunks are persisted before calling this method
 func (c *TxBlockManager) Accept(height uint64) {
-	evicted := c.txBlocks.SetMin(height)
-	c.update <- nil
-	c.vm.snowCtx.Log.Info("evicted chunks from memory", zap.Int("n", len(evicted)))
+	// evicted := c.txBlocks.SetMin(height)
+	// c.update <- nil
+	// c.vm.snowCtx.Log.Info("evicted chunks from memory", zap.Int("n", len(evicted)))
 }
 
 // TODO: pre-store chunks on disk if bootstrapping
@@ -627,7 +628,7 @@ func (c *TxBlockManager) VerifyAll(blkID ids.ID) {
 func (c *TxBlockManager) Verify(blkID ids.ID) error {
 	blk := c.txBlocks.Get(blkID)
 	if blk == nil {
-		return errors.New("tx block is missing")
+		return fmt.Errorf("tx block is missing: %v", blkID)
 	}
 	if blk.verified.Load() {
 		return errors.New("tx block already verified")

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -711,6 +711,7 @@ func (vm *VM) BuildBlockWithContext(
 	return vm.buildBlock(ctx, blockContext)
 }
 
+// TODO: batch submit to better amortize block context overhead
 func (vm *VM) Submit(
 	ctx context.Context,
 	verifySig bool,


### PR DESCRIPTION
- [ ] reduce app concurrency parallelism
- [x] reduce sending of tx block updates
- [x] ensure no lock held during verify in tx block manager, switch verified to normal boolean instead of atomic