### PR TITLE
avoid type assertion on Action/Auth in switchs

### DIFF
--- a/examples/morpheusvm/cmd/morpheus-cli/cmd/resolutions.go
+++ b/examples/morpheusvm/cmd/morpheus-cli/cmd/resolutions.go
@@ -52,8 +52,9 @@ func handleTx(tx *chain.Transaction, result *chain.Result) {
 	status := "⚠️"
 	if result.Success {
 		status = "✅"
-		switch action := tx.Action.(type) { //nolint:gocritic
-		case *actions.Transfer:
+		switch tx.Action.GetTypeID() { //nolint:gocritic
+		case (&actions.Transfer{}).GetTypeID():
+			action := tx.Action.(*actions.Transfer)
 			summaryStr = fmt.Sprintf("%s %s -> %s", utils.FormatBalance(action.Value), consts.Symbol, tutils.Address(action.To))
 		}
 	}

--- a/examples/morpheusvm/controller/controller.go
+++ b/examples/morpheusvm/controller/controller.go
@@ -163,8 +163,8 @@ func (c *Controller) Accepted(ctx context.Context, blk *chain.StatelessBlock) er
 			}
 		}
 		if result.Success {
-			switch tx.Action.(type) { //nolint:gocritic
-			case *actions.Transfer:
+			switch tx.Action.GetTypeID() { //nolint:gocritic
+			case (&actions.Transfer{}).GetTypeID():
 				c.metrics.transfer.Inc()
 			}
 		}

--- a/examples/tokenvm/auth/helpers.go
+++ b/examples/tokenvm/auth/helpers.go
@@ -9,18 +9,18 @@ import (
 )
 
 func GetActor(auth chain.Auth) crypto.PublicKey {
-	switch a := auth.(type) {
-	case *ED25519:
-		return a.Signer
+	switch auth.GetTypeID() {
+	case (&ED25519{}).GetTypeID():
+		return auth.(*ED25519).Signer
 	default:
 		return crypto.EmptyPublicKey
 	}
 }
 
 func GetSigner(auth chain.Auth) crypto.PublicKey {
-	switch a := auth.(type) {
-	case *ED25519:
-		return a.Signer
+	switch auth.GetTypeID() {
+	case (&ED25519{}).GetTypeID():
+		return auth.(*ED25519).Signer
 	default:
 		return crypto.EmptyPublicKey
 	}

--- a/examples/tokenvm/controller/controller.go
+++ b/examples/tokenvm/controller/controller.go
@@ -176,23 +176,24 @@ func (c *Controller) Accepted(ctx context.Context, blk *chain.StatelessBlock) er
 			}
 		}
 		if result.Success {
-			switch action := tx.Action.(type) {
-			case *actions.CreateAsset:
+			switch tx.Action.GetTypeID() {
+			case (&actions.CreateAsset{}).GetTypeID():
 				c.metrics.createAsset.Inc()
-			case *actions.MintAsset:
+			case (&actions.MintAsset{}).GetTypeID():
 				c.metrics.mintAsset.Inc()
-			case *actions.BurnAsset:
+			case (&actions.BurnAsset{}).GetTypeID():
 				c.metrics.burnAsset.Inc()
-			case *actions.ModifyAsset:
+			case (&actions.ModifyAsset{}).GetTypeID():
 				c.metrics.modifyAsset.Inc()
-			case *actions.Transfer:
+			case (&actions.Transfer{}).GetTypeID():
 				c.metrics.transfer.Inc()
-			case *actions.CreateOrder:
+			case (&actions.CreateOrder{}).GetTypeID():
 				c.metrics.createOrder.Inc()
 				actor := auth.GetActor(tx.Auth)
-				c.orderBook.Add(tx.ID(), actor, action)
-			case *actions.FillOrder:
+				c.orderBook.Add(tx.ID(), actor, tx.Action.(*actions.CreateOrder))
+			case (&actions.FillOrder{}).GetTypeID():
 				c.metrics.fillOrder.Inc()
+				action := tx.Action.(*actions.FillOrder)
 				orderResult, err := actions.UnmarshalOrderResult(result.Output)
 				if err != nil {
 					// This should never happen
@@ -203,12 +204,12 @@ func (c *Controller) Accepted(ctx context.Context, blk *chain.StatelessBlock) er
 					continue
 				}
 				c.orderBook.UpdateRemaining(action.Order, orderResult.Remaining)
-			case *actions.CloseOrder:
+			case (&actions.CloseOrder{}).GetTypeID():
 				c.metrics.closeOrder.Inc()
-				c.orderBook.Remove(action.Order)
-			case *actions.ImportAsset:
+				c.orderBook.Remove(tx.Action.(*actions.CloseOrder).Order)
+			case (&actions.ImportAsset{}).GetTypeID():
 				c.metrics.importAsset.Inc()
-			case *actions.ExportAsset:
+			case (&actions.ExportAsset{}).GetTypeID():
 				c.metrics.exportAsset.Inc()
 			}
 		}


### PR DESCRIPTION
@patrick-ogrady I am not a big fan of switching from type assertion to `GetTypeID()` usage in switch statement.
1. in cases we often use the type assertion.
2. type assertion is faster than reflection we deleted in #297 
3. it makes code more difficult to read