### PR TITLE
add github workflow to identify stale issues and PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,26 @@
+name: Mark stale issues and pull requests
+on:
+  schedule:
+    - cron: '0 0 * * 0' # Run every day at midnight UTC on Sunday
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8
+        with:
+          # Overall configuration
+          operations-per-run: 100
+
+          # PR configuration
+          days-before-pr-stale: 30
+          stale-pr-message: 'This PR has become stale because it has been open for 30 days with no activity. Adding the `lifecycle/frozen` label will cause this PR to ignore lifecycle events.'
+          days-before-pr-close: -1
+          stale-pr-label: lifecycle/stale
+          exempt-pr-labels: lifecycle/frozen
+
+          # Issue configuration
+          days-before-issue-stale: 60
+          stale-issue-message: 'This issue has become stale because it has been open 60 days with no activity. Adding the `lifecycle/frozen` label will cause this issue to ignore lifecycle events.'
+          days-before-issue-close: -1
+          stale-issue-label: lifecycle/stale
+          exempt-issue-labels: lifecycle/frozen

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,7 +1,7 @@
 name: Mark stale issues and pull requests
 on:
   schedule:
-    - cron: '0 0 * * 0' # Run every day at midnight UTC on Sunday
+    - cron: '0 0 * * *' # Run every day at midnight UTC
 jobs:
   stale:
     runs-on: ubuntu-latest
@@ -13,14 +13,14 @@ jobs:
 
           # PR configuration
           days-before-pr-stale: 30
-          stale-pr-message: 'This PR has become stale because it has been open for 30 days with no activity. Adding the `lifecycle/frozen` label will cause this PR to ignore lifecycle events.'
+          stale-pr-message: 'This PR has become stale because it has been open for 30 days with no activity. Adding the `lifecycle/frozen` label will exempt this PR from future lifecycle events..'
           days-before-pr-close: -1
           stale-pr-label: lifecycle/stale
           exempt-pr-labels: lifecycle/frozen
 
           # Issue configuration
           days-before-issue-stale: 60
-          stale-issue-message: 'This issue has become stale because it has been open 60 days with no activity. Adding the `lifecycle/frozen` label will cause this issue to ignore lifecycle events.'
+          stale-issue-message: 'This issue has become stale because it has been open 60 days with no activity. Adding the `lifecycle/frozen` label will exempt this issue from future lifecycle events.'
           days-before-issue-close: -1
           stale-issue-label: lifecycle/stale
           exempt-issue-labels: lifecycle/frozen


### PR DESCRIPTION
Close #261 

I used the PR identified in the issue to create this PR.
This puts label `lifecycle/stale` on issues after 30 days of inactivity and on PRs after 60 days of inactivity.

I just deleted useless values `close-issue-label: lifecycle/rotten` and `close-pr-label: lifecycle/rotten` because the workflow does not auto-close issues/PRs.