### PR TITLE
Update CODEOWNERS for the x/ package

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 * @patrick-ogrady
-/x/programs/ @hexfusion @samliok
+/x/programs/ @hexfusion @samliok @patrick-ogrady


### PR DESCRIPTION
Although `*` covers every directory defining specific owners to a directory overrides the default owner. This PR adds @patrick-ogrady to `\x\programs`.