### PR TITLE
[mempool] Cap `mempool.Build` time

### DIFF
--- a/chain/builder.go
+++ b/chain/builder.go
@@ -106,6 +106,7 @@ func BuildBlock(
 	)
 	mempoolErr := mempool.Build(
 		ctx,
+		vm.GetTargetBuildDuration(),
 		func(fctx context.Context, next *Transaction) (cont bool, restore bool, removeAcct bool, err error) {
 			if txsAttempted == 0 {
 				lockWait = time.Since(start)

--- a/chain/builder.go
+++ b/chain/builder.go
@@ -239,6 +239,9 @@ func BuildBlock(
 			return true, false, false, nil
 		},
 	)
+	if time.Since(start) > b.vm.GetTargetBuildDuration() {
+		b.vm.RecordBuildCapped()
+	}
 	span.SetAttributes(
 		attribute.Int("attempted", txsAttempted),
 		attribute.Int("added", len(b.Txs)),

--- a/chain/dependencies.go
+++ b/chain/dependencies.go
@@ -67,6 +67,7 @@ type VM interface {
 	RecordWaitSignatures(time.Duration) // only called in Verify
 	RecordStateChanges(int)
 	RecordStateOperations(int)
+	RecordBuildCapped()
 }
 
 type Mempool interface {

--- a/chain/dependencies.go
+++ b/chain/dependencies.go
@@ -47,6 +47,7 @@ type VM interface {
 
 	Mempool() Mempool
 	IsRepeat(context.Context, []*Transaction) bool
+	GetTargetBuildDuration() time.Duration
 
 	Verified(context.Context, *StatelessBlock)
 	Rejected(context.Context, *StatelessBlock)
@@ -73,6 +74,7 @@ type Mempool interface {
 	Add(context.Context, []*Transaction)
 	Build(
 		context.Context,
+		time.Duration,
 		func(context.Context, *Transaction) (bool /* continue */, bool /* restore */, bool /* remove account */, error),
 	) error
 }

--- a/config/config.go
+++ b/config/config.go
@@ -45,4 +45,6 @@ func (c *Config) GetAcceptedBlockCacheSize() int         { return 128 }
 func (c *Config) GetContinuousProfilerConfig() *profiler.Config {
 	return &profiler.Config{Enabled: false}
 }
-func (c *Config) GetVerifySignatures() bool { return true }
+func (c *Config) GetVerifySignatures() bool              { return true }
+func (c *Config) GetTargetBuildDuration() time.Duration  { return 100 * time.Millisecond }
+func (c *Config) GetTargetGossipDuration() time.Duration { return 20 * time.Millisecond }

--- a/examples/morpheusvm/cmd/morpheus-cli/cmd/prometheus.go
+++ b/examples/morpheusvm/cmd/morpheus-cli/cmd/prometheus.go
@@ -34,6 +34,9 @@ var generatePrometheusCmd = &cobra.Command{
 			panels = append(panels, fmt.Sprintf("increase(avalanche_%s_blks_rejected_count[5s])/5", chainID))
 			utils.Outf("{{yellow}}blocks rejected per second:{{/}} %s\n", panels[len(panels)-1])
 
+			panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hypersdk_chain_build_capped[5s])/5", chainID))
+			utils.Outf("{{yellow}}build capped per second:{{/}} %s\n", panels[len(panels)-1])
+
 			panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hypersdk_vm_txs_submitted[5s])/5", chainID))
 			utils.Outf("{{yellow}}transactions submitted per second:{{/}} %s\n", panels[len(panels)-1])
 
@@ -71,7 +74,7 @@ var generatePrometheusCmd = &cobra.Command{
 			utils.Outf("{{yellow}}memory (avalanchego) usage:{{/}} %s\n", panels[len(panels)-1])
 
 			panels = append(panels, fmt.Sprintf("avalanche_%s_vm_go_memstats_alloc_bytes", chainID))
-			utils.Outf("{{yellow}}memory (tokenvm) usage:{{/}} %s\n", panels[len(panels)-1])
+			utils.Outf("{{yellow}}memory (morpheusvm) usage:{{/}} %s\n", panels[len(panels)-1])
 
 			panels = append(panels, fmt.Sprintf("increase(avalanche_%s_handler_chits_sum[5s])/1000000/5 + increase(avalanche_%s_handler_notify_sum[5s])/1000000/5 + increase(avalanche_%s_handler_get_sum[5s])/1000000/5 + increase(avalanche_%s_handler_push_query_sum[5s])/1000000/5 + increase(avalanche_%s_handler_put_sum[5s])/1000000/5 + increase(avalanche_%s_handler_pull_query_sum[5s])/1000000/5 + increase(avalanche_%s_handler_query_failed_sum[5s])/1000000/5", chainID, chainID, chainID, chainID, chainID, chainID, chainID))
 			utils.Outf("{{yellow}}consensus engine processing (ms/s):{{/}} %s\n", panels[len(panels)-1])

--- a/examples/morpheusvm/scripts/run.sh
+++ b/examples/morpheusvm/scripts/run.sh
@@ -131,12 +131,13 @@ cat <<EOF > ${TMPDIR}/morpheusvm.config
   "verifySignatures":true,
   "storeTransactions":true,
   "streamingBacklogSize": 10000000,
-  "continuousProfilerDir":"${TMPDIR}/morpheusvm-e2e-profiles/*",
   "logLevel": "${LOGLEVEL}",
   "stateSyncServerDelay": ${STATESYNC_DELAY}
 }
 EOF
 mkdir -p ${TMPDIR}/morpheusvm-e2e-profiles
+
+# Profiling config:  {"continuousProfilerDir":"${TMPDIR}/morpheusvm-e2e-profiles/*"}
 
 ############################
 

--- a/examples/morpheusvm/tests/e2e/e2e_test.go
+++ b/examples/morpheusvm/tests/e2e/e2e_test.go
@@ -216,6 +216,8 @@ var _ = ginkgo.BeforeSuite(func() {
 		runner_sdk.WithPluginDir(pluginDir),
 		// We don't disable PUT gossip here because the E2E test adds multiple
 		// non-validating nodes (which will fall behind).
+		//
+		// TODO: re-enable profiling
 		runner_sdk.WithGlobalNodeConfig(`{
 				"log-display-level":"info",
 				"proposervm-use-current-height":true,
@@ -232,7 +234,7 @@ var _ = ginkgo.BeforeSuite(func() {
 				"consensus-on-accept-gossip-peer-size":"10",
 				"network-compression-type":"zstd",
 				"consensus-app-concurrency":"512",
-				"profile-continuous-enabled":true,
+				"profile-continuous-enabled":false,
 				"profile-continuous-freq":"1m"
 			}`),
 	)

--- a/examples/tokenvm/cmd/token-cli/cmd/prometheus.go
+++ b/examples/tokenvm/cmd/token-cli/cmd/prometheus.go
@@ -34,6 +34,9 @@ var generatePrometheusCmd = &cobra.Command{
 			panels = append(panels, fmt.Sprintf("increase(avalanche_%s_blks_rejected_count[5s])/5", chainID))
 			utils.Outf("{{yellow}}blocks rejected per second:{{/}} %s\n", panels[len(panels)-1])
 
+			panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hypersdk_chain_build_capped[5s])/5", chainID))
+			utils.Outf("{{yellow}}build capped per second:{{/}} %s\n", panels[len(panels)-1])
+
 			panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hypersdk_vm_txs_submitted[5s])/5", chainID))
 			utils.Outf("{{yellow}}transactions submitted per second:{{/}} %s\n", panels[len(panels)-1])
 

--- a/examples/tokenvm/scripts/run.sh
+++ b/examples/tokenvm/scripts/run.sh
@@ -136,12 +136,13 @@ cat <<EOF > ${TMPDIR}/tokenvm.config
   "gossipProposerDepth": 1,
   "noGossipBuilderDiff": 5,
   "trackedPairs":["*"],
-  "continuousProfilerDir":"${TMPDIR}/tokenvm-e2e-profiles/*",
   "logLevel": "${LOGLEVEL}",
   "stateSyncServerDelay": ${STATESYNC_DELAY}
 }
 EOF
 mkdir -p ${TMPDIR}/tokenvm-e2e-profiles
+
+# Profiling config: {"continuousProfilerDir":"${TMPDIR}/tokenvm-e2e-profiles/*"}
 
 ############################
 

--- a/examples/tokenvm/tests/e2e/e2e_test.go
+++ b/examples/tokenvm/tests/e2e/e2e_test.go
@@ -210,6 +210,8 @@ var _ = ginkgo.BeforeSuite(func() {
 		runner_sdk.WithPluginDir(pluginDir),
 		// We don't disable PUT gossip here because the E2E test adds multiple
 		// non-validating nodes (which will fall behind).
+		//
+		// TODO: re-enable profiling
 		runner_sdk.WithGlobalNodeConfig(`{
 				"log-display-level":"info",
 				"proposervm-use-current-height":true,
@@ -226,7 +228,7 @@ var _ = ginkgo.BeforeSuite(func() {
 				"consensus-on-accept-gossip-peer-size":"10",
 				"network-compression-type":"zstd",
 				"consensus-app-concurrency":"512",
-				"profile-continuous-enabled":true,
+				"profile-continuous-enabled":false,
 				"profile-continuous-freq":"1m"
 			}`),
 	)

--- a/gossiper/dependencies.go
+++ b/gossiper/dependencies.go
@@ -5,6 +5,7 @@ package gossiper
 
 import (
 	"context"
+	"time"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/trace"
@@ -19,6 +20,7 @@ type VM interface {
 	StopChan() chan struct{}
 	Tracer() trace.Tracer
 	Mempool() chain.Mempool
+	GetTargetGossipDuration() time.Duration
 	Proposers(ctx context.Context, diff int, depth int) (set.Set[ids.NodeID], error)
 	IsValidator(context.Context, ids.NodeID) (bool, error)
 	Logger() logging.Logger

--- a/gossiper/manual.go
+++ b/gossiper/manual.go
@@ -43,6 +43,7 @@ func (g *Manual) ForceGossip(ctx context.Context) error {
 	r := g.vm.Rules(now)
 	mempoolErr := g.vm.Mempool().Build(
 		ctx,
+		g.vm.GetTargetGossipDuration(),
 		func(ictx context.Context, next *chain.Transaction) (cont bool, restore bool, removeAcct bool, err error) {
 			// Remove txs that are expired
 			if next.Base.Timestamp < now {

--- a/gossiper/proposer.go
+++ b/gossiper/proposer.go
@@ -183,6 +183,7 @@ func (g *Proposer) ForceGossip(ctx context.Context) error {
 	}
 	mempoolErr := g.vm.Mempool().Build(
 		ctx,
+		g.vm.GetTargetGossipDuration(),
 		func(ictx context.Context, next *chain.Transaction) (cont bool, restore bool, removeAcct bool, err error) {
 			// Remove txs that are expired
 			if next.Base.Timestamp < now {

--- a/vm/dependencies.go
+++ b/vm/dependencies.go
@@ -39,6 +39,8 @@ type Config interface {
 	GetParsedBlockCacheSize() int
 	GetAcceptedBlockCacheSize() int
 	GetContinuousProfilerConfig() *profiler.Config
+	GetTargetBuildDuration() time.Duration
+	GetTargetGossipDuration() time.Duration
 }
 
 type Genesis interface {

--- a/vm/metrics.go
+++ b/vm/metrics.go
@@ -19,6 +19,7 @@ type Metrics struct {
 	txsAccepted     prometheus.Counter
 	stateChanges    prometheus.Counter
 	stateOperations prometheus.Counter
+	buildCapped     prometheus.Counter
 	mempoolSize     prometheus.Gauge
 	rootCalculated  metric.Averager
 	waitSignatures  metric.Averager
@@ -92,6 +93,11 @@ func newMetrics() (*prometheus.Registry, *Metrics, error) {
 			Name:      "state_operations",
 			Help:      "number of state operations",
 		}),
+		buildCapped: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: "chain",
+			Name:      "build_capped",
+			Help:      "number of times build capped by target duration",
+		}),
 		mempoolSize: prometheus.NewGauge(prometheus.GaugeOpts{
 			Namespace: "chain",
 			Name:      "mempool_size",
@@ -112,6 +118,7 @@ func newMetrics() (*prometheus.Registry, *Metrics, error) {
 		r.Register(m.stateChanges),
 		r.Register(m.stateOperations),
 		r.Register(m.mempoolSize),
+		r.Register(m.buildCapped),
 	)
 	return r, m, errs.Err
 }

--- a/vm/resolutions.go
+++ b/vm/resolutions.go
@@ -374,6 +374,10 @@ func (vm *VM) RecordTxsReceived(c int) {
 	vm.metrics.txsReceived.Add(float64(c))
 }
 
+func (vm *VM) RecordBuildCapped() {
+	vm.metrics.buildCapped.Inc()
+}
+
 func (vm *VM) GetTargetBuildDuration() time.Duration {
 	return vm.config.GetTargetBuildDuration()
 }

--- a/vm/resolutions.go
+++ b/vm/resolutions.go
@@ -373,3 +373,11 @@ func (vm *VM) RecordTxsGossiped(c int) {
 func (vm *VM) RecordTxsReceived(c int) {
 	vm.metrics.txsReceived.Add(float64(c))
 }
+
+func (vm *VM) GetTargetBuildDuration() time.Duration {
+	return vm.config.GetTargetBuildDuration()
+}
+
+func (vm *VM) GetTargetGossipDuration() time.Duration {
+	return vm.config.GetTargetGossipDuration()
+}


### PR DESCRIPTION
Resolves: #283 

This is useful for determining how many units should be allowed in a block.

## Action Items
* https://github.com/ava-labs/hypersdk/issues/331