### PR TITLE
[mempool] Use `Stream` instead of `Build` + Prefetch Mempool Txs/State + Batch `IsRepeat`

### DIFF
--- a/chain/block.go
+++ b/chain/block.go
@@ -434,7 +434,7 @@ func (b *StatelessBlock) innerVerify(ctx context.Context) (merkledb.TrieView, er
 		// Can occur if verifying genesis
 		oldestAllowed = 0
 	}
-	dup, err := parent.IsRepeat(ctx, oldestAllowed, b.Txs, set.Bits{}, true)
+	dup, err := parent.IsRepeat(ctx, oldestAllowed, b.Txs, set.NewBits(), true)
 	if err != nil {
 		return nil, err
 	}

--- a/chain/block.go
+++ b/chain/block.go
@@ -725,6 +725,11 @@ func (b *StatelessBlock) childState(
 	return b.state.NewPreallocatedView(estimatedChanges)
 }
 
+// IsRepeat returns a bitset of all transactions that are considered repeats in
+// the range that spans back to [oldestAllowed].
+//
+// If [stop] is set to true, IsRepeat will return as soon as the first repeat
+// is found (useful for block verification).
 func (b *StatelessBlock) IsRepeat(
 	ctx context.Context,
 	oldestAllowed int64,

--- a/chain/block.go
+++ b/chain/block.go
@@ -756,6 +756,9 @@ func (b *StatelessBlock) IsRepeat(
 		}
 		if b.txsSet.Contains(tx.ID()) {
 			marker.Add(i)
+			if stop {
+				return marker, nil
+			}
 		}
 	}
 	prnt, err := b.vm.GetStatelessBlock(ctx, b.Prnt)

--- a/chain/builder.go
+++ b/chain/builder.go
@@ -248,6 +248,13 @@ func BuildBlock(
 					zap.Uint64("tx max units", nextUnits),
 				)
 				restorable = append(restorable, next)
+
+				// We only stop building once we are within [stopBuildingThreshold] to protect
+				// against a case where there is a very large transaction in the mempool (and the
+				// block is still empty).
+				//
+				// We are willing to give up building early (although there may be some remaining space)
+				// to avoid iterating over everything in the mempool to find something that may fit.
 				if r.GetMaxBlockUnits()-b.UnitsConsumed < stopBuildingThreshold {
 					execErr = errBlockFull
 				}

--- a/chain/builder.go
+++ b/chain/builder.go
@@ -196,7 +196,7 @@ func BuildBlock(
 
 		// Execute transactions as they become ready
 		ctx, executeSpan := vm.Tracer().Start(ctx, "chain.BuildBlock.Execute")
-		seen := 0
+		txIndex := 0
 		for nextTxData := range readyTxs {
 			txsAttempted++
 			next := nextTxData.tx
@@ -206,10 +206,10 @@ func BuildBlock(
 			}
 
 			// Skip if tx is a duplicate
-			if dup.Contains(seen) {
+			if dup.Contains(txIndex) {
 				continue
 			}
-			seen++
+			txIndex++
 
 			// Ensure we can process if transaction includes a warp message
 			if next.WarpMessage != nil && blockContext == nil {
@@ -402,12 +402,10 @@ func BuildBlock(
 	}
 	log.Info(
 		"built block",
+		zap.Bool("context", blockContext != nil),
 		zap.Uint64("hght", b.Hght),
 		zap.Int("attempted", txsAttempted),
 		zap.Int("added", len(b.Txs)),
-		zap.Int("restored", len(restorable)),
-		zap.Int("mempool size", b.vm.Mempool().Len(ctx)),
-		zap.Bool("context", blockContext != nil),
 		zap.Int("state changes", ts.PendingChanges()),
 		zap.Int("state operations", ts.OpIndex()),
 		zap.Int64("parent (t)", parent.Tmstmp),

--- a/chain/builder.go
+++ b/chain/builder.go
@@ -108,6 +108,7 @@ func BuildBlock(
 	for time.Since(start) < vm.GetTargetBuildDuration() {
 		// Bulk fetch items from mempool to unblock incoming RPC/Gossip traffic
 		var execErr error
+		// TODO: make this size a config
 		txs := mempool.LeaseItems(ctx, 256)
 		if len(txs) == 0 {
 			break
@@ -156,7 +157,7 @@ func BuildBlock(
 		}()
 
 		// Perform a batch repeat check while we are waiting for state prefetching
-		dup, err := parent.IsRepeat(ctx, oldestAllowed, txs, set.Bits{}, false)
+		dup, err := parent.IsRepeat(ctx, oldestAllowed, txs, set.NewBits(), false)
 		if err != nil {
 			execErr = err
 		}

--- a/chain/builder.go
+++ b/chain/builder.go
@@ -119,7 +119,7 @@ func BuildBlock(
 	for time.Since(start) < vm.GetTargetBuildDuration() {
 		// Bulk fetch items from mempool to unblock incoming RPC/Gossip traffic
 		var execErr error
-		fl.Lock()
+		fl.Lock() // ensures we don't run Prepare twice without reading values first
 		txs := mempool.LeaseItems(ctx, leaseBatch)
 		fl.Unlock()
 		if len(txs) == 0 {

--- a/chain/builder.go
+++ b/chain/builder.go
@@ -111,13 +111,17 @@ func BuildBlock(
 		alreadyFetched = map[string]*fetchData{}
 
 		// Ensures we don't exit without waiting for all prepare leases to come back
+		//
+		// TODO: find a way to refactor to remove this
 		fl sync.Mutex
 	)
 	mempool.StartBuild(ctx)
 	for time.Since(start) < vm.GetTargetBuildDuration() {
 		// Bulk fetch items from mempool to unblock incoming RPC/Gossip traffic
 		var execErr error
+		fl.Lock()
 		txs := mempool.LeaseItems(ctx, leaseBatch)
+		fl.Unlock()
 		if len(txs) == 0 {
 			break
 		}

--- a/chain/dependencies.go
+++ b/chain/dependencies.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ava-labs/avalanchego/snow/validators"
 	"github.com/ava-labs/avalanchego/trace"
 	"github.com/ava-labs/avalanchego/utils/logging"
+	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/vms/platformvm/warp"
 	"github.com/ava-labs/avalanchego/x/merkledb"
 
@@ -50,7 +51,7 @@ type VM interface {
 	ValidatorState() validators.State
 
 	Mempool() Mempool
-	IsRepeat(context.Context, []*Transaction) bool
+	IsRepeat(context.Context, []*Transaction, set.Bits, bool) set.Bits
 	GetTargetBuildDuration() time.Duration
 
 	Verified(context.Context, *StatelessBlock)

--- a/chain/dependencies.go
+++ b/chain/dependencies.go
@@ -86,10 +86,10 @@ type Mempool interface {
 		func(context.Context, *Transaction) (cont bool, restore bool, err error),
 	) error
 
-	StartBuild(context.Context)
-	PrepareLeaseItems(context.Context, int)
-	LeaseItems(context.Context, int) []*Transaction
-	FinishBuild(context.Context, []*Transaction)
+	StartStreaming(context.Context)
+	PrepareStream(context.Context, int)
+	Stream(context.Context, int) []*Transaction
+	FinishStreaming(context.Context, []*Transaction)
 }
 
 type Database interface {

--- a/chain/dependencies.go
+++ b/chain/dependencies.go
@@ -89,7 +89,7 @@ type Mempool interface {
 	StartStreaming(context.Context)
 	PrepareStream(context.Context, int)
 	Stream(context.Context, int) []*Transaction
-	FinishStreaming(context.Context, []*Transaction)
+	FinishStreaming(context.Context, []*Transaction) int
 }
 
 type Database interface {

--- a/chain/dependencies.go
+++ b/chain/dependencies.go
@@ -85,6 +85,7 @@ type Mempool interface {
 		func(context.Context, *Transaction) (bool /* continue */, bool /* restore */, bool /* remove account */, error),
 	) error
 	StartBuild(context.Context)
+	PrepareLeaseItems(context.Context, int)
 	LeaseItems(context.Context, int) []*Transaction
 	FinishBuild(context.Context, []*Transaction)
 }

--- a/chain/dependencies.go
+++ b/chain/dependencies.go
@@ -83,6 +83,9 @@ type Mempool interface {
 		time.Duration,
 		func(context.Context, *Transaction) (bool /* continue */, bool /* restore */, bool /* remove account */, error),
 	) error
+	StartBuild(context.Context)
+	LeaseItems(context.Context, int) []*Transaction
+	FinishBuild(context.Context, []*Transaction)
 }
 
 type Database interface {

--- a/chain/dependencies.go
+++ b/chain/dependencies.go
@@ -79,11 +79,13 @@ type VM interface {
 type Mempool interface {
 	Len(context.Context) int
 	Add(context.Context, []*Transaction)
-	Build(
+
+	Top(
 		context.Context,
 		time.Duration,
-		func(context.Context, *Transaction) (bool /* continue */, bool /* restore */, bool /* remove account */, error),
+		func(context.Context, *Transaction) (cont bool, restore bool, err error),
 	) error
+
 	StartBuild(context.Context)
 	PrepareLeaseItems(context.Context, int)
 	LeaseItems(context.Context, int) []*Transaction

--- a/emap/emap.go
+++ b/emap/emap.go
@@ -123,3 +123,21 @@ func (e *EMap[T]) Any(items []T) bool {
 	}
 	return false
 }
+
+func (e *EMap[T]) Contains(items []T, marker set.Bits, stop bool) set.Bits {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+
+	for i, item := range items {
+		if marker.Contains(i) {
+			continue
+		}
+		if e.seen.Contains(item.ID()) {
+			marker.Add(i)
+			if stop {
+				return marker
+			}
+		}
+	}
+	return marker
+}

--- a/examples/morpheusvm/tests/load/load_test.go
+++ b/examples/morpheusvm/tests/load/load_test.go
@@ -404,7 +404,7 @@ var _ = ginkgo.Describe("load tests vm", func() {
 				}
 			}
 
-			gomega.Ω(requiredTxs).To(gomega.BeEmpty())
+			gomega.Ω(len(requiredTxs)).To(gomega.BeZero())
 		})
 	})
 
@@ -418,6 +418,7 @@ var _ = ginkgo.Describe("load tests vm", func() {
 			gomega.Ω(err).Should(gomega.BeNil())
 			for i := 0; i < txs; i++ {
 				j.Go(func() error {
+					// TODO make this way more efficient
 					var txID ids.ID
 					for {
 						// It is ok if a transfer is to self
@@ -461,7 +462,7 @@ var _ = ginkgo.Describe("load tests vm", func() {
 				}
 				blks = append(blks, blk)
 			}
-			gomega.Ω(allTxs).To(gomega.BeEmpty())
+			gomega.Ω(len(allTxs)).To(gomega.BeZero())
 			blockGen = time.Since(start)
 		})
 	})

--- a/examples/tokenvm/tests/integration/integration_test.go
+++ b/examples/tokenvm/tests/integration/integration_test.go
@@ -575,9 +575,9 @@ var _ = ginkgo.Describe("[Tx Processing]", func() {
 			tx := blk2.(*chain.StatelessBlock).Txs[0]
 			sblk3 := blk3.(*chain.StatelessBlock)
 			sblk3t := sblk3.Timestamp().UnixMilli()
-			ok, err := sblk3.IsRepeat(ctx, sblk3t-n.vm.Rules(sblk3t).GetValidityWindow(), []*chain.Transaction{tx})
+			ok, err := sblk3.IsRepeat(ctx, sblk3t-n.vm.Rules(sblk3t).GetValidityWindow(), []*chain.Transaction{tx}, set.NewBits(), false)
 			gomega.Ω(err).Should(gomega.BeNil())
-			gomega.Ω(ok).Should(gomega.BeTrue())
+			gomega.Ω(ok.Len()).Should(gomega.Equal(1))
 
 			// Accept tip
 			err = blk1.Accept(ctx)
@@ -597,7 +597,7 @@ var _ = ginkgo.Describe("[Tx Processing]", func() {
 
 			// Check if tx from old block would be considered a repeat on accepted tip
 			time.Sleep(2 * time.Second)
-			gomega.Ω(n.vm.IsRepeat(ctx, []*chain.Transaction{tx})).Should(gomega.BeTrue())
+			gomega.Ω(n.vm.IsRepeat(ctx, []*chain.Transaction{tx}, set.NewBits(), false).Len()).Should(gomega.Equal(1))
 		})
 	})
 

--- a/examples/tokenvm/tests/integration/integration_test.go
+++ b/examples/tokenvm/tests/integration/integration_test.go
@@ -1830,6 +1830,15 @@ var _ = ginkgo.Describe("[Tx Processing]", func() {
 		gomega.Ω(err).To(gomega.Not(gomega.BeNil()))
 		gomega.Ω(blk).To(gomega.BeNil())
 
+		// Wait for mempool to be size 1 (txs are restored async)
+		for {
+			if instances[0].vm.Mempool().Len(context.Background()) > 0 {
+				break
+			}
+			log.Info("waiting for txs to be restored")
+			time.Sleep(100 * time.Millisecond)
+		}
+
 		// Build block with context
 		accept := expectBlkWithContext(instances[0])
 		results := accept()

--- a/gossiper/manual.go
+++ b/gossiper/manual.go
@@ -41,13 +41,13 @@ func (g *Manual) ForceGossip(ctx context.Context) error {
 	totalUnits := uint64(0)
 	now := time.Now().UnixMilli()
 	r := g.vm.Rules(now)
-	mempoolErr := g.vm.Mempool().Build(
+	mempoolErr := g.vm.Mempool().Top(
 		ctx,
 		g.vm.GetTargetGossipDuration(),
-		func(ictx context.Context, next *chain.Transaction) (cont bool, restore bool, removeAcct bool, err error) {
+		func(ictx context.Context, next *chain.Transaction) (cont bool, restore bool, err error) {
 			// Remove txs that are expired
 			if next.Base.Timestamp < now {
-				return true, false, false, nil
+				return true, false, nil
 			}
 
 			// Gossip up to a block of content
@@ -55,16 +55,16 @@ func (g *Manual) ForceGossip(ctx context.Context) error {
 			units, err := next.MaxUnits(r)
 			if err != nil {
 				// Should never happen
-				return true, false, false, nil
+				return true, false, nil
 			}
 			// TODO: limit to a smaller amount
 			if units+totalUnits > r.GetMaxBlockUnits() {
 				// Attempt to mirror the function of building a block without execution
-				return false, true, false, nil
+				return false, true, nil
 			}
 			txs = append(txs, next)
 			totalUnits += units
-			return true, true, false, nil
+			return true, true, nil
 		},
 	)
 	if mempoolErr != nil {

--- a/gossiper/proposer.go
+++ b/gossiper/proposer.go
@@ -181,19 +181,19 @@ func (g *Proposer) ForceGossip(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	mempoolErr := g.vm.Mempool().Build(
+	mempoolErr := g.vm.Mempool().Top(
 		ctx,
 		g.vm.GetTargetGossipDuration(),
-		func(ictx context.Context, next *chain.Transaction) (cont bool, restore bool, removeAcct bool, err error) {
+		func(ictx context.Context, next *chain.Transaction) (cont bool, restore bool, err error) {
 			// Remove txs that are expired
 			if next.Base.Timestamp < now {
-				return true, false, false, nil
+				return true, false, nil
 			}
 
 			// Don't gossip txs that are about to expire
 			life := next.Base.Timestamp - now
 			if life < g.cfg.GossipMinLife {
-				return true, true, false, nil
+				return true, true, nil
 			}
 
 			// Don't gossip txs we received from other nodes (original gossiper will
@@ -203,7 +203,7 @@ func (g *Proposer) ForceGossip(ctx context.Context) error {
 			// We still keep these transactions in our mempool as they may still be
 			// the highest-paying transaction to execute at a given time.
 			if _, has := g.receivedTxs.Get(next.ID()); has {
-				return true, true, false, nil
+				return true, true, nil
 			}
 
 			// PreExecute does not make any changes to state
@@ -213,18 +213,18 @@ func (g *Proposer) ForceGossip(ctx context.Context) error {
 			if err := next.PreExecute(ctx, ectx, r, state, now); err != nil {
 				// Do not gossip invalid txs (may become invalid during normal block
 				// processing)
-				cont, restore, removeAcct := chain.HandlePreExecute(err)
-				return cont, restore, removeAcct, nil
+				cont, restore, _ := chain.HandlePreExecute(err)
+				return cont, restore, nil
 			}
 
 			// Gossip up to [consts.NetworkSizeLimit]
 			txSize := next.Size()
 			if txSize+size > g.cfg.GossipMaxSize {
-				return false, true, false, nil
+				return false, true, nil
 			}
 			txs = append(txs, next)
 			size += txSize
-			return true, true, false, nil
+			return true, true, nil
 		},
 	)
 	if mempoolErr != nil {

--- a/gossiper/proposer.go
+++ b/gossiper/proposer.go
@@ -282,6 +282,8 @@ func (g *Proposer) HandleAppGossip(ctx context.Context, nodeID ids.NodeID, msg [
 	}
 
 	// Submit incoming gossip to mempool
+	//
+	// TODO: use batch verification and batched repeat check
 	start := time.Now()
 	for _, err := range g.vm.Submit(ctx, true, txs) {
 		if err == nil || errors.Is(err, chain.ErrDuplicateTx) {

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -118,12 +118,10 @@ func (th *Mempool[T]) add(items []T) {
 		// Ensure no duplicate
 		itemID := item.ID()
 		if th.leasedItems != nil && th.leasedItems.Contains(itemID) {
-			panic("in leased")
 			continue
 		}
 		if th.pm.Has(itemID) {
 			// Don't drop because already exists
-			panic("already exists")
 			continue
 		}
 
@@ -146,7 +144,6 @@ func (th *Mempool[T]) add(items []T) {
 			lowItem, _ := th.pm.PopMin()
 			th.tm.Remove(lowItem.ID())
 			th.removeFromOwned(lowItem)
-			panic("larger than max")
 		}
 	}
 }
@@ -385,8 +382,8 @@ func (th *Mempool[T]) FinishBuild(ctx context.Context, restorable []T) {
 	th.leasedItems = nil
 	th.add(restorable)
 	if th.nextLeastFetched {
-		fmt.Println("next lease restored", len(th.nextLease))
 		th.add(th.nextLease)
+		fmt.Println("next lease restored", len(th.nextLease))
 		th.nextLease = nil
 		th.nextLeastFetched = false
 	}

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -379,19 +379,22 @@ func (th *Mempool[T]) streamItems(count int) []T {
 
 // FinishStreaming restores [restorable] items to the mempool and clears
 // the set of all previously streamed items.
-func (th *Mempool[T]) FinishStreaming(ctx context.Context, restorable []T) {
+func (th *Mempool[T]) FinishStreaming(ctx context.Context, restorable []T) int {
 	_, span := th.tracer.Start(ctx, "Mempool.FinishStreaming")
 	defer span.End()
 
 	th.mu.Lock()
 	defer th.mu.Unlock()
 
+	restored := len(restorable)
 	th.streamedItems = nil
 	th.add(restorable)
 	if th.nextStreamFetched {
 		th.add(th.nextStream)
+		restored += len(th.nextStream)
 		th.nextStream = nil
 		th.nextStreamFetched = false
 	}
 	th.streamLock.Unlock()
+	return restored
 }

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -275,6 +275,7 @@ func (th *Mempool[T]) SetMinTimestamp(ctx context.Context, t int64) []T {
 	return removed
 }
 
+// TODO: use a different name for this
 func (th *Mempool[T]) Build(
 	ctx context.Context,
 	targetDuration time.Duration,

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -336,7 +336,7 @@ func (th *Mempool[T]) StartStreaming(ctx context.Context) {
 // PrepareStream prefetches the next [count] items from the mempool to
 // reduce the latency of calls to [StreamItems].
 func (th *Mempool[T]) PrepareStream(ctx context.Context, count int) {
-	ctx, span := th.tracer.Start(ctx, "Mempool.PrepareStream")
+	_, span := th.tracer.Start(ctx, "Mempool.PrepareStream")
 	defer span.End()
 
 	th.mu.Lock()
@@ -349,7 +349,7 @@ func (th *Mempool[T]) PrepareStream(ctx context.Context, count int) {
 // Stream gets the next highest-valued [count] items from the mempool, not
 // including what has already been streamed.
 func (th *Mempool[T]) Stream(ctx context.Context, count int) []T {
-	ctx, span := th.tracer.Start(ctx, "Mempool.Stream")
+	_, span := th.tracer.Start(ctx, "Mempool.Stream")
 	defer span.End()
 
 	th.mu.Lock()
@@ -380,7 +380,7 @@ func (th *Mempool[T]) streamItems(count int) []T {
 // FinishStreaming restores [restorable] items to the mempool and clears
 // the set of all previously streamed items.
 func (th *Mempool[T]) FinishStreaming(ctx context.Context, restorable []T) {
-	ctx, span := th.tracer.Start(ctx, "Mempool.FinishStreaming")
+	_, span := th.tracer.Start(ctx, "Mempool.FinishStreaming")
 	defer span.End()
 
 	th.mu.Lock()

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -325,7 +325,7 @@ func (th *Mempool[T]) Top(
 // Streaming is useful for block building because we can get a feed of the
 // best txs to build without holding the lock during the duration of the build
 // process. Streaming in batches allows for various state prefetching operations.
-func (th *Mempool[T]) StartStreaming(ctx context.Context) {
+func (th *Mempool[T]) StartStreaming(_ context.Context) {
 	th.mu.Lock()
 	defer th.mu.Unlock()
 

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -326,7 +326,7 @@ func (th *Mempool[T]) StartBuild(ctx context.Context) {
 	defer th.mu.Unlock()
 
 	th.bl.Lock()
-	th.leasedItems = set.NewSet[ids.ID](1_024)
+	th.leasedItems = set.NewSet[ids.ID](16_384)
 }
 
 func (th *Mempool[T]) LeaseItems(ctx context.Context, count int) []T {
@@ -352,6 +352,7 @@ func (th *Mempool[T]) FinishBuild(ctx context.Context, restorable []T) {
 	th.mu.Lock()
 	defer th.mu.Unlock()
 
+	th.leasedItems = nil
 	th.add(restorable)
 	th.bl.Unlock()
 }

--- a/vm/resolutions.go
+++ b/vm/resolutions.go
@@ -90,11 +90,11 @@ func (vm *VM) Mempool() chain.Mempool {
 	return vm.mempool
 }
 
-func (vm *VM) IsRepeat(ctx context.Context, txs []*chain.Transaction) bool {
+func (vm *VM) IsRepeat(ctx context.Context, txs []*chain.Transaction, marker set.Bits, stop bool) set.Bits {
 	_, span := vm.tracer.Start(ctx, "VM.IsRepeat")
 	defer span.End()
 
-	return vm.seen.Any(txs)
+	return vm.seen.Contains(txs, marker, stop)
 }
 
 func (vm *VM) Verified(ctx context.Context, b *chain.StatelessBlock) {

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/crypto/bls"
 	"github.com/ava-labs/avalanchego/utils/profiler"
+	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/version"
 	"github.com/ava-labs/avalanchego/x/merkledb"
 	syncEng "github.com/ava-labs/avalanchego/x/sync"
@@ -708,12 +709,12 @@ func (vm *VM) Submit(
 			continue
 		}
 		// TODO: Batch this repeat check (and collect multiple txs at once)
-		repeat, err := blk.IsRepeat(ctx, oldestAllowed, []*chain.Transaction{tx})
+		repeat, err := blk.IsRepeat(ctx, oldestAllowed, []*chain.Transaction{tx}, set.Bits{}, true)
 		if err != nil {
 			errs = append(errs, err)
 			continue
 		}
-		if repeat {
+		if repeat.Len() > 0 {
 			errs = append(errs, chain.ErrDuplicateTx)
 			continue
 		}

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -709,7 +709,7 @@ func (vm *VM) Submit(
 			continue
 		}
 		// TODO: Batch this repeat check (and collect multiple txs at once)
-		repeat, err := blk.IsRepeat(ctx, oldestAllowed, []*chain.Transaction{tx}, set.Bits{}, true)
+		repeat, err := blk.IsRepeat(ctx, oldestAllowed, []*chain.Transaction{tx}, set.NewBits(), true)
 		if err != nil {
 			errs = append(errs, err)
 			continue


### PR DESCRIPTION
Resolves: #249 

### Testing (10k accounts, 500k txs, M2 Max)
#### Before [`main`] (~86856 TPS)
```
[1] block generation {"t": "5.646185875s", "avg(ms)": 115, "tps": 88555.35596408256}
[2] block generation {"t": "5.6602125s", "avg(ms)": 113, "tps": 88335.90611659898}
[3] block generation {"t": "5.770886625s", "avg(ms)": 117, "tps": 86641.7991706777}
[4] block generation {"t": "5.646529958s", "avg(ms)": 115, "tps": 88549.95966002098}
[5] block generation {"t": "6.082898417s", "avg(ms)": 124, "tps": 82197.65738691934}
```

#### After (~108493 TPS) => ~24.9% boost in build speed 🎉 
```
[1] block generation {"t": "4.482730875s", "avg(ms)": 91, "tps": 111539.1519014623}
[2] block generation {"t": "4.759061083s", "avg(ms)": 95, "tps": 105062.74058680747}
[3] block generation {"t": "4.592278459s", "avg(ms)": 93, "tps": 108878.41503167001}
[4] block generation {"t": "4.618432834s", "avg(ms)": 94, "tps": 108261.83209141805}
[5] block generation {"t": "4.598757792s", "avg(ms)": 93, "tps": 108725.01284364228}
```

### TODO
- [x] `Build` -> `Top`
- [x] Remove account purging (avoid iteration and just wait for cleanup naturally)