### PR TITLE
Move repeat check to deferred verification

### DIFF
--- a/chain/dependencies.go
+++ b/chain/dependencies.go
@@ -94,7 +94,6 @@ type VM interface {
 	RecordTxFailedExecution()
 	RecordBuildSelect(time.Duration)
 	RecordBuildMarshal(time.Duration)
-	RecordBuildRepeat(time.Duration)
 	// TODO: track repeats found
 }
 

--- a/chain/dependencies.go
+++ b/chain/dependencies.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ava-labs/avalanchego/snow/validators"
 	"github.com/ava-labs/avalanchego/trace"
 	"github.com/ava-labs/avalanchego/utils/logging"
+	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/vms/platformvm/warp"
 	"github.com/ava-labs/avalanchego/x/merkledb"
 
@@ -56,7 +57,7 @@ type VM interface {
 	State() (merkledb.MerkleDB, error)
 	StateManager() StateManager
 	ValidatorState() validators.State
-	IsRepeat(context.Context, []*Transaction) bool
+	CollectRepeats(context.Context, []*Transaction, *set.Bits)
 
 	IssueTxBlock(context.Context, *StatelessTxBlock)
 	RequireTxBlocks(context.Context, uint64, []ids.ID) int

--- a/chain/dependencies.go
+++ b/chain/dependencies.go
@@ -95,6 +95,7 @@ type VM interface {
 	RecordBuildSelect(time.Duration)
 	RecordBuildMarshal(time.Duration)
 	RecordBuildRepeat(time.Duration)
+	// TODO: track repeats found
 }
 
 type Mempool interface {

--- a/chain/root_block.go
+++ b/chain/root_block.go
@@ -624,10 +624,14 @@ func (b *StatelessRootBlock) Execute(ctx context.Context, parent *StatelessRootB
 		// Check repeats and populate block object
 		repeats := set.NewBits()
 		// TODO: may not need to pass by reference because inner is pointer
-		if err := txBlock.parent.CollectRepeats(ctx, oldestAllowed, txBlock.Txs, &repeats); err != nil {
-			return err
+		if txBlock.Hght > 1 {
+			// parent will be nil if genesis
+			if err := txBlock.parent.CollectRepeats(ctx, oldestAllowed, txBlock.Txs, &repeats); err != nil {
+				return err
+			}
 		}
 		txBlock.repeats = repeats
+		log.Info("repeats", zap.Any("bits", repeats), zap.Binary("bits", repeats.Bytes()))
 
 		for i, tx := range txBlock.Txs {
 			if txBlock.repeats.Contains(i) {

--- a/chain/tx_block.go
+++ b/chain/tx_block.go
@@ -57,7 +57,8 @@ func NewTxBlock(vm VM, parent *StatelessTxBlock, tmstmp int64) *StatelessTxBlock
 			Prnt:   parent.ID(),
 			Hght:   parent.Hght + 1,
 		},
-		vm: vm,
+		vm:     vm,
+		parent: parent,
 	}
 }
 
@@ -69,6 +70,9 @@ func (b *StatelessTxBlock) populateTxs(ctx context.Context) error {
 	// Process transactions
 	b.txsSet = set.NewSet[ids.ID](len(b.Txs))
 	for _, tx := range b.Txs {
+		// Don't allow duplicates in same block
+		//
+		// TODO: may want to remove this so can pre-build txBlocks?
 		if b.txsSet.Contains(tx.ID()) {
 			return ErrDuplicateTx
 		}

--- a/chain/tx_block.go
+++ b/chain/tx_block.go
@@ -213,6 +213,11 @@ func (b *StatelessTxBlock) Reject(ctx context.Context) error {
 	return nil
 }
 
+func (b *StatelessTxBlock) Free() {
+	// TODO: reset txSet (requires lock so don't remove while someone is checking repeats)
+	b.parent = nil // otherwise all blocks will stay in memory
+}
+
 // implements "snowman.Block"
 func (b *StatelessTxBlock) Parent() ids.ID { return b.TxBlock.Prnt }
 

--- a/emap/emap.go
+++ b/emap/emap.go
@@ -112,14 +112,16 @@ func (e *EMap[T]) SetMin(t int64) []ids.ID {
 }
 
 // Any returns true if any items have been seen by EMap.
-func (e *EMap[T]) Any(items []T) bool {
+func (e *EMap[T]) CollectRepeats(items []T, repeats *set.Bits) {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
 
-	for _, item := range items {
+	for i, item := range items {
+		if repeats.Contains(i) {
+			continue
+		}
 		if e.seen.Contains(item.ID()) {
-			return true
+			repeats.Add(i)
 		}
 	}
-	return false
 }

--- a/examples/tokenvm/DEVNETS.md
+++ b/examples/tokenvm/DEVNETS.md
@@ -500,3 +500,18 @@ If you get the following error, make sure to install `gcc` before running
 # github.com/supranational/blst/bindings/go
 ../../../go/pkg/mod/github.com/supranational/blst@v0.3.11-0.20220920110316-f72618070295/bindings/go/rb_tree.go:130:18: undefined: Message
 ```
+
+### AWS Network Rate Limiting
+```
+ethtool -S ens5
+```
+
+```
+bw_in_allowance_exceeded: 2983
+bw_out_allowance_exceeded: 0
+pps_allowance_exceeded: 0
+conntrack_allowance_exceeded: 0
+linklocal_allowance_exceeded: 0
+```
+
+https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/monitoring-network-performance-ena.html

--- a/examples/tokenvm/cmd/token-cli/cmd/prometheus.go
+++ b/examples/tokenvm/cmd/token-cli/cmd/prometheus.go
@@ -136,6 +136,9 @@ var generatePrometheusCmd = &cobra.Command{
 		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_chain_tx_block_verify_sum[5s])/increase(avalanche_%s_vm_hyper_sdk_chain_tx_block_verify_count[5s])/1000000", chainID, chainID))
 		utils.Outf("{{yellow}}verify tx block (ms):{{/}} %s\n", panels[len(panels)-1])
 
+		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_chain_root_block_execute_sum[5s])/increase(avalanche_%s_vm_hyper_sdk_chain_root_block_execute_count[5s])/1000000", chainID, chainID))
+		utils.Outf("{{yellow}}execute root block (ms):{{/}} %s\n", panels[len(panels)-1])
+
 		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_vm_add_verify_diff_sum[5s])/increase(avalanche_%s_vm_hyper_sdk_vm_add_verify_diff_count[5s])/1000000", chainID, chainID))
 		utils.Outf("{{yellow}}add verify diff (ms):{{/}} %s\n", panels[len(panels)-1])
 

--- a/examples/tokenvm/cmd/token-cli/cmd/prometheus.go
+++ b/examples/tokenvm/cmd/token-cli/cmd/prometheus.go
@@ -130,9 +130,6 @@ var generatePrometheusCmd = &cobra.Command{
 		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_chain_build_marshal_sum[5s])/increase(avalanche_%s_vm_hyper_sdk_chain_build_marshal_count[5s])/1000000", chainID, chainID))
 		utils.Outf("{{yellow}}build block (marshal) (ms):{{/}} %s\n", panels[len(panels)-1])
 
-		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_chain_build_repeat_sum[5s])/increase(avalanche_%s_vm_hyper_sdk_chain_build_repeat_count[5s])/1000000", chainID, chainID))
-		utils.Outf("{{yellow}}build block (repeat) (ms):{{/}} %s\n", panels[len(panels)-1])
-
 		panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hyper_sdk_chain_early_build_stop[5s])", chainID))
 		utils.Outf("{{yellow}}early build stop:{{/}} %s\n", panels[len(panels)-1])
 

--- a/examples/tokenvm/cmd/token-cli/cmd/spam.go
+++ b/examples/tokenvm/cmd/token-cli/cmd/spam.go
@@ -263,7 +263,7 @@ var runSpamCmd = &cobra.Command{
 			}
 		}
 		for i := 0; i < numAccounts; i++ {
-			_, dErr, result, err := dcli.ListenTx(ctx)
+			txID, dErr, result, err := dcli.ListenTx(ctx)
 			if err != nil {
 				return err
 			}
@@ -272,7 +272,7 @@ var runSpamCmd = &cobra.Command{
 			}
 			if !result.Success {
 				// Should never happen
-				return ErrTxFailed
+				return fmt.Errorf("%w: %v", ErrTxFailed, txID)
 			}
 		}
 		hutils.Outf("{{yellow}}distributed funds to %d accounts{{/}}\n", numAccounts)

--- a/vm/metrics.go
+++ b/vm/metrics.go
@@ -39,6 +39,7 @@ type Metrics struct {
 	buildBlock                    metric.Averager
 	verifyWait                    metric.Averager
 	txBlockVerify                 metric.Averager
+	rootBlockExecute              metric.Averager
 	txBlockIssuanceDiff           metric.Averager
 	rootBlockIssuanceDiff         metric.Averager
 	rootBlockAcceptanceDiff       metric.Averager
@@ -153,6 +154,15 @@ func newMetrics() (*prometheus.Registry, *Metrics, error) {
 		"chain",
 		"build_marshal",
 		"time spent marshaling in builder",
+		r,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	rootBlockExecute, err := metric.NewAverager(
+		"chain",
+		"root_block_execute",
+		"time spent executing a tx block",
 		r,
 	)
 	if err != nil {
@@ -281,6 +291,7 @@ func newMetrics() (*prometheus.Registry, *Metrics, error) {
 		buildBlock:              buildBlock,
 		verifyWait:              verifyWait,
 		txBlockVerify:           txBlockVerify,
+		rootBlockExecute:        rootBlockExecute,
 		txBlockIssuanceDiff:     txBlockIssuanceDiff,
 		rootBlockIssuanceDiff:   rootBlockIssuanceDiff,
 		rootBlockAcceptanceDiff: rootBlockAcceptanceDiff,

--- a/vm/metrics.go
+++ b/vm/metrics.go
@@ -45,7 +45,6 @@ type Metrics struct {
 	addVerifyDiff                 metric.Averager
 	buildSelect                   metric.Averager
 	buildMarshal                  metric.Averager
-	buildRepeat                   metric.Averager
 }
 
 func newMetrics() (*prometheus.Registry, *Metrics, error) {
@@ -154,15 +153,6 @@ func newMetrics() (*prometheus.Registry, *Metrics, error) {
 		"chain",
 		"build_marshal",
 		"time spent marshaling in builder",
-		r,
-	)
-	if err != nil {
-		return nil, nil, err
-	}
-	buildRepeat, err := metric.NewAverager(
-		"chain",
-		"build_repeat",
-		"time spent checking repeats in builder",
 		r,
 	)
 	if err != nil {
@@ -297,7 +287,6 @@ func newMetrics() (*prometheus.Registry, *Metrics, error) {
 		addVerifyDiff:           addVerifyDiff,
 		buildSelect:             buildSelect,
 		buildMarshal:            buildMarshal,
-		buildRepeat:             buildRepeat,
 	}
 	errs := wrappers.Errs{}
 	errs.Add(

--- a/vm/resolutions.go
+++ b/vm/resolutions.go
@@ -99,11 +99,11 @@ func (vm *VM) Mempool() chain.Mempool {
 	return vm.mempool
 }
 
-func (vm *VM) IsRepeat(ctx context.Context, txs []*chain.Transaction) bool {
-	_, span := vm.tracer.Start(ctx, "VM.IsRepeat")
+func (vm *VM) CollectRepeats(ctx context.Context, txs []*chain.Transaction, repeats *set.Bits) {
+	_, span := vm.tracer.Start(ctx, "VM.CollectRepeats")
 	defer span.End()
 
-	return vm.seen.Any(txs)
+	vm.seen.CollectRepeats(txs, repeats)
 }
 
 func (vm *VM) Verified(ctx context.Context, b *chain.StatelessRootBlock) {

--- a/vm/resolutions.go
+++ b/vm/resolutions.go
@@ -519,7 +519,3 @@ func (vm *VM) RecordBuildSelect(t time.Duration) {
 func (vm *VM) RecordBuildMarshal(t time.Duration) {
 	vm.metrics.buildMarshal.Observe(float64(t))
 }
-
-func (vm *VM) RecordBuildRepeat(t time.Duration) {
-	vm.metrics.buildRepeat.Observe(float64(t))
-}

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -748,6 +748,8 @@ func (vm *VM) Submit(
 	oldestAllowed := now - r.GetValidityWindow()
 	validTxs := []*chain.Transaction{}
 	for _, tx := range txs {
+		// TODO: need to verify recent
+
 		txID := tx.ID()
 		// We already verify in streamer, let's avoid re-verification
 		if verifySig && vm.config.GetVerifySignatures() {


### PR DESCRIPTION
if we aren't checking signatures before accept, we don't need to check repeats

- [ ] update height in block manager at end of block issuance (trigger gossip)
- [ ] track account pending balances in a DA account (one-way transfer) if producer to know if will get fees -> how to originally fund? -> don't need to keep 2 states (need this to avoid DOS'ing proposer mempool with junk txs)
  - [ ] should have a "fee balance" to also make sure can pay for computation units they desire
- [ ] Attempt pull only block fetching (more scalable than complex push/broadcast tree)
- [ ] revert channel wait for each tx in exec loop (will lead to a TON of context switching, which means scheduling locks prevent full CPU usage)
- [ ] check bandwidth throttling on dev-machine (for tx broadcast)