### PR TITLE
[vm] async builder+verifier

### DIFF
--- a/chain/dependencies.go
+++ b/chain/dependencies.go
@@ -46,6 +46,8 @@ type VM interface {
 	SetLastAccepted(*StatelessBlock) error
 	GetStatelessBlock(context.Context, ids.ID) (*StatelessBlock, error)
 
+	GetAsyncBuildVerify() bool
+
 	State() (merkledb.MerkleDB, error)
 	StateManager() StateManager
 	ValidatorState() validators.State

--- a/chain/errors.go
+++ b/chain/errors.go
@@ -66,4 +66,5 @@ var (
 	// Misc
 	ErrNotImplemented    = errors.New("not implemented")
 	ErrBlockNotProcessed = errors.New("block is not processed")
+	ErrVerifyingAsync    = errors.New("verifying async")
 )

--- a/config/config.go
+++ b/config/config.go
@@ -48,3 +48,4 @@ func (c *Config) GetContinuousProfilerConfig() *profiler.Config {
 func (c *Config) GetVerifySignatures() bool              { return true }
 func (c *Config) GetTargetBuildDuration() time.Duration  { return 100 * time.Millisecond }
 func (c *Config) GetTargetGossipDuration() time.Duration { return 20 * time.Millisecond }
+func (c *Config) GetAsyncBuildVerify() bool              { return true }

--- a/vm/dependencies.go
+++ b/vm/dependencies.go
@@ -41,6 +41,7 @@ type Config interface {
 	GetContinuousProfilerConfig() *profiler.Config
 	GetTargetBuildDuration() time.Duration
 	GetTargetGossipDuration() time.Duration
+	GetAsyncBuildVerify() bool
 }
 
 type Genesis interface {

--- a/vm/errors.go
+++ b/vm/errors.go
@@ -8,9 +8,10 @@ import (
 )
 
 var (
-	ErrNotAdded     = errors.New("not added")
-	ErrDropped      = errors.New("dropped")
-	ErrNotReady     = errors.New("not ready")
-	ErrStateMissing = errors.New("state missing")
-	ErrStateSyncing = errors.New("state still syncing")
+	ErrNotAdded      = errors.New("not added")
+	ErrDropped       = errors.New("dropped")
+	ErrNotReady      = errors.New("not ready")
+	ErrBuildingAsync = errors.New("building async")
+	ErrStateMissing  = errors.New("state missing")
+	ErrStateSyncing  = errors.New("state still syncing")
 )

--- a/vm/resolutions.go
+++ b/vm/resolutions.go
@@ -408,3 +408,7 @@ func (vm *VM) cacheAuth(auth chain.Auth) {
 	}
 	bv.Cache(auth)
 }
+
+func (vm *VM) GetAsyncBuildVerify() bool {
+	return vm.config.GetAsyncBuildVerify()
+}

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -660,7 +660,7 @@ func (vm *VM) buildBlock(
 		if builtBlock.Prnt == vm.preferred && ((builtContext == nil && blockContext == nil) || (builtContext != nil && blockContext != nil && builtContext.PChainHeight == blockContext.PChainHeight)) {
 			vm.snowCtx.Log.Info("found previously built block", zap.Stringer("blkID", builtBlock.ID()), zap.Uint64("height", builtBlock.Hght))
 			vm.parsedBlocks.Put(builtBlock.ID(), builtBlock)
-			return vm.builtBlock, nil
+			return builtBlock, nil
 		}
 		vm.snowCtx.Log.Info("discarding previously built block", zap.Stringer("blkID", builtBlock.ID()), zap.Uint64("height", builtBlock.Hght))
 		vm.mempool.Add(ctx, builtBlock.Txs)

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -625,8 +625,8 @@ func (vm *VM) buildBlock(
 		return nil, ErrNotReady
 	}
 
-	// If async building is not enabled or the mempool is empty, we'll build synchronously
-	if !vm.config.GetAsyncBuildVerify() || vm.mempool.Len(ctx) == 0 {
+	// If async building is not enabled, we'll build synchronously
+	if !vm.config.GetAsyncBuildVerify() {
 		// Notify builder if we should build again (whether or not we are successful this time)
 		//
 		// Note: builder should regulate whether or not it actually decides to build based on state

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -5,6 +5,7 @@ package vm
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
 	"net/http"
 	"sync"
@@ -262,6 +263,9 @@ func (vm *VM) Initialize(
 		}
 		if err := vm.genesis.Load(ctx, vm.tracer, view); err != nil {
 			snowCtx.Log.Error("could not set genesis allocation", zap.Error(err))
+			return err
+		}
+		if err := view.Insert(ctx, vm.StateManager().HeightKey(), binary.BigEndian.AppendUint64(nil, 0)); err != nil {
 			return err
 		}
 		if err := view.CommitToDB(ctx); err != nil {

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -645,6 +645,7 @@ func (vm *VM) buildBlock(
 		vm.snowCtx.Log.Warn("BuildBlock failed", zap.Error(err))
 		return nil, err
 	}
+	// TODO: only store in parsed after we actually use the block
 	vm.parsedBlocks.Put(blk.ID(), blk)
 	return blk, nil
 }


### PR DESCRIPTION
Resolves: #304 

Under high load, we saturate the consensus engine (causes instability/leads to us not utilizing all resources): 
![image](https://github.com/ava-labs/hypersdk/assets/13023275/670dd57e-5ee1-4d8a-b529-674f6f585c97)


### TODO
- [ ] Add metric for discarded build blocks/verify blocks
- [ ] Add metric for wait between finish build/verify and usage
- [ ] Add cumulative network metric for inbound/outbound bandwidth