### PR TITLE
Pre-allocate Memory in `codec.Packer`

### DIFF
--- a/chain/base.go
+++ b/chain/base.go
@@ -39,6 +39,10 @@ func (b *Base) Execute(chainID ids.ID, r Rules, timestamp int64) error {
 	}
 }
 
+func (b *Base) Size() int {
+	return consts.Uint64Len*2 + consts.IDLen
+}
+
 func (b *Base) Marshal(p *codec.Packer) {
 	p.PackInt64(b.Timestamp)
 	p.PackID(b.ChainID)

--- a/chain/base.go
+++ b/chain/base.go
@@ -39,7 +39,7 @@ func (b *Base) Execute(chainID ids.ID, r Rules, timestamp int64) error {
 	}
 }
 
-func (b *Base) Size() int {
+func (*Base) Size() int {
 	return consts.Uint64Len*2 + consts.IDLen
 }
 

--- a/chain/block.go
+++ b/chain/block.go
@@ -764,7 +764,12 @@ func (b *StatefulBlock) Marshal(
 	actionRegistry ActionRegistry,
 	authRegistry AuthRegistry,
 ) ([]byte, error) {
-	p := codec.NewWriter(consts.NetworkSizeLimit)
+	size := consts.IDLen + consts.Uint64Len + consts.Uint64Len +
+		consts.Uint64Len + window.WindowSliceSize +
+		consts.IntLen + codec.TotalSize(b.Txs) +
+		consts.IDLen + consts.Uint64Len + consts.Uint64Len
+
+	p := codec.NewWriter(size, consts.NetworkSizeLimit)
 
 	p.PackID(b.Prnt)
 	p.PackInt64(b.Tmstmp)

--- a/chain/block.go
+++ b/chain/block.go
@@ -766,7 +766,7 @@ func (b *StatefulBlock) Marshal(
 ) ([]byte, error) {
 	size := consts.IDLen + consts.Uint64Len + consts.Uint64Len +
 		consts.Uint64Len + window.WindowSliceSize +
-		consts.IntLen + codec.TotalSize(b.Txs) +
+		consts.IntLen + codec.CummSize(b.Txs) +
 		consts.IDLen + consts.Uint64Len + consts.Uint64Len
 
 	p := codec.NewWriter(size, consts.NetworkSizeLimit)

--- a/chain/dependencies.go
+++ b/chain/dependencies.go
@@ -147,6 +147,7 @@ type Action interface {
 		warpVerified bool,
 	) (result *Result, err error) // err should only be returned if fatal
 
+	Size() int
 	Marshal(p *codec.Packer)
 }
 
@@ -175,6 +176,7 @@ type Auth interface {
 	Deduct(ctx context.Context, db Database, amount uint64) error
 	Refund(ctx context.Context, db Database, amount uint64) error // only invoked if amount > 0
 
+	Size() int
 	Marshal(p *codec.Packer)
 }
 

--- a/chain/mock_action.go
+++ b/chain/mock_action.go
@@ -80,6 +80,20 @@ func (mr *MockActionMockRecorder) MaxUnits(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MaxUnits", reflect.TypeOf((*MockAction)(nil).MaxUnits), arg0)
 }
 
+// Size mocks base method.
+func (m *MockAction) Size() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Size")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// Size indicates an expected call of Size.
+func (mr *MockActionMockRecorder) Size() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Size", reflect.TypeOf((*MockAction)(nil).Size))
+}
+
 // StateKeys mocks base method.
 func (m *MockAction) StateKeys(arg0 Auth, arg1 ids.ID) [][]byte {
 	m.ctrl.T.Helper()

--- a/chain/mock_auth.go
+++ b/chain/mock_auth.go
@@ -134,6 +134,20 @@ func (mr *MockAuthMockRecorder) Refund(arg0, arg1, arg2 interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Refund", reflect.TypeOf((*MockAuth)(nil).Refund), arg0, arg1, arg2)
 }
 
+// Size mocks base method.
+func (m *MockAuth) Size() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Size")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// Size indicates an expected call of Size.
+func (mr *MockAuthMockRecorder) Size() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Size", reflect.TypeOf((*MockAuth)(nil).Size))
+}
+
 // StateKeys mocks base method.
 func (m *MockAuth) StateKeys() [][]byte {
 	m.ctrl.T.Helper()

--- a/chain/result.go
+++ b/chain/result.go
@@ -16,6 +16,16 @@ type Result struct {
 	WarpMessage *warp.UnsignedMessage
 }
 
+func (r *Result) Size() int {
+	size := codec.BoolLen + consts.Uint64Len + codec.BytesLen(r.Output)
+	if r.WarpMessage != nil {
+		size += codec.BytesLen(r.WarpMessage.Bytes())
+	} else {
+		size += codec.BytesLen(nil)
+	}
+	return size
+}
+
 func (r *Result) Marshal(p *codec.Packer) {
 	p.PackBool(r.Success)
 	p.PackUint64(r.Units)
@@ -28,7 +38,11 @@ func (r *Result) Marshal(p *codec.Packer) {
 }
 
 func MarshalResults(src []*Result) ([]byte, error) {
-	p := codec.NewWriter(consts.MaxInt) // could be much larger than [NetworkSizeLimit]
+	size := consts.IntLen
+	for _, result := range src {
+		size += result.Size()
+	}
+	p := codec.NewWriter(size, consts.MaxInt) // could be much larger than [NetworkSizeLimit]
 	p.PackInt(len(src))
 	for _, result := range src {
 		result.Marshal(p)

--- a/chain/result.go
+++ b/chain/result.go
@@ -17,7 +17,7 @@ type Result struct {
 }
 
 func (r *Result) Size() int {
-	size := codec.BoolLen + consts.Uint64Len + codec.BytesLen(r.Output)
+	size := consts.BoolLen + consts.Uint64Len + codec.BytesLen(r.Output)
 	if r.WarpMessage != nil {
 		size += codec.BytesLen(r.WarpMessage.Bytes())
 	} else {

--- a/chain/result.go
+++ b/chain/result.go
@@ -38,10 +38,7 @@ func (r *Result) Marshal(p *codec.Packer) {
 }
 
 func MarshalResults(src []*Result) ([]byte, error) {
-	size := consts.IntLen
-	for _, result := range src {
-		size += result.Size()
-	}
+	size := consts.IntLen + codec.TotalSize(src)
 	p := codec.NewWriter(size, consts.MaxInt) // could be much larger than [NetworkSizeLimit]
 	p.PackInt(len(src))
 	for _, result := range src {

--- a/chain/result.go
+++ b/chain/result.go
@@ -38,7 +38,7 @@ func (r *Result) Marshal(p *codec.Packer) {
 }
 
 func MarshalResults(src []*Result) ([]byte, error) {
-	size := consts.IntLen + codec.TotalSize(src)
+	size := consts.IntLen + codec.CummSize(src)
 	p := codec.NewWriter(size, consts.MaxInt) // could be much larger than [NetworkSizeLimit]
 	p.PackInt(len(src))
 	for _, result := range src {

--- a/chain/transaction.go
+++ b/chain/transaction.go
@@ -374,7 +374,7 @@ func MarshalTxs(
 	if len(txs) == 0 {
 		return nil, ErrNoTxs
 	}
-	size := consts.IntLen + codec.TotalSize(txs)
+	size := consts.IntLen + codec.CummSize(txs)
 	p := codec.NewWriter(size, consts.NetworkSizeLimit)
 	p.PackInt(len(txs))
 	for _, tx := range txs {

--- a/chain/transaction.go
+++ b/chain/transaction.go
@@ -34,7 +34,7 @@ type Transaction struct {
 
 	digest         []byte
 	bytes          []byte
-	size           uint64
+	size           int
 	id             ids.ID
 	numWarpSigners int
 	// warpID is just the hash of the *warp.Message.Payload. We assumed that
@@ -68,12 +68,15 @@ func (t *Transaction) Digest(
 	if !ok {
 		return nil, fmt.Errorf("unknown action type %T", t.Action)
 	}
-	p := codec.NewWriter(consts.NetworkSizeLimit)
-	t.Base.Marshal(p)
 	var warpBytes []byte
 	if t.WarpMessage != nil {
 		warpBytes = t.WarpMessage.Bytes()
 	}
+	size := t.Base.Size() +
+		codec.BytesLen(warpBytes) +
+		consts.ByteLen + t.Action.Size()
+	p := codec.NewWriter(size, consts.NetworkSizeLimit)
+	t.Base.Marshal(p)
 	p.PackBytes(warpBytes)
 	p.PackByte(actionByte)
 	t.Action.Marshal(p)
@@ -98,7 +101,8 @@ func (t *Transaction) Sign(
 
 	// Ensure transaction is fully initialized and correct by reloading it from
 	// bytes
-	p := codec.NewWriter(consts.NetworkSizeLimit)
+	size := len(msg) + consts.ByteLen + t.Auth.Size()
+	p := codec.NewWriter(size, consts.NetworkSizeLimit)
 	if err := t.Marshal(p, actionRegistry, authRegistry); err != nil {
 		return nil, err
 	}
@@ -117,7 +121,7 @@ func (t *Transaction) AuthAsyncVerify() func() error {
 
 func (t *Transaction) Bytes() []byte { return t.bytes }
 
-func (t *Transaction) Size() uint64 { return t.size }
+func (t *Transaction) Size() int { return t.size }
 
 func (t *Transaction) ID() ids.ID { return t.id }
 
@@ -370,7 +374,8 @@ func MarshalTxs(
 	if len(txs) == 0 {
 		return nil, ErrNoTxs
 	}
-	p := codec.NewWriter(consts.NetworkSizeLimit)
+	size := consts.IntLen + codec.TotalSize(txs)
+	p := codec.NewWriter(size, consts.NetworkSizeLimit)
 	p.PackInt(len(txs))
 	for _, tx := range txs {
 		if err := tx.Marshal(p, actionRegistry, authRegistry); err != nil {
@@ -473,7 +478,7 @@ func UnmarshalTx(
 	codecBytes := p.Bytes()
 	tx.digest = codecBytes[start:digest]
 	tx.bytes = codecBytes[start:p.Offset()] // ensure errors handled before grabbing memory
-	tx.size = uint64(len(tx.bytes))
+	tx.size = len(tx.bytes)
 	tx.id = utils.ToID(tx.bytes)
 	if tx.WarpMessage != nil {
 		tx.numWarpSigners = numWarpSigners

--- a/codec/consts.go
+++ b/codec/consts.go
@@ -1,0 +1,3 @@
+package codec
+
+const BoolLen = 1

--- a/codec/consts.go
+++ b/codec/consts.go
@@ -1,3 +1,0 @@
-package codec
-
-const BoolLen = 1

--- a/codec/optional_packer.go
+++ b/codec/optional_packer.go
@@ -23,9 +23,9 @@ type OptionalPacker struct {
 // a new Packer instance with MaxSize set to the maximum size. The maximum items
 // OptionalPacker can hold is set to [size]. If [size] > MaxItems sets
 // OptionalPackers MaxItems to MaxItems
-func NewOptionalWriter() *OptionalPacker {
+func NewOptionalWriter(initial int) *OptionalPacker {
 	return &OptionalPacker{
-		ip: NewWriter(consts.MaxInt),
+		ip: NewWriter(initial, consts.MaxInt),
 	}
 }
 

--- a/codec/optional_packer_test.go
+++ b/codec/optional_packer_test.go
@@ -19,7 +19,7 @@ import (
 func (o *OptionalPacker) toReader() *OptionalPacker {
 	// Add one for o.b byte
 	size := len(o.ip.Bytes()) + consts.Uint64Len
-	p := NewWriter(size)
+	p := NewWriter(10_000, size)
 	p.PackOptional(o)
 	pr := NewReader(p.Bytes(), size)
 	return pr.NewOptionalReader()
@@ -28,7 +28,7 @@ func (o *OptionalPacker) toReader() *OptionalPacker {
 func TestOptionalPackerWriter(t *testing.T) {
 	// Initializes empty writer with a limit two byte limit
 	require := require.New(t)
-	opw := NewOptionalWriter()
+	opw := NewOptionalWriter(10_000)
 	require.Empty(opw.ip.Bytes())
 	var pubKey crypto.PublicKey
 	copy(pubKey[:], TestPublicKey)
@@ -50,7 +50,7 @@ func TestOptionalPackerWriter(t *testing.T) {
 
 func TestOptionalPackerPublicKey(t *testing.T) {
 	require := require.New(t)
-	opw := NewOptionalWriter()
+	opw := NewOptionalWriter(10_000)
 	var pubKey crypto.PublicKey
 	copy(pubKey[:], TestPublicKey)
 	t.Run("Pack", func(t *testing.T) {
@@ -77,7 +77,7 @@ func TestOptionalPackerPublicKey(t *testing.T) {
 
 func TestOptionalPackerID(t *testing.T) {
 	require := require.New(t)
-	opw := NewOptionalWriter()
+	opw := NewOptionalWriter(10_000)
 	id := ids.GenerateTestID()
 	t.Run("Pack", func(t *testing.T) {
 		// Pack empty
@@ -105,7 +105,7 @@ func TestOptionalPackerID(t *testing.T) {
 
 func TestOptionalPackerUint64(t *testing.T) {
 	require := require.New(t)
-	opw := NewOptionalWriter()
+	opw := NewOptionalWriter(10_000)
 	val := uint64(900)
 	t.Run("Pack", func(t *testing.T) {
 		// Pack empty
@@ -132,7 +132,7 @@ func TestOptionalPackerUint64(t *testing.T) {
 
 func TestOptionalPackerInvalidSet(t *testing.T) {
 	require := require.New(t)
-	opw := NewOptionalWriter()
+	opw := NewOptionalWriter(10_000)
 	val := uint64(900)
 	t.Run("Pack", func(t *testing.T) {
 		// Pack empty

--- a/codec/packer.go
+++ b/codec/packer.go
@@ -31,10 +31,11 @@ func NewReader(src []byte, limit int) *Packer {
 	}
 }
 
-// NewWriter returns a Packer instance with its MaxSize set to [limit].
-func NewWriter(limit int) *Packer {
+// NewWriter returns a Packer instance with an initial size of [initial] and a
+// MaxSize set to [limit].
+func NewWriter(initial, limit int) *Packer {
 	return &Packer{
-		p: &wrappers.Packer{MaxSize: limit},
+		p: &wrappers.Packer{Bytes: make([]byte, 0, initial), MaxSize: limit},
 	}
 }
 

--- a/codec/packer_test.go
+++ b/codec/packer_test.go
@@ -34,7 +34,7 @@ var (
 
 func TestNewWriter(t *testing.T) {
 	require := require.New(t)
-	wr := NewWriter(2)
+	wr := NewWriter(2, 2)
 	require.True(wr.Empty(), "Writer not empty when initialized.")
 	// Pack up to the limit
 	bytes := []byte{1, 2}
@@ -48,7 +48,7 @@ func TestNewWriter(t *testing.T) {
 
 func TestPackerPublicKey(t *testing.T) {
 	require := require.New(t)
-	wp := NewWriter(crypto.PublicKeyLen)
+	wp := NewWriter(crypto.PublicKeyLen, crypto.PublicKeyLen)
 	var pubKey crypto.PublicKey
 	copy(pubKey[:], TestPublicKey)
 	t.Run("Pack", func(t *testing.T) {
@@ -73,7 +73,7 @@ func TestPackerPublicKey(t *testing.T) {
 
 func TestPackerSignature(t *testing.T) {
 	require := require.New(t)
-	wp := NewWriter(crypto.SignatureLen)
+	wp := NewWriter(crypto.SignatureLen, crypto.SignatureLen)
 	var sig crypto.Signature
 	copy(sig[:], TestSignature)
 	t.Run("Pack", func(t *testing.T) {
@@ -98,7 +98,7 @@ func TestPackerSignature(t *testing.T) {
 
 func TestPackerID(t *testing.T) {
 	require := require.New(t)
-	wp := NewWriter(consts.IDLen)
+	wp := NewWriter(consts.IDLen, consts.IDLen)
 	// Pack
 	id := ids.GenerateTestID()
 	t.Run("Pack", func(t *testing.T) {
@@ -127,7 +127,7 @@ func TestPackerID(t *testing.T) {
 
 func TestPackerWindow(t *testing.T) {
 	require := require.New(t)
-	wp := NewWriter(window.WindowSliceSize)
+	wp := NewWriter(window.WindowSliceSize, window.WindowSliceSize)
 	var wind window.Window
 	// Fill window
 	copy(wind[:], TestWindow)
@@ -156,7 +156,7 @@ func TestPackerWindow(t *testing.T) {
 func TestNewReader(t *testing.T) {
 	require := require.New(t)
 	vInt := 900
-	wp := NewWriter(5)
+	wp := NewWriter(5, 5)
 	// Add an int and a bool
 	wp.PackInt(vInt)
 	wp.PackBool(true)

--- a/codec/utils.go
+++ b/codec/utils.go
@@ -5,6 +5,18 @@ package codec
 
 import "github.com/ava-labs/hypersdk/consts"
 
+type SizeType interface {
+	Size() int
+}
+
+func TotalSize[T SizeType](arr []T) int {
+	size := 0
+	for _, item := range arr {
+		size += item.Size()
+	}
+	return size
+}
+
 func BytesLen(msg []byte) int {
 	return consts.IntLen + len(msg)
 }

--- a/codec/utils.go
+++ b/codec/utils.go
@@ -9,7 +9,7 @@ type SizeType interface {
 	Size() int
 }
 
-func TotalSize[T SizeType](arr []T) int {
+func CummSize[T SizeType](arr []T) int {
 	size := 0
 	for _, item := range arr {
 		size += item.Size()

--- a/consts/consts.go
+++ b/consts/consts.go
@@ -4,6 +4,7 @@
 package consts
 
 const (
+	ByteLen               = 1
 	IDLen                 = 32
 	NodeIDLen             = 20
 	MaxUint8              = ^uint8(0)

--- a/consts/consts.go
+++ b/consts/consts.go
@@ -5,8 +5,6 @@ package consts
 
 const (
 	// These `codec` consts are defined here to avoid a circular dependency
-	//
-	// TODO: move everything to codec
 	BoolLen   = 1
 	ByteLen   = 1
 	IDLen     = 32
@@ -14,6 +12,7 @@ const (
 	IntLen    = 4
 	Uint16Len = 2
 	Uint64Len = 8
+	Int64Len  = 8
 
 	// AvalancheGo imposes a limit of 2 MiB on the network, so we limit at
 	// 2 MiB - ProposerVM header - Protobuf encoding overhead (we assume this is

--- a/consts/consts.go
+++ b/consts/consts.go
@@ -4,22 +4,27 @@
 package consts
 
 const (
-	ByteLen               = 1
-	IDLen                 = 32
-	NodeIDLen             = 20
-	MaxUint8              = ^uint8(0)
-	MaxUint8Offset        = 7
-	MaxUint               = ^uint(0)
-	MaxInt                = int(MaxUint >> 1)
-	IntLen                = 4
-	Uint16Len             = 2
-	Uint64Len             = 8
-	MaxUint64Offset       = 63
-	MaxUint64             = ^uint64(0)
-	MillisecondsPerSecond = 1000
+	// These `codec` consts are defined here to avoid a circular dependency
+	//
+	// TODO: move everything to codec
+	BoolLen   = 1
+	ByteLen   = 1
+	IDLen     = 32
+	NodeIDLen = 20
+	IntLen    = 4
+	Uint16Len = 2
+	Uint64Len = 8
 
 	// AvalancheGo imposes a limit of 2 MiB on the network, so we limit at
 	// 2 MiB - ProposerVM header - Protobuf encoding overhead (we assume this is
 	// no more than 50 KiB of overhead but is likely much less)
 	NetworkSizeLimit = 2_044_723 // 1.95 MiB
+
+	MaxUint8              = ^uint8(0)
+	MaxUint8Offset        = 7
+	MaxUint               = ^uint(0)
+	MaxInt                = int(MaxUint >> 1)
+	MaxUint64Offset       = 63
+	MaxUint64             = ^uint64(0)
+	MillisecondsPerSecond = 1000
 )

--- a/examples/morpheusvm/actions/transfer.go
+++ b/examples/morpheusvm/actions/transfer.go
@@ -63,6 +63,10 @@ func (*Transfer) MaxUnits(chain.Rules) uint64 {
 	return crypto.PublicKeyLen + consts.Uint64Len
 }
 
+func (*Transfer) Size() int {
+	return crypto.PublicKeyLen + consts.Uint64Len
+}
+
 func (t *Transfer) Marshal(p *codec.Packer) {
 	p.PackPublicKey(t.To)
 	p.PackUint64(t.Value)

--- a/examples/morpheusvm/auth/ed25519.go
+++ b/examples/morpheusvm/auth/ed25519.go
@@ -59,6 +59,10 @@ func (d *ED25519) Payer() []byte {
 	return d.Signer[:]
 }
 
+func (*ED25519) Size() int {
+	return crypto.PublicKeyLen + crypto.SignatureLen
+}
+
 func (d *ED25519) Marshal(p *codec.Packer) {
 	p.PackPublicKey(d.Signer)
 	p.PackSignature(d.Signature)

--- a/examples/morpheusvm/tests/integration/integration_test.go
+++ b/examples/morpheusvm/tests/integration/integration_test.go
@@ -377,7 +377,7 @@ var _ = ginkgo.Describe("[Tx Processing]", func() {
 			auth, err := factory.Sign(msg, tx.Action)
 			gomega.Ω(err).To(gomega.BeNil())
 			tx.Auth = auth
-			p := codec.NewWriter(consts.MaxInt)
+			p := codec.NewWriter(0, consts.MaxInt) // test codec growth
 			gomega.Ω(tx.Marshal(p, actionRegistry, authRegistry)).To(gomega.BeNil())
 			gomega.Ω(p.Err()).To(gomega.BeNil())
 			_, err = instances[0].cli.SubmitTx(

--- a/examples/tokenvm/actions/burn_asset.go
+++ b/examples/tokenvm/actions/burn_asset.go
@@ -77,6 +77,10 @@ func (*BurnAsset) MaxUnits(chain.Rules) uint64 {
 	return consts.IDLen + consts.Uint64Len
 }
 
+func (*BurnAsset) Size() int {
+	return consts.IDLen + consts.Uint64Len
+}
+
 func (b *BurnAsset) Marshal(p *codec.Packer) {
 	p.PackID(b.Asset)
 	p.PackUint64(b.Value)

--- a/examples/tokenvm/actions/close_order.go
+++ b/examples/tokenvm/actions/close_order.go
@@ -74,6 +74,10 @@ func (*CloseOrder) MaxUnits(chain.Rules) uint64 {
 	return consts.IDLen * 2
 }
 
+func (*CloseOrder) Size() int {
+	return consts.IDLen * 2
+}
+
 func (c *CloseOrder) Marshal(p *codec.Packer) {
 	p.PackID(c.Order)
 	p.PackID(c.Out)

--- a/examples/tokenvm/actions/create_asset.go
+++ b/examples/tokenvm/actions/create_asset.go
@@ -55,6 +55,10 @@ func (c *CreateAsset) MaxUnits(chain.Rules) uint64 {
 	return uint64(len(c.Metadata))
 }
 
+func (c *CreateAsset) Size() int {
+	return codec.BytesLen(c.Metadata)
+}
+
 func (c *CreateAsset) Marshal(p *codec.Packer) {
 	p.PackBytes(c.Metadata)
 }

--- a/examples/tokenvm/actions/create_order.go
+++ b/examples/tokenvm/actions/create_order.go
@@ -96,6 +96,10 @@ func (*CreateOrder) MaxUnits(chain.Rules) uint64 {
 	return consts.IDLen*2 + consts.Uint64Len*3
 }
 
+func (*CreateOrder) Size() int {
+	return consts.IDLen*2 + consts.Uint64Len*3
+}
+
 func (c *CreateOrder) Marshal(p *codec.Packer) {
 	p.PackID(c.In)
 	p.PackUint64(c.InTick)

--- a/examples/tokenvm/actions/export_asset.go
+++ b/examples/tokenvm/actions/export_asset.go
@@ -218,14 +218,14 @@ func (e *ExportAsset) Execute(
 
 func (*ExportAsset) MaxUnits(chain.Rules) uint64 {
 	return crypto.PublicKeyLen + consts.IDLen +
-		consts.Uint64Len + codec.BoolLen + consts.Uint64Len +
+		consts.Uint64Len + consts.BoolLen + consts.Uint64Len +
 		consts.Uint64Len + consts.IDLen + consts.Uint64Len +
 		consts.Uint64Len + consts.IDLen
 }
 
 func (*ExportAsset) Size() int {
 	return crypto.PublicKeyLen + consts.IDLen +
-		consts.Uint64Len + codec.BoolLen + consts.Uint64Len +
+		consts.Uint64Len + consts.BoolLen + consts.Uint64Len +
 		consts.Uint64Len + consts.IDLen + consts.Uint64Len +
 		consts.Uint64Len + consts.IDLen
 }

--- a/examples/tokenvm/actions/export_asset.go
+++ b/examples/tokenvm/actions/export_asset.go
@@ -218,7 +218,14 @@ func (e *ExportAsset) Execute(
 
 func (*ExportAsset) MaxUnits(chain.Rules) uint64 {
 	return crypto.PublicKeyLen + consts.IDLen +
-		consts.Uint64Len + 1 + consts.Uint64Len +
+		consts.Uint64Len + codec.BoolLen + consts.Uint64Len +
+		consts.Uint64Len + consts.IDLen + consts.Uint64Len +
+		consts.Uint64Len + consts.IDLen
+}
+
+func (*ExportAsset) Size() int {
+	return crypto.PublicKeyLen + consts.IDLen +
+		consts.Uint64Len + codec.BoolLen + consts.Uint64Len +
 		consts.Uint64Len + consts.IDLen + consts.Uint64Len +
 		consts.Uint64Len + consts.IDLen
 }
@@ -228,7 +235,7 @@ func (e *ExportAsset) Marshal(p *codec.Packer) {
 	p.PackID(e.Asset)
 	p.PackUint64(e.Value)
 	p.PackBool(e.Return)
-	op := codec.NewOptionalWriter()
+	op := codec.NewOptionalWriter(consts.Uint64Len*4 + consts.IDLen)
 	op.PackUint64(e.Reward)
 	op.PackUint64(e.SwapIn)
 	op.PackID(e.AssetOut)

--- a/examples/tokenvm/actions/export_asset.go
+++ b/examples/tokenvm/actions/export_asset.go
@@ -19,6 +19,12 @@ import (
 	"github.com/ava-labs/hypersdk/utils"
 )
 
+const exportAssetSize = crypto.PublicKeyLen + consts.IDLen +
+	consts.Uint64Len + consts.BoolLen +
+	consts.Uint64Len + /* op bits */
+	consts.Uint64Len + consts.Uint64Len + consts.IDLen + consts.Uint64Len +
+	consts.Int64Len + consts.IDLen
+
 var _ chain.Action = (*ExportAsset)(nil)
 
 type ExportAsset struct {
@@ -217,17 +223,11 @@ func (e *ExportAsset) Execute(
 }
 
 func (*ExportAsset) MaxUnits(chain.Rules) uint64 {
-	return crypto.PublicKeyLen + consts.IDLen +
-		consts.Uint64Len + consts.BoolLen + consts.Uint64Len +
-		consts.Uint64Len + consts.IDLen + consts.Uint64Len +
-		consts.Uint64Len + consts.IDLen
+	return exportAssetSize
 }
 
 func (*ExportAsset) Size() int {
-	return crypto.PublicKeyLen + consts.IDLen +
-		consts.Uint64Len + consts.BoolLen + consts.Uint64Len +
-		consts.Uint64Len + consts.IDLen + consts.Uint64Len +
-		consts.Uint64Len + consts.IDLen
+	return exportAssetSize
 }
 
 func (e *ExportAsset) Marshal(p *codec.Packer) {
@@ -235,7 +235,7 @@ func (e *ExportAsset) Marshal(p *codec.Packer) {
 	p.PackID(e.Asset)
 	p.PackUint64(e.Value)
 	p.PackBool(e.Return)
-	op := codec.NewOptionalWriter(consts.Uint64Len*4 + consts.IDLen)
+	op := codec.NewOptionalWriter(consts.Uint64Len*3 + consts.Int64Len + consts.IDLen)
 	op.PackUint64(e.Reward)
 	op.PackUint64(e.SwapIn)
 	op.PackID(e.AssetOut)

--- a/examples/tokenvm/actions/fill_order.go
+++ b/examples/tokenvm/actions/fill_order.go
@@ -159,6 +159,10 @@ func (*FillOrder) MaxUnits(chain.Rules) uint64 {
 	return basePrice + tradeSucceededPrice
 }
 
+func (*FillOrder) Size() int {
+	return consts.IDLen*3 + crypto.PublicKeyLen + consts.Uint64Len
+}
+
 func (f *FillOrder) Marshal(p *codec.Packer) {
 	p.PackID(f.Order)
 	p.PackPublicKey(f.Owner)
@@ -200,7 +204,7 @@ func UnmarshalOrderResult(b []byte) (*OrderResult, error) {
 }
 
 func (o *OrderResult) Marshal() ([]byte, error) {
-	p := codec.NewWriter(consts.Uint64Len * 3)
+	p := codec.NewWriter(consts.Uint64Len*3, consts.Uint64Len*3)
 	p.PackUint64(o.In)
 	p.PackUint64(o.Out)
 	p.PackUint64(o.Remaining)

--- a/examples/tokenvm/actions/import_asset.go
+++ b/examples/tokenvm/actions/import_asset.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/ava-labs/hypersdk/chain"
 	"github.com/ava-labs/hypersdk/codec"
+	"github.com/ava-labs/hypersdk/consts"
 	"github.com/ava-labs/hypersdk/crypto"
 	"github.com/ava-labs/hypersdk/examples/tokenvm/auth"
 	"github.com/ava-labs/hypersdk/examples/tokenvm/storage"

--- a/examples/tokenvm/actions/import_asset.go
+++ b/examples/tokenvm/actions/import_asset.go
@@ -208,11 +208,11 @@ func (i *ImportAsset) Execute(
 }
 
 func (i *ImportAsset) MaxUnits(chain.Rules) uint64 {
-	return uint64(len(i.warpMessage.Payload)) + codec.BoolLen
+	return uint64(len(i.warpMessage.Payload)) + consts.BoolLen
 }
 
 func (*ImportAsset) Size() int {
-	return codec.BoolLen
+	return consts.BoolLen
 }
 
 // All we encode that is action specific for now is the type byte from the

--- a/examples/tokenvm/actions/import_asset.go
+++ b/examples/tokenvm/actions/import_asset.go
@@ -208,7 +208,11 @@ func (i *ImportAsset) Execute(
 }
 
 func (i *ImportAsset) MaxUnits(chain.Rules) uint64 {
-	return uint64(len(i.warpMessage.Payload)) + 1
+	return uint64(len(i.warpMessage.Payload)) + codec.BoolLen
+}
+
+func (*ImportAsset) Size() int {
+	return codec.BoolLen
 }
 
 // All we encode that is action specific for now is the type byte from the

--- a/examples/tokenvm/actions/mint_asset.go
+++ b/examples/tokenvm/actions/mint_asset.go
@@ -92,6 +92,10 @@ func (*MintAsset) MaxUnits(chain.Rules) uint64 {
 	return crypto.PublicKeyLen + consts.IDLen + consts.Uint64Len
 }
 
+func (*MintAsset) Size() int {
+	return crypto.PublicKeyLen + consts.IDLen + consts.Uint64Len
+}
+
 func (m *MintAsset) Marshal(p *codec.Packer) {
 	p.PackPublicKey(m.To)
 	p.PackID(m.Asset)

--- a/examples/tokenvm/actions/modify_asset.go
+++ b/examples/tokenvm/actions/modify_asset.go
@@ -85,6 +85,10 @@ func (m *ModifyAsset) MaxUnits(chain.Rules) uint64 {
 	return consts.IDLen + crypto.PublicKeyLen + uint64(len(m.Metadata))
 }
 
+func (m *ModifyAsset) Size() int {
+	return consts.IDLen + crypto.PublicKeyLen + codec.BytesLen(m.Metadata)
+}
+
 func (m *ModifyAsset) Marshal(p *codec.Packer) {
 	p.PackID(m.Asset)
 	p.PackPublicKey(m.Owner)

--- a/examples/tokenvm/actions/transfer.go
+++ b/examples/tokenvm/actions/transfer.go
@@ -66,6 +66,10 @@ func (*Transfer) MaxUnits(chain.Rules) uint64 {
 	return crypto.PublicKeyLen + consts.IDLen + consts.Uint64Len
 }
 
+func (*Transfer) Size() int {
+	return crypto.PublicKeyLen + consts.IDLen + consts.Uint64Len
+}
+
 func (t *Transfer) Marshal(p *codec.Packer) {
 	p.PackPublicKey(t.To)
 	p.PackID(t.Asset)

--- a/examples/tokenvm/actions/warp_transfer.go
+++ b/examples/tokenvm/actions/warp_transfer.go
@@ -13,9 +13,10 @@ import (
 )
 
 const WarpTransferSize = crypto.PublicKeyLen + consts.IDLen +
-	consts.Uint64Len + 1 + consts.Uint64Len + consts.Uint64Len +
-	consts.IDLen + consts.Uint64Len + consts.Uint64Len + consts.IDLen +
-	consts.IDLen
+	consts.Uint64Len + consts.BoolLen +
+	consts.Uint64Len + /* op bits */
+	consts.Uint64Len + consts.Uint64Len + consts.IDLen + consts.Uint64Len + consts.Int64Len +
+	consts.IDLen + consts.IDLen
 
 type WarpTransfer struct {
 	To    crypto.PublicKey `json:"to"`
@@ -50,12 +51,12 @@ type WarpTransfer struct {
 }
 
 func (w *WarpTransfer) Marshal() ([]byte, error) {
-	p := codec.NewWriter(WarpTransferSize)
+	p := codec.NewWriter(WarpTransferSize, WarpTransferSize)
 	p.PackPublicKey(w.To)
 	p.PackID(w.Asset)
 	p.PackUint64(w.Value)
 	p.PackBool(w.Return)
-	op := codec.NewOptionalWriter()
+	op := codec.NewOptionalWriter(consts.Uint64Len*3 + consts.IDLen + consts.Int64Len)
 	op.PackUint64(w.Reward)
 	op.PackUint64(w.SwapIn)
 	op.PackID(w.AssetOut)

--- a/examples/tokenvm/auth/ed25519.go
+++ b/examples/tokenvm/auth/ed25519.go
@@ -60,6 +60,10 @@ func (d *ED25519) Payer() []byte {
 	return d.Signer[:]
 }
 
+func (*ED25519) Size() int {
+	return crypto.PublicKeyLen + crypto.SignatureLen
+}
+
 func (d *ED25519) Marshal(p *codec.Packer) {
 	p.PackPublicKey(d.Signer)
 	p.PackSignature(d.Signature)

--- a/examples/tokenvm/tests/integration/integration_test.go
+++ b/examples/tokenvm/tests/integration/integration_test.go
@@ -379,7 +379,7 @@ var _ = ginkgo.Describe("[Tx Processing]", func() {
 			auth, err := factory.Sign(msg, tx.Action)
 			gomega.Ω(err).To(gomega.BeNil())
 			tx.Auth = auth
-			p := codec.NewWriter(consts.MaxInt)
+			p := codec.NewWriter(0, consts.MaxInt) // test codec growth
 			gomega.Ω(tx.Marshal(p, actionRegistry, authRegistry)).To(gomega.BeNil())
 			gomega.Ω(p.Err()).To(gomega.BeNil())
 			_, err = instances[0].cli.SubmitTx(
@@ -808,7 +808,7 @@ var _ = ginkgo.Describe("[Tx Processing]", func() {
 		auth, err := factory.Sign(msg, tx.Action)
 		gomega.Ω(err).To(gomega.BeNil())
 		tx.Auth = auth
-		p := codec.NewWriter(consts.MaxInt)
+		p := codec.NewWriter(0, consts.MaxInt) // test codec growth
 		gomega.Ω(tx.Marshal(p, actionRegistry, authRegistry)).To(gomega.BeNil())
 		gomega.Ω(p.Err()).To(gomega.BeNil())
 		_, err = instances[0].cli.SubmitTx(
@@ -1029,7 +1029,7 @@ var _ = ginkgo.Describe("[Tx Processing]", func() {
 		auth, err := factory.Sign(msg, tx.Action)
 		gomega.Ω(err).To(gomega.BeNil())
 		tx.Auth = auth
-		p := codec.NewWriter(consts.MaxInt)
+		p := codec.NewWriter(0, consts.MaxInt) // test codec growth
 		gomega.Ω(tx.Marshal(p, actionRegistry, authRegistry)).To(gomega.BeNil())
 		gomega.Ω(p.Err()).To(gomega.BeNil())
 		_, err = instances[0].cli.SubmitTx(
@@ -1175,7 +1175,7 @@ var _ = ginkgo.Describe("[Tx Processing]", func() {
 		auth, err := factory.Sign(msg, tx.Action)
 		gomega.Ω(err).To(gomega.BeNil())
 		tx.Auth = auth
-		p := codec.NewWriter(consts.MaxInt)
+		p := codec.NewWriter(0, consts.MaxInt) // test codec growth
 		gomega.Ω(tx.Marshal(p, actionRegistry, authRegistry)).To(gomega.BeNil())
 		gomega.Ω(p.Err()).To(gomega.BeNil())
 		_, err = instances[0].cli.SubmitTx(
@@ -1696,7 +1696,7 @@ var _ = ginkgo.Describe("[Tx Processing]", func() {
 		auth, err := factory.Sign(msg, tx.Action)
 		gomega.Ω(err).To(gomega.BeNil())
 		tx.Auth = auth
-		p := codec.NewWriter(consts.MaxInt)
+		p := codec.NewWriter(0, consts.MaxInt) // test codec growth
 		gomega.Ω(tx.Marshal(p, actionRegistry, authRegistry)).To(gomega.BeNil())
 		gomega.Ω(p.Err()).To(gomega.BeNil())
 		_, err = instances[0].cli.SubmitTx(
@@ -1726,7 +1726,7 @@ var _ = ginkgo.Describe("[Tx Processing]", func() {
 		auth, err := factory.Sign(msg, tx.Action)
 		gomega.Ω(err).To(gomega.BeNil())
 		tx.Auth = auth
-		p := codec.NewWriter(consts.MaxInt)
+		p := codec.NewWriter(0, consts.MaxInt) // test codec growth
 		gomega.Ω(tx.Marshal(p, actionRegistry, authRegistry)).To(gomega.BeNil())
 		gomega.Ω(p.Err()).To(gomega.BeNil())
 		_, err = instances[0].cli.SubmitTx(
@@ -1758,7 +1758,7 @@ var _ = ginkgo.Describe("[Tx Processing]", func() {
 		auth, err := factory.Sign(msg, tx.Action)
 		gomega.Ω(err).To(gomega.BeNil())
 		tx.Auth = auth
-		p := codec.NewWriter(consts.MaxInt)
+		p := codec.NewWriter(0, consts.MaxInt) // test codec growth
 		gomega.Ω(tx.Marshal(p, actionRegistry, authRegistry)).To(gomega.BeNil())
 		gomega.Ω(p.Err()).To(gomega.BeNil())
 		_, err = instances[0].cli.SubmitTx(
@@ -1793,7 +1793,7 @@ var _ = ginkgo.Describe("[Tx Processing]", func() {
 		auth, err := factory.Sign(msg, tx.Action)
 		gomega.Ω(err).To(gomega.BeNil())
 		tx.Auth = auth
-		p := codec.NewWriter(consts.MaxInt)
+		p := codec.NewWriter(0, consts.MaxInt) // test codec growth
 		gomega.Ω(tx.Marshal(p, actionRegistry, authRegistry)).To(gomega.BeNil())
 		gomega.Ω(p.Err()).To(gomega.BeNil())
 		_, err = instances[0].cli.SubmitTx(

--- a/gossiper/proposer.go
+++ b/gossiper/proposer.go
@@ -158,7 +158,7 @@ func (g *Proposer) ForceGossip(ctx context.Context) error {
 	// Gossip highest paying txs
 	var (
 		txs   = []*chain.Transaction{}
-		size  = uint64(0)
+		size  = 0
 		start = time.Now()
 		now   = start.UnixMilli()
 		r     = g.vm.Rules(now)
@@ -220,7 +220,7 @@ func (g *Proposer) ForceGossip(ctx context.Context) error {
 
 			// Gossip up to [consts.NetworkSizeLimit]
 			txSize := next.Size()
-			if txSize+size > uint64(g.cfg.GossipMaxSize) {
+			if txSize+size > g.cfg.GossipMaxSize {
 				return false, true, false, nil
 			}
 			txs = append(txs, next)

--- a/pubsub/message_buffer.go
+++ b/pubsub/message_buffer.go
@@ -126,13 +126,12 @@ func (m *MessageBuffer) Send(msg []byte) error {
 	return nil
 }
 
-// TODO: re-add maxSize once add codec preallocate
-func CreateBatchMessage(_ int, msgs [][]byte) ([]byte, error) {
+func CreateBatchMessage(maxSize int, msgs [][]byte) ([]byte, error) {
 	size := consts.IntLen
 	for _, msg := range msgs {
 		size += codec.BytesLen(msg)
 	}
-	msgBatch := codec.NewWriter(size)
+	msgBatch := codec.NewWriter(size, maxSize)
 	msgBatch.PackInt(len(msgs))
 	for _, msg := range msgs {
 		msgBatch.PackBytes(msg)

--- a/pubsub/server_test.go
+++ b/pubsub/server_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/logging"
+	"github.com/ava-labs/hypersdk/consts"
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/require"
 )
@@ -150,7 +151,7 @@ func TestServerRead(t *testing.T) {
 	require.NoError(err, "Error connecting to the server.")
 	defer resp.Body.Close()
 	id := ids.GenerateTestID()
-	batchMsg, err := CreateBatchMessage(0, [][]byte{id[:]})
+	batchMsg, err := CreateBatchMessage(consts.NetworkSizeLimit, [][]byte{id[:]})
 	require.NoError(err)
 	err = webCon.WriteMessage(websocket.TextMessage, batchMsg)
 	require.NoError(err, "Error writing message to server.")

--- a/rpc/websocket_packer.go
+++ b/rpc/websocket_packer.go
@@ -19,7 +19,7 @@ const (
 
 func PackBlockMessage(b *chain.StatelessBlock) ([]byte, error) {
 	results := b.Results()
-	size := codec.BytesLen(b.Bytes()) + consts.IntLen + codec.TotalSize(results)
+	size := codec.BytesLen(b.Bytes()) + consts.IntLen + codec.CummSize(results)
 	p := codec.NewWriter(size, consts.MaxInt)
 	p.PackBytes(b.Bytes())
 	mresults, err := chain.MarshalResults(results)

--- a/rpc/websocket_packer.go
+++ b/rpc/websocket_packer.go
@@ -18,13 +18,15 @@ const (
 )
 
 func PackBlockMessage(b *chain.StatelessBlock) ([]byte, error) {
-	p := codec.NewWriter(consts.MaxInt)
+	results := b.Results()
+	size := codec.BytesLen(b.Bytes()) + consts.IntLen + codec.TotalSize(results)
+	p := codec.NewWriter(size, consts.MaxInt)
 	p.PackBytes(b.Bytes())
-	results, err := chain.MarshalResults(b.Results())
+	mresults, err := chain.MarshalResults(results)
 	if err != nil {
 		return nil, err
 	}
-	p.PackBytes(results)
+	p.PackBytes(mresults)
 	return p.Bytes(), p.Err()
 }
 
@@ -54,7 +56,8 @@ func UnpackBlockMessage(
 // Could be a better place for these methods
 // Packs an accepted block message
 func PackAcceptedTxMessage(txID ids.ID, result *chain.Result) ([]byte, error) {
-	p := codec.NewWriter(consts.MaxInt)
+	size := consts.IDLen + codec.BoolLen + result.Size()
+	p := codec.NewWriter(size, consts.MaxInt)
 	p.PackID(txID)
 	p.PackBool(false)
 	result.Marshal(p)
@@ -63,10 +66,12 @@ func PackAcceptedTxMessage(txID ids.ID, result *chain.Result) ([]byte, error) {
 
 // Packs a removed block message
 func PackRemovedTxMessage(txID ids.ID, err error) ([]byte, error) {
-	p := codec.NewWriter(consts.MaxInt)
+	errString := err.Error()
+	size := consts.IDLen + codec.BoolLen + codec.StringLen(errString)
+	p := codec.NewWriter(size, consts.MaxInt)
 	p.PackID(txID)
 	p.PackBool(true)
-	p.PackString(err.Error())
+	p.PackString(errString)
 	return p.Bytes(), p.Err()
 }
 

--- a/rpc/websocket_packer.go
+++ b/rpc/websocket_packer.go
@@ -56,7 +56,7 @@ func UnpackBlockMessage(
 // Could be a better place for these methods
 // Packs an accepted block message
 func PackAcceptedTxMessage(txID ids.ID, result *chain.Result) ([]byte, error) {
-	size := consts.IDLen + codec.BoolLen + result.Size()
+	size := consts.IDLen + consts.BoolLen + result.Size()
 	p := codec.NewWriter(size, consts.MaxInt)
 	p.PackID(txID)
 	p.PackBool(false)
@@ -67,7 +67,7 @@ func PackAcceptedTxMessage(txID ids.ID, result *chain.Result) ([]byte, error) {
 // Packs a removed block message
 func PackRemovedTxMessage(txID ids.ID, err error) ([]byte, error) {
 	errString := err.Error()
-	size := consts.IDLen + codec.BoolLen + codec.StringLen(errString)
+	size := consts.IDLen + consts.BoolLen + codec.StringLen(errString)
 	p := codec.NewWriter(size, consts.MaxInt)
 	p.PackID(txID)
 	p.PackBool(true)


### PR DESCRIPTION
Resolves: #178 

## TODO
- [x] Update usage of `codec`
- [x] re-generate mocks
- [ ] ~remove `Crypto` from `codec`~: https://github.com/ava-labs/hypersdk/issues/287
- [ ] ~remove `Window` from `codec`~: https://github.com/ava-labs/hypersdk/issues/287
- [ ] ~Migrate size-related consts to `codec` (circular dependency before other migrations)~: https://github.com/ava-labs/hypersdk/issues/287