### PR TITLE
lock-free mempool

### DIFF
--- a/builder/time.go
+++ b/builder/time.go
@@ -5,6 +5,7 @@ package builder
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/ava-labs/avalanchego/snow/engine/common"
@@ -62,6 +63,10 @@ func (b *Time) shouldBuild(ctx context.Context) (bool, error) {
 	}
 	now := time.Now().Unix()
 	since := int(now - preferredBlk.Tmstmp)
+	if since < 0 {
+		// TODO: better handle this (can panic without protection)
+		return false, errors.New("preferred block greater than current")
+	}
 	newRollupWindow, err := window.Roll(preferredBlk.BlockWindow, since)
 	if err != nil {
 		return false, err

--- a/chain/builder.go
+++ b/chain/builder.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 	smblock "github.com/ava-labs/avalanchego/snow/engine/snowman/block"
 	"github.com/ava-labs/avalanchego/utils/units"
+	"github.com/ava-labs/hypersdk/consts"
 	"go.uber.org/zap"
 )
 
@@ -146,7 +147,7 @@ func BuildBlock(
 			// Determine if we need to create a new TxBlock
 			//
 			// TODO: handle case where tx is larger than max size of TxBlock
-			if txBlockSize+nextSize > 256*units.KiB {
+			if txBlockSize+nextSize > consts.NetworkSizeLimit-32*units.KiB {
 				txBlock.Issued = time.Now().UnixMilli()
 				if err := txBlock.initializeBuilt(ctx); err != nil {
 					restorable = append(restorable, txs[i:]...)

--- a/chain/builder.go
+++ b/chain/builder.go
@@ -96,7 +96,7 @@ func BuildBlock(
 		func(fctx context.Context, next *Transaction) (cont bool, restore bool, err error) {
 			txsAttempted++
 			if next.Base.Timestamp < oldestAllowed {
-				return txBlock != nil, false, nil
+				return true, false, nil
 			}
 
 			// Ensure we can process if transaction includes a warp message
@@ -105,7 +105,7 @@ func BuildBlock(
 					"dropping pending warp message because no context provided",
 					zap.Stringer("txID", next.ID()),
 				)
-				return txBlock != nil, true, nil
+				return true, true, nil
 			}
 
 			// Skip warp message if at max
@@ -114,7 +114,7 @@ func BuildBlock(
 					"dropping pending warp message because already have MaxWarpMessages",
 					zap.Stringer("txID", next.ID()),
 				)
-				return txBlock != nil, true, nil
+				return true, true, nil
 			}
 
 			// Check for repeats
@@ -126,7 +126,7 @@ func BuildBlock(
 				return false, true, err
 			}
 			if dup {
-				return txBlock != nil, false, nil
+				return true, false, nil
 			}
 
 			// TODO: verify units space

--- a/chain/builder.go
+++ b/chain/builder.go
@@ -135,7 +135,7 @@ func BuildBlock(
 			// Determine if we need to create a new TxBlock
 			//
 			// TODO: handle case where tx is larger than max size of TxBlock
-			if txBlockSize+nextSize > 512*units.KiB {
+			if txBlockSize+nextSize > 1*units.MiB {
 				txBlock.Issued = time.Now().UnixMilli()
 				if err := txBlock.initializeBuilt(ctx); err != nil {
 					return false, true, err

--- a/chain/builder.go
+++ b/chain/builder.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 	smblock "github.com/ava-labs/avalanchego/snow/engine/snowman/block"
 	"github.com/ava-labs/avalanchego/utils/units"
-	"github.com/ava-labs/hypersdk/consts"
 	"go.uber.org/zap"
 )
 
@@ -136,7 +135,7 @@ func BuildBlock(
 			// Determine if we need to create a new TxBlock
 			//
 			// TODO: handle case where tx is larger than max size of TxBlock
-			if txBlockSize+nextSize > consts.NetworkSizeLimit-32*units.KiB {
+			if txBlockSize+nextSize > 512*units.KiB {
 				txBlock.Issued = time.Now().UnixMilli()
 				if err := txBlock.initializeBuilt(ctx); err != nil {
 					return false, true, err

--- a/chain/builder.go
+++ b/chain/builder.go
@@ -96,7 +96,7 @@ func BuildBlock(
 		func(fctx context.Context, next *Transaction) (cont bool, restore bool, err error) {
 			txsAttempted++
 			if next.Base.Timestamp < oldestAllowed {
-				return true, false, nil
+				return txBlock != nil, false, nil
 			}
 
 			// Ensure we can process if transaction includes a warp message
@@ -105,7 +105,7 @@ func BuildBlock(
 					"dropping pending warp message because no context provided",
 					zap.Stringer("txID", next.ID()),
 				)
-				return true, true, nil
+				return txBlock != nil, true, nil
 			}
 
 			// Skip warp message if at max
@@ -114,7 +114,7 @@ func BuildBlock(
 					"dropping pending warp message because already have MaxWarpMessages",
 					zap.Stringer("txID", next.ID()),
 				)
-				return true, true, nil
+				return txBlock != nil, true, nil
 			}
 
 			// Check for repeats
@@ -126,7 +126,7 @@ func BuildBlock(
 				return false, true, err
 			}
 			if dup {
-				return true, false, nil
+				return txBlock != nil, false, nil
 			}
 
 			// TODO: verify units space

--- a/chain/builder.go
+++ b/chain/builder.go
@@ -92,6 +92,8 @@ func BuildBlock(
 
 	mempoolErr := mempool.Build(
 		ctx,
+		vm.GetMinBuildTime(),
+		vm.GetMaxBuildTime(),
 		func(fctx context.Context, next *Transaction) (cont bool, restore bool, err error) {
 			txsAttempted++
 			if next.Base.Timestamp < oldestAllowed {
@@ -159,7 +161,7 @@ func BuildBlock(
 			}
 			txBlockSize += nextSize
 			txsAdded++
-			return txBlock != nil && time.Since(start) < vm.GetMaxBuildTime(), false, nil
+			return txBlock != nil, false, nil
 		},
 	)
 	if mempoolErr != nil {

--- a/chain/dependencies.go
+++ b/chain/dependencies.go
@@ -98,6 +98,8 @@ type Mempool interface {
 	Add(context.Context, []*Transaction)
 	Build(
 		context.Context,
+		time.Duration,
+		time.Duration,
 		func(context.Context, *Transaction) (bool /* continue */, bool /* restore */, error),
 	) error
 }

--- a/chain/dependencies.go
+++ b/chain/dependencies.go
@@ -91,6 +91,9 @@ type VM interface {
 	RecordEarlyBuildStop()
 	RecordMempoolSizeAfterBuild(int)
 	RecordTxFailedExecution()
+	RecordBuildSelect(time.Duration)
+	RecordBuildMarshal(time.Duration)
+	RecordBuildRepeat(time.Duration)
 }
 
 type Mempool interface {

--- a/chain/dependencies.go
+++ b/chain/dependencies.go
@@ -98,12 +98,8 @@ type Mempool interface {
 	Add(context.Context, []*Transaction)
 	Build(
 		context.Context,
-		func(context.Context, *Transaction) (bool /* continue */, bool /* restore */, bool /* remove account */, error),
+		func(context.Context, *Transaction) (bool /* continue */, bool /* restore */, error),
 	) error
-	StartBuild(context.Context)
-	LeaseItems(context.Context, int) []*Transaction
-	ClearLease(context.Context, []*Transaction, []*Transaction)
-	FinishBuild(context.Context)
 }
 
 type Database interface {

--- a/chain/tx_block.go
+++ b/chain/tx_block.go
@@ -249,7 +249,7 @@ func (b *StatelessTxBlock) IsRepeat(
 
 	// If we are at an accepted block or genesis, we can use the emap on the VM
 	// instead of checking each block
-	if b.Hght <= b.vm.LastAcceptedBlock().MaxTxHght() {
+	if b.Hght <= b.vm.LastProcessedBlock().MaxTxHght() {
 		return b.vm.IsRepeat(ctx, txs), nil
 	}
 

--- a/chain/tx_block.go
+++ b/chain/tx_block.go
@@ -210,6 +210,7 @@ func (b *StatelessTxBlock) Accept(ctx context.Context) error {
 	ctx, span := b.vm.Tracer().Start(ctx, "StatelessTxBlock.Accept")
 	defer span.End()
 
+	// we cannot clear any memory here because the block will be processed AFTER acceptance
 	return nil
 }
 

--- a/chain/tx_block.go
+++ b/chain/tx_block.go
@@ -210,7 +210,6 @@ func (b *StatelessTxBlock) Accept(ctx context.Context) error {
 	ctx, span := b.vm.Tracer().Start(ctx, "StatelessTxBlock.Accept")
 	defer span.End()
 
-	b.txsSet = nil // only used for replay protection when processing
 	return nil
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -48,5 +48,5 @@ func (c *Config) GetContinuousProfilerConfig() *profiler.Config {
 
 func (c *Config) GetRootBlockPruneDiff() uint64  { return 1024 }
 func (c *Config) GetVerifySignatures() bool      { return true }
-func (c *Config) GetMinBuildTime() time.Duration { return 128 * time.Millisecond } // still need to limit with units to avoid DoS on verify
-func (c *Config) GetMaxBuildTime() time.Duration { return 256 * time.Millisecond } // still need to limit with units to avoid DoS on verify
+func (c *Config) GetMinBuildTime() time.Duration { return 256 * time.Millisecond } // still need to limit with units to avoid DoS on verify
+func (c *Config) GetMaxBuildTime() time.Duration { return 384 * time.Millisecond } // still need to limit with units to avoid DoS on verify

--- a/config/config.go
+++ b/config/config.go
@@ -48,5 +48,5 @@ func (c *Config) GetContinuousProfilerConfig() *profiler.Config {
 
 func (c *Config) GetRootBlockPruneDiff() uint64  { return 1024 }
 func (c *Config) GetVerifySignatures() bool      { return true }
-func (c *Config) GetMinBuildTime() time.Duration { return 256 * time.Millisecond } // still need to limit with units to avoid DoS on verify
-func (c *Config) GetMaxBuildTime() time.Duration { return 257 * time.Millisecond } // still need to limit with units to avoid DoS on verify
+func (c *Config) GetMinBuildTime() time.Duration { return 128 * time.Millisecond } // still need to limit with units to avoid DoS on verify
+func (c *Config) GetMaxBuildTime() time.Duration { return 256 * time.Millisecond } // still need to limit with units to avoid DoS on verify

--- a/examples/tokenvm/DEVNETS.md
+++ b/examples/tokenvm/DEVNETS.md
@@ -162,7 +162,7 @@ avalanchego_config:
   consensus-on-accept-gossip-non-validator-size: 0
   consensus-on-accept-gossip-peer-size: 10
   consensus-accepted-frontier-gossip-peer-size: 0
-  consensus-app-concurrency: 512
+  consensus-app-concurrency: 16
   network-compression-type: none
 ```
 

--- a/examples/tokenvm/DEVNETS.md
+++ b/examples/tokenvm/DEVNETS.md
@@ -162,7 +162,7 @@ avalanchego_config:
   consensus-on-accept-gossip-non-validator-size: 0
   consensus-on-accept-gossip-peer-size: 10
   consensus-accepted-frontier-gossip-peer-size: 0
-  consensus-app-concurrency: 16
+  consensus-app-concurrency: 128
   network-compression-type: none
 ```
 
@@ -173,6 +173,11 @@ CloudWatch. To ingest all metrics, change the configured filters in
 ```yaml
 filters:
   - regex: ^*$
+```
+
+#### Disable Metrics
+```yaml
+metrics_fetch_interval_seconds: 0
 ```
 
 ### Step 6: Apply Local Network Deploy

--- a/examples/tokenvm/DEVNETS.md
+++ b/examples/tokenvm/DEVNETS.md
@@ -178,6 +178,7 @@ filters:
 #### Disable Metrics
 ```yaml
 metrics_fetch_interval_seconds: 0
+disable_logs_auto_removal: true
 ```
 
 ### Step 6: Apply Local Network Deploy

--- a/examples/tokenvm/DEVNETS.md
+++ b/examples/tokenvm/DEVNETS.md
@@ -162,7 +162,7 @@ avalanchego_config:
   consensus-on-accept-gossip-non-validator-size: 0
   consensus-on-accept-gossip-peer-size: 10
   consensus-accepted-frontier-gossip-peer-size: 0
-  consensus-app-concurrency: 128
+  consensus-app-concurrency: 32
   network-compression-type: none
 ```
 
@@ -178,7 +178,6 @@ filters:
 #### Disable Metrics
 ```yaml
 metrics_fetch_interval_seconds: 0
-disable_logs_auto_removal: true
 ```
 
 ### Step 6: Apply Local Network Deploy

--- a/examples/tokenvm/cmd/token-cli/cmd/prometheus.go
+++ b/examples/tokenvm/cmd/token-cli/cmd/prometheus.go
@@ -145,13 +145,16 @@ var generatePrometheusCmd = &cobra.Command{
 		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_chain_root_block_acceptance_diff_sum[5s])/increase(avalanche_%s_vm_hyper_sdk_chain_root_block_acceptance_diff_count[5s])/1000000", chainID, chainID))
 		utils.Outf("{{yellow}}root block acceptance diff (ms):{{/}} %s\n", panels[len(panels)-1])
 
-		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_chain_tx_blocks_missing[5s])", chainID))
+		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_chain_request_fulfilled_by_gossip[5s])/5", chainID))
+		utils.Outf("{{yellow}}request fulfilled by gossip:{{/}} %s\n", panels[len(panels)-1])
+
+		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_chain_tx_blocks_missing[5s])/5", chainID))
 		utils.Outf("{{yellow}}missing tx blocks:{{/}} %s\n", panels[len(panels)-1])
 
-		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_chain_tx_blocks_dropped[5s])", chainID))
+		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_chain_tx_blocks_dropped[5s])/5", chainID))
 		utils.Outf("{{yellow}}dropped tx blocks:{{/}} %s\n", panels[len(panels)-1])
 
-		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_chain_deleted_tx_blocks[5s])", chainID))
+		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_chain_deleted_tx_blocks[5s])/5", chainID))
 		utils.Outf("{{yellow}}deleted tx blocks:{{/}} %s\n", panels[len(panels)-1])
 
 		panels = append(panels, fmt.Sprintf("avalanche_%s_vm_hyper_sdk_chain_mempool_size", chainID))

--- a/examples/tokenvm/cmd/token-cli/cmd/prometheus.go
+++ b/examples/tokenvm/cmd/token-cli/cmd/prometheus.go
@@ -124,6 +124,15 @@ var generatePrometheusCmd = &cobra.Command{
 		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_chain_build_block_sum[5s])/increase(avalanche_%s_vm_hyper_sdk_chain_build_block_count[5s])/1000000", chainID, chainID))
 		utils.Outf("{{yellow}}build block (ms):{{/}} %s\n", panels[len(panels)-1])
 
+		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_chain_build_select_sum[5s])/increase(avalanche_%s_vm_hyper_sdk_chain_build_select_count[5s])/1000000", chainID, chainID))
+		utils.Outf("{{yellow}}build block (select) (ms):{{/}} %s\n", panels[len(panels)-1])
+
+		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_chain_build_marshal_sum[5s])/increase(avalanche_%s_vm_hyper_sdk_chain_build_marshal_count[5s])/1000000", chainID, chainID))
+		utils.Outf("{{yellow}}build block (marshal) (ms):{{/}} %s\n", panels[len(panels)-1])
+
+		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_chain_build_repeat_sum[5s])/increase(avalanche_%s_vm_hyper_sdk_chain_build_repeat_count[5s])/1000000", chainID, chainID))
+		utils.Outf("{{yellow}}build block (repeat) (ms):{{/}} %s\n", panels[len(panels)-1])
+
 		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_chain_early_build_stop[5s])", chainID))
 		utils.Outf("{{yellow}}early build stop:{{/}} %s\n", panels[len(panels)-1])
 

--- a/examples/tokenvm/cmd/token-cli/cmd/prometheus.go
+++ b/examples/tokenvm/cmd/token-cli/cmd/prometheus.go
@@ -169,6 +169,9 @@ var generatePrometheusCmd = &cobra.Command{
 		panels = append(panels, fmt.Sprintf("sum(increase(avalanche_%s_vm_hyper_sdk_chain_txs_attempted[5s])/5)", chainID))
 		utils.Outf("{{yellow}}txs attempted:{{/}} %s\n", panels[len(panels)-1])
 
+		panels = append(panels, fmt.Sprintf("sum(increase(avalanche_%s_vm_hyper_sdk_chain_tx_gossip_triggered[5s])/5)", chainID))
+		utils.Outf("{{yellow}}tx gossip triggered:{{/}} %s\n", panels[len(panels)-1])
+
 		panels = append(panels, fmt.Sprintf("avalanche_%s_vm_hyper_sdk_chain_acceptor_drift", chainID))
 		utils.Outf("{{yellow}}acceptor drift:{{/}} %s\n", panels[len(panels)-1])
 

--- a/examples/tokenvm/tests/e2e/e2e_test.go
+++ b/examples/tokenvm/tests/e2e/e2e_test.go
@@ -207,7 +207,7 @@ var _ = ginkgo.BeforeSuite(func() {
 				"consensus-on-accept-gossip-validator-size":"10",
 				"consensus-on-accept-gossip-peer-size":"10",
 				"network-compression-type":"none",
-				"consensus-app-concurrency":"128"
+				"consensus-app-concurrency":"32"
 			}`),
 	)
 	cancel()

--- a/examples/tokenvm/tests/e2e/e2e_test.go
+++ b/examples/tokenvm/tests/e2e/e2e_test.go
@@ -207,7 +207,7 @@ var _ = ginkgo.BeforeSuite(func() {
 				"consensus-on-accept-gossip-validator-size":"10",
 				"consensus-on-accept-gossip-peer-size":"10",
 				"network-compression-type":"none",
-				"consensus-app-concurrency":"16"
+				"consensus-app-concurrency":"128"
 			}`),
 	)
 	cancel()

--- a/examples/tokenvm/tests/e2e/e2e_test.go
+++ b/examples/tokenvm/tests/e2e/e2e_test.go
@@ -207,7 +207,7 @@ var _ = ginkgo.BeforeSuite(func() {
 				"consensus-on-accept-gossip-validator-size":"10",
 				"consensus-on-accept-gossip-peer-size":"10",
 				"network-compression-type":"none",
-				"consensus-app-concurrency":"512"
+				"consensus-app-concurrency":"16"
 			}`),
 	)
 	cancel()

--- a/gossiper/dependencies.go
+++ b/gossiper/dependencies.go
@@ -26,4 +26,5 @@ type VM interface {
 	NodeID() ids.NodeID
 	Rules(int64) chain.Rules
 	Submit(ctx context.Context, verify bool, txs []*chain.Transaction) []error
+	RecordGossipTrigger()
 }

--- a/gossiper/manual.go
+++ b/gossiper/manual.go
@@ -37,6 +37,8 @@ func (g *Manual) Run(appSender common.AppSender) {
 }
 
 func (g *Manual) TriggerGossip(ctx context.Context) error {
+	g.vm.RecordGossipTrigger()
+
 	// Gossip highest paying txs
 	txs := []*chain.Transaction{}
 	size := 0

--- a/gossiper/manual.go
+++ b/gossiper/manual.go
@@ -43,6 +43,8 @@ func (g *Manual) TriggerGossip(ctx context.Context) error {
 	now := time.Now().Unix()
 	mempoolErr := g.vm.Mempool().Build(
 		ctx,
+		0,
+		20*time.Millisecond,
 		func(ictx context.Context, next *chain.Transaction) (cont bool, restore bool, err error) {
 			// Remove txs that are expired
 			if next.Base.Timestamp < now {

--- a/gossiper/manual.go
+++ b/gossiper/manual.go
@@ -43,20 +43,20 @@ func (g *Manual) TriggerGossip(ctx context.Context) error {
 	now := time.Now().Unix()
 	mempoolErr := g.vm.Mempool().Build(
 		ctx,
-		func(ictx context.Context, next *chain.Transaction) (cont bool, restore bool, removeAcct bool, err error) {
+		func(ictx context.Context, next *chain.Transaction) (cont bool, restore bool, err error) {
 			// Remove txs that are expired
 			if next.Base.Timestamp < now {
-				return true, false, false, nil
+				return true, false, nil
 			}
 
 			nextSize := next.Size()
 			if size+nextSize > consts.NetworkSizeLimit-4_096 {
 				// Attempt to mirror the function of building a block without execution
-				return false, true, false, nil
+				return false, true, nil
 			}
 			txs = append(txs, next)
 			size += nextSize
-			return true, true, false, nil
+			return true, true, nil
 		},
 	)
 	if mempoolErr != nil {

--- a/gossiper/proposer.go
+++ b/gossiper/proposer.go
@@ -170,6 +170,8 @@ func (g *Proposer) TriggerGossip(ctx context.Context) error {
 	}
 	mempoolErr := g.vm.Mempool().Build(
 		ctx,
+		0,
+		20*time.Millisecond,
 		func(ictx context.Context, next *chain.Transaction) (cont bool, restore bool, err error) {
 			// Remove txs that are expired
 			if next.Base.Timestamp < now {

--- a/gossiper/proposer.go
+++ b/gossiper/proposer.go
@@ -170,16 +170,16 @@ func (g *Proposer) TriggerGossip(ctx context.Context) error {
 	}
 	mempoolErr := g.vm.Mempool().Build(
 		ctx,
-		func(ictx context.Context, next *chain.Transaction) (cont bool, restore bool, removeAcct bool, err error) {
+		func(ictx context.Context, next *chain.Transaction) (cont bool, restore bool, err error) {
 			// Remove txs that are expired
 			if next.Base.Timestamp < now {
-				return true, false, false, nil
+				return true, false, nil
 			}
 
 			// Don't gossip txs that are about to expire
 			life := next.Base.Timestamp - now
 			if life < g.cfg.GossipMinLife {
-				return true, true, false, nil
+				return true, true, nil
 			}
 
 			// Don't gossip txs we received from other nodes (original gossiper will
@@ -189,17 +189,17 @@ func (g *Proposer) TriggerGossip(ctx context.Context) error {
 			// We still keep these transactions in our mempool as they may still be
 			// the highest-paying transaction to execute at a given time.
 			if _, has := g.receivedTxs.Get(next.ID()); has {
-				return true, true, false, nil
+				return true, true, nil
 			}
 
 			// Gossip up to [consts.NetworkSizeLimit]
 			txSize := next.Size()
 			if txSize+size > g.cfg.GossipMaxSize {
-				return false, true, false, nil
+				return false, true, nil
 			}
 			txs = append(txs, next)
 			size += txSize
-			return true, true, false, nil
+			return true, true, nil
 		},
 	)
 	if mempoolErr != nil {

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -130,7 +130,7 @@ func (th *Mempool[T]) Build(
 		stop bool
 	)
 
-	for !stop || time.Since(start) > maxBuildTime {
+	for !stop && time.Since(start) < maxBuildTime {
 		select {
 		case next := <-th.c:
 			vmStart := time.Now()
@@ -153,6 +153,8 @@ func (th *Mempool[T]) Build(
 	}
 
 	// Restore unused items
+	//
+	// TODO: this could block
 	for _, item := range restorableItems {
 		th.c <- item
 	}

--- a/vm/metrics.go
+++ b/vm/metrics.go
@@ -29,6 +29,7 @@ type Metrics struct {
 	txFailedExecution             prometheus.Counter
 	txsAttempted                  prometheus.Counter
 	txGossipTriggered             prometheus.Counter
+	requestFulfilledByGossip      prometheus.Counter
 	mempoolSize                   prometheus.Gauge
 	mempoolSizeAfterBuild         prometheus.Gauge
 	acceptorDrift                 prometheus.Gauge
@@ -219,6 +220,11 @@ func newMetrics() (*prometheus.Registry, *Metrics, error) {
 			Name:      "tx_gossip_triggered",
 			Help:      "number of times we attempt to gossip",
 		}),
+		requestFulfilledByGossip: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: "chain",
+			Name:      "request_fulfilled_by_gossip",
+			Help:      "number of times tx block request fulfilled by gossip",
+		}),
 		mempoolSize: prometheus.NewGauge(prometheus.GaugeOpts{
 			Namespace: "chain",
 			Name:      "mempool_size",
@@ -278,6 +284,7 @@ func newMetrics() (*prometheus.Registry, *Metrics, error) {
 		r.Register(m.txFailedExecution),
 		r.Register(m.txGossipTriggered),
 		r.Register(m.txsAttempted),
+		r.Register(m.requestFulfilledByGossip),
 		r.Register(m.mempoolSize),
 		r.Register(m.mempoolSizeAfterBuild),
 		r.Register(m.acceptorDrift),

--- a/vm/metrics.go
+++ b/vm/metrics.go
@@ -28,6 +28,7 @@ type Metrics struct {
 	txBlockBytesReceived          prometheus.Counter
 	txFailedExecution             prometheus.Counter
 	txsAttempted                  prometheus.Counter
+	txGossipTriggered             prometheus.Counter
 	mempoolSize                   prometheus.Gauge
 	mempoolSizeAfterBuild         prometheus.Gauge
 	acceptorDrift                 prometheus.Gauge
@@ -213,6 +214,11 @@ func newMetrics() (*prometheus.Registry, *Metrics, error) {
 			Name:      "txs_attempted",
 			Help:      "number of txs evaluated when building",
 		}),
+		txGossipTriggered: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: "chain",
+			Name:      "tx_gossip_triggered",
+			Help:      "number of times we attempt to gossip",
+		}),
 		mempoolSize: prometheus.NewGauge(prometheus.GaugeOpts{
 			Namespace: "chain",
 			Name:      "mempool_size",
@@ -270,6 +276,7 @@ func newMetrics() (*prometheus.Registry, *Metrics, error) {
 		r.Register(m.txBlocksDropped),
 		r.Register(m.deletedTxBlocks),
 		r.Register(m.txFailedExecution),
+		r.Register(m.txGossipTriggered),
 		r.Register(m.txsAttempted),
 		r.Register(m.mempoolSize),
 		r.Register(m.mempoolSizeAfterBuild),

--- a/vm/metrics.go
+++ b/vm/metrics.go
@@ -43,6 +43,9 @@ type Metrics struct {
 	rootBlockIssuanceDiff         metric.Averager
 	rootBlockAcceptanceDiff       metric.Averager
 	addVerifyDiff                 metric.Averager
+	buildSelect                   metric.Averager
+	buildMarshal                  metric.Averager
+	buildRepeat                   metric.Averager
 }
 
 func newMetrics() (*prometheus.Registry, *Metrics, error) {
@@ -133,6 +136,33 @@ func newMetrics() (*prometheus.Registry, *Metrics, error) {
 		"vm",
 		"add_verify_diff",
 		"time spent waiting to verify a tx block",
+		r,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	buildSelect, err := metric.NewAverager(
+		"chain",
+		"build_select",
+		"time spent waiting for next tx in builder",
+		r,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	buildMarshal, err := metric.NewAverager(
+		"chain",
+		"build_marshal",
+		"time spent marshaling in builder",
+		r,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	buildRepeat, err := metric.NewAverager(
+		"chain",
+		"build_repeat",
+		"time spent checking repeats in builder",
 		r,
 	)
 	if err != nil {
@@ -265,6 +295,9 @@ func newMetrics() (*prometheus.Registry, *Metrics, error) {
 		rootBlockIssuanceDiff:   rootBlockIssuanceDiff,
 		rootBlockAcceptanceDiff: rootBlockAcceptanceDiff,
 		addVerifyDiff:           addVerifyDiff,
+		buildSelect:             buildSelect,
+		buildMarshal:            buildMarshal,
+		buildRepeat:             buildRepeat,
 	}
 	errs := wrappers.Errs{}
 	errs.Add(

--- a/vm/resolutions.go
+++ b/vm/resolutions.go
@@ -507,3 +507,7 @@ func (vm *VM) RecordTxsAttempted(attempted int) {
 func (vm *VM) IsBuilding() bool {
 	return vm.building
 }
+
+func (vm *VM) RecordGossipTrigger() {
+	vm.metrics.txGossipTriggered.Inc()
+}

--- a/vm/resolutions.go
+++ b/vm/resolutions.go
@@ -511,3 +511,15 @@ func (vm *VM) IsBuilding() bool {
 func (vm *VM) RecordGossipTrigger() {
 	vm.metrics.txGossipTriggered.Inc()
 }
+
+func (vm *VM) RecordBuildSelect(t time.Duration) {
+	vm.metrics.buildSelect.Observe(float64(t))
+}
+
+func (vm *VM) RecordBuildMarshal(t time.Duration) {
+	vm.metrics.buildMarshal.Observe(float64(t))
+}
+
+func (vm *VM) RecordBuildRepeat(t time.Duration) {
+	vm.metrics.buildRepeat.Observe(float64(t))
+}

--- a/vm/tx_block_manager.go
+++ b/vm/tx_block_manager.go
@@ -568,6 +568,8 @@ func (c *TxBlockManager) HandleAppGossip(ctx context.Context, nodeID ids.NodeID,
 		c.vm.metrics.txBlockBytesReceived.Add(float64(len(b)))
 
 		// Option 0: already have txBlock, drop
+		//
+		// TODO: should not drop if trying to fetch it, instad cancel
 		if !c.txBlocks.Fetch(blkID) {
 			return nil
 		}

--- a/vm/tx_block_manager.go
+++ b/vm/tx_block_manager.go
@@ -578,7 +578,7 @@ func (c *TxBlockManager) HandleAppGossip(ctx context.Context, nodeID ids.NodeID,
 			c.vm.Logger().Error("unable to handle txBlock", zap.Error(err))
 			return nil
 		}
-		c.vm.Logger().Info("received tx block gossip", zap.Stringer("blkID", blkID))
+		c.vm.Logger().Debug("received tx block gossip", zap.Stringer("blkID", blkID))
 	default:
 		c.vm.Logger().Error("unexpected message type", zap.Uint8("type", msg[0]))
 		return nil
@@ -623,10 +623,9 @@ func (c *TxBlockManager) VerifyAll(blkID ids.ID) {
 		for _, blkID := range next {
 			err := c.Verify(blkID)
 			if err != nil {
-				c.vm.Logger().Warn("manager block verification failed", zap.Error(err))
 				c.vm.metrics.txBlocksVerifiedFailedManager.Inc()
 			} else {
-				c.vm.Logger().Info("manager block verification success", zap.Stringer("blkID", blkID))
+				c.vm.Logger().Debug("manager block verification success", zap.Stringer("blkID", blkID))
 			}
 			nextRound = append(nextRound, c.txBlocks.Verified(blkID, err == nil)...)
 		}

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -243,8 +243,6 @@ func (vm *VM) Initialize(
 	mem, mempoolRegistry, err := mempool.New[*chain.Transaction](
 		vm.tracer,
 		vm.config.GetMempoolSize(),
-		vm.config.GetMempoolPayerSize(),
-		vm.config.GetMempoolExemptPayers(),
 	)
 	if err != nil {
 		return err
@@ -763,13 +761,6 @@ func (vm *VM) Submit(
 				errs = append(errs, err)
 				continue
 			}
-		}
-		// Avoid any state lookup if we already have tx in mempool
-		if vm.mempool.Has(ctx, txID) {
-			// Don't remove from listeners, it will be removed elsewhere if not
-			// included
-			errs = append(errs, ErrNotAdded)
-			continue
 		}
 		// TODO: do we need this? (just ensures people can't spam mempool with
 		// txs from already verified blocks)


### PR DESCRIPTION
theory: as soon as have some txs, send them. do merkle root async as needed (shouldn't block building on that)

- [x] don't gossip if under verify timeout
- [x] increase app concurrency
- [x] include full sendTxs time in tx gossip
- [x] disable cloudwatch monitoring polling
- [ ] check proposer monitor refresh
  - [x] reduce invocations of GetValidators
- [x] Ensure tokenvm config doesn't do profiles 
- [x] Add metric for triggered tx gossip
- [ ] verify timestamp range during parse?
- [x] handle outstanding blocks instead of dropping them
- [ ] marshal tx blocks outside of mempool build loop (should not take 400 ms to enqueue 40k txs)
- [x] Look at time for select to execute (we could be yielding thread during block build under load)
- [ ] reduce number of goroutines created in tx_block_manager (should just have a fetch loop and/or reuse workers)
  - [ ] add these metrics first: https://pkg.go.dev/runtime/metrics (https://go.dev/play/p/u1EdTHkbTCp) -> https://github.com/ava-labs/hypersdk/tree/sched-metrics
- [ ] only call `IsRepeat` once per txBlock: https://github.com/ava-labs/hypersdk/pull/204
  - [ ] batch `IsRepeat` check every X millis on submitted txs