### PR TITLE
[x/gossip] Activity-Based Gossip

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -3,9 +3,11 @@
 
 package builder
 
+import "context"
+
 type Builder interface {
 	Run()
-	Queue() // new tx, block verified, post-block build (if mempool > 0)
-	Force()
+	Queue(context.Context) // new tx, block verified, post-block build (if mempool > 0)
+	Force(context.Context) error
 	Done() // wait after stop
 }

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -5,7 +5,7 @@ package builder
 
 type Builder interface {
 	Run()
-	QueueNotify() // new tx, block verified, post-block build (if mempool > 0)
-	ForceNotify()
+	Queue() // new tx, block verified, post-block build (if mempool > 0)
+	Force()
 	Done() // wait after stop
 }

--- a/builder/manual.go
+++ b/builder/manual.go
@@ -3,7 +3,11 @@
 
 package builder
 
-import "github.com/ava-labs/avalanchego/snow/engine/common"
+import (
+	"context"
+
+	"github.com/ava-labs/avalanchego/snow/engine/common"
+)
 
 var _ Builder = (*Manual)(nil)
 
@@ -24,14 +28,15 @@ func (b *Manual) Run() {
 }
 
 // Queue is a no-op in [Manual].
-func (*Manual) Queue() {}
+func (*Manual) Queue(context.Context) {}
 
-func (b *Manual) Force() {
+func (b *Manual) Force(context.Context) error {
 	select {
 	case b.vm.EngineChan() <- common.PendingTxs:
 	default:
 		b.vm.Logger().Debug("dropping message to consensus engine")
 	}
+	return nil
 }
 
 func (b *Manual) Done() {

--- a/builder/manual.go
+++ b/builder/manual.go
@@ -23,9 +23,10 @@ func (b *Manual) Run() {
 	close(b.doneBuild)
 }
 
-func (*Manual) QueueNotify() {}
+// Queue is a no-op in [Manual].
+func (*Manual) Queue() {}
 
-func (b *Manual) ForceNotify() {
+func (b *Manual) Force() {
 	select {
 	case b.vm.EngineChan() <- common.PendingTxs:
 	default:

--- a/builder/time.go
+++ b/builder/time.go
@@ -13,6 +13,7 @@ import (
 	"go.uber.org/zap"
 )
 
+// TODO: block building can fail, fill in context
 const minBuildGap int64 = 30 // ms
 
 var _ Builder = (*Time)(nil)
@@ -72,6 +73,7 @@ func (b *Time) QueueNotify() {
 		}
 		sleep = b.lastQueue + minBuildGap - now
 	} else {
+		// TODO: this may not respect minBuildGap
 		sleep = preferredBlk.Tmstmp + gap - now
 	}
 	sleepDur := time.Duration(sleep * int64(time.Millisecond))

--- a/cache/fifo.go
+++ b/cache/fifo.go
@@ -38,6 +38,7 @@ func (f *FIFO[K, V]) Put(key K, val V) bool {
 	var exists bool
 	if _, ok := f.m[key]; !ok {
 		f.buffer.Push(key) // Insert will remove the oldest [K] if we are at the [limit]
+	} else {
 		exists = true
 	}
 	f.m[key] = val

--- a/cache/fifo.go
+++ b/cache/fifo.go
@@ -10,13 +10,15 @@ import (
 )
 
 type FIFO[K comparable, V any] struct {
-	l sync.RWMutex
-
+	l      sync.RWMutex
 	buffer buffer.Queue[K]
 	m      map[K]V
 }
 
 // NewFIFO creates a new First-In-First-Out cache of size [limit].
+//
+// If a duplicate item is stored, it will not be requeued but its
+// value will be changed.
 func NewFIFO[K comparable, V any](limit int) (*FIFO[K, V], error) {
 	c := &FIFO[K, V]{
 		m: make(map[K]V, limit),
@@ -29,12 +31,17 @@ func NewFIFO[K comparable, V any](limit int) (*FIFO[K, V], error) {
 	return c, nil
 }
 
-func (f *FIFO[K, V]) Put(key K, val V) {
+func (f *FIFO[K, V]) Put(key K, val V) bool {
 	f.l.Lock()
 	defer f.l.Unlock()
 
-	f.buffer.Push(key) // Insert will remove the oldest [K] if we are at the [limit]
+	var exists bool
+	if _, ok := f.m[key]; !ok {
+		f.buffer.Push(key) // Insert will remove the oldest [K] if we are at the [limit]
+		exists = true
+	}
 	f.m[key] = val
+	return exists
 }
 
 func (f *FIFO[K, V]) Get(key K) (V, bool) {

--- a/chain/builder.go
+++ b/chain/builder.go
@@ -402,7 +402,7 @@ func BuildBlock(
 			// Update block with new transaction
 			b.Txs = append(b.Txs, next)
 			usedKeys.Add(stateKeys.List()...)
-			if err := nextFeeManager.Consume(result.Units); err != nil {
+			if err := nextFeeManager.Consume(result.Consumed); err != nil {
 				execErr = err
 				continue
 			}

--- a/chain/builder.go
+++ b/chain/builder.go
@@ -402,7 +402,7 @@ func BuildBlock(
 			// Update block with new transaction
 			b.Txs = append(b.Txs, next)
 			usedKeys.Add(stateKeys.List()...)
-			if err := nextFeeManager.Consume(nextUnits); err != nil {
+			if err := nextFeeManager.Consume(result.Units); err != nil {
 				execErr = err
 				continue
 			}

--- a/chain/dependencies.go
+++ b/chain/dependencies.go
@@ -122,7 +122,19 @@ type Rules interface {
 	GetWarpComputeUnitsPerSigner() uint64
 	GetOutgoingWarpComputeUnits() uint64
 
-	// Controllers must manage the max key length and max value length
+	// Invariants:
+	// * Controllers must manage the max key length and max value length (max network
+	//   limit is ~2MB)
+	// * Cold key reads/modifications are assumed to be more expensive than warm
+	//   when estimating the max fee
+	// * Keys are only charged once per transaction (even if used multiple times), it is
+	//   up to the controller to ensure multiple usage has some compute cost
+	//
+	// Interesting Scenarios:
+	// * If a key is created and then modified during a transaction, the second
+	//   read will be a warm read of 0 chunks (reads are based on disk contents before exec)
+	// * If a key is removed and then re-created during a transaction, it counts
+	//   as a modification and a creation instead of just a modification
 	GetColdStorageKeyReadUnits() uint64
 	GetColdStorageValueReadUnits() uint64 // per chunk
 	GetWarmStorageKeyReadUnits() uint64
@@ -181,6 +193,8 @@ type Action interface {
 	//
 	// All keys specified must be suffixed with the number of chunks that could ever be read from that
 	// key (formatted as a big-endian uint16). This is used to automatically calculate storage usage.
+	//
+	// If any key is removed and then re-created, this will count as a creation instead of a modification.
 	StateKeys(auth Auth, txID ids.ID) []string
 
 	// StateKeysMaxChunks is used to estimate the fee a transaction should pay. It includes the max
@@ -278,6 +292,9 @@ type Auth interface {
 
 	// Refund returns [amount] to [Auth] after transaction execution if any fees were
 	// not used.
+	//
+	// Refund will return an error if it attempts to create any new keys. It can only
+	// modify or remove existing keys.
 	//
 	// Refund is only invoked if [amount] > 0.
 	Refund(ctx context.Context, db Database, amount uint64) error

--- a/chain/dependencies.go
+++ b/chain/dependencies.go
@@ -80,7 +80,8 @@ type VM interface {
 }
 
 type Mempool interface {
-	Len(context.Context) int
+	Len(context.Context) int  // items
+	Size(context.Context) int // bytes
 	Add(context.Context, []*Transaction)
 
 	Top(

--- a/chain/errors.go
+++ b/chain/errors.go
@@ -69,4 +69,5 @@ var (
 	ErrBlockNotProcessed      = errors.New("block is not processed")
 	ErrInvalidKeyValue        = errors.New("invalid key or value")
 	ErrModificationNotAllowed = errors.New("modification not allowed")
+	ErrWrongDimensionSize     = errors.New("wrong dimensions size")
 )

--- a/chain/fee_manager.go
+++ b/chain/fee_manager.go
@@ -285,7 +285,7 @@ func (d Dimensions) Bytes() []byte {
 // Greater is used to determine if the max units allowed
 // are greater than the units consumed by a transaction.
 //
-// THis would be considered a fatal error.
+// This would be considered a fatal error.
 func (d Dimensions) Greater(o Dimensions) bool {
 	for i := Dimension(0); i < FeeDimensions; i++ {
 		if d[i] < o[i] {

--- a/chain/fee_manager.go
+++ b/chain/fee_manager.go
@@ -5,11 +5,10 @@ package chain
 
 import (
 	"encoding/binary"
-	"errors"
+	"fmt"
 	"strconv"
 
 	"github.com/ava-labs/avalanchego/utils/math"
-	"github.com/ava-labs/hypersdk/codec"
 	"github.com/ava-labs/hypersdk/consts"
 	"github.com/ava-labs/hypersdk/window"
 )
@@ -63,7 +62,7 @@ func (f *FeeManager) ComputeNext(lastTime int64, currTime int64, r Rules) (*FeeM
 	unitPriceChangeDenom := r.GetUnitPriceChangeDenominator()
 	minUnitPrice := r.GetMinUnitPrice()
 	since := int((currTime - lastTime) / consts.MillisecondsPerSecond)
-	packer := codec.NewWriter(dimensionStateLen*FeeDimensions, consts.MaxInt)
+	bytes := make([]byte, dimensionStateLen*FeeDimensions)
 	for i := Dimension(0); i < FeeDimensions; i++ {
 		nextUnitPrice, nextUnitWindow, err := computeNextPriceWindow(
 			f.Window(i),
@@ -77,11 +76,12 @@ func (f *FeeManager) ComputeNext(lastTime int64, currTime int64, r Rules) (*FeeM
 		if err != nil {
 			return nil, err
 		}
-		packer.PackUint64(nextUnitPrice)
-		packer.PackWindow(nextUnitWindow)
-		packer.PackUint64(0) // must set usage after block is processed
+		start := dimensionStateLen * i
+		binary.BigEndian.PutUint64(bytes[start:start+consts.Uint64Len], nextUnitPrice)
+		copy(bytes[start+consts.Uint64Len:start+consts.Uint64Len+window.WindowSliceSize], nextUnitWindow[:])
+		// Usage must be set after block is processed (we leave as 0 for now)
 	}
-	return &FeeManager{raw: packer.Bytes()}, packer.Err()
+	return &FeeManager{raw: bytes}, nil
 }
 
 func (f *FeeManager) SetUnitPrice(d Dimension, price uint64) {
@@ -142,6 +142,14 @@ func (f *FeeManager) UnitPrices() Dimensions {
 	var d Dimensions
 	for i := Dimension(0); i < FeeDimensions; i++ {
 		d[i] = f.UnitPrice(i)
+	}
+	return d
+}
+
+func (f *FeeManager) UnitsConsumed() Dimensions {
+	var d Dimensions
+	for i := Dimension(0); i < FeeDimensions; i++ {
+		d[i] = f.LastConsumed(i)
 	}
 	return d
 }
@@ -266,26 +274,41 @@ func (d Dimensions) CanAdd(a Dimensions, l Dimensions) bool {
 	return true
 }
 
-func (d Dimensions) Bytes() ([]byte, error) {
-	packer := codec.NewWriter(DimensionsLen, consts.MaxInt)
+func (d Dimensions) Bytes() []byte {
+	bytes := make([]byte, DimensionsLen)
 	for i := Dimension(0); i < FeeDimensions; i++ {
-		packer.PackUint64(d[i])
+		binary.BigEndian.PutUint64(bytes[i*consts.Uint64Len:], d[i])
 	}
-	return packer.Bytes(), packer.Err()
+	return bytes
+}
+
+// Greater is used to determine if the max units allowed
+// are greater than the units consumed by a transaction.
+//
+// THis would be considered a fatal error.
+func (d Dimensions) Greater(o Dimensions) bool {
+	for i := Dimension(0); i < FeeDimensions; i++ {
+		if d[i] < o[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func UnpackDimensions(raw []byte) (Dimensions, error) {
-	d := Dimensions{}
-	packer := codec.NewReader(raw, DimensionsLen)
-	for i := Dimension(0); i < FeeDimensions; i++ {
-		d[i] = packer.UnpackUint64(false)
+	if len(raw) != DimensionsLen {
+		return Dimensions{}, fmt.Errorf("%w: found=%d wanted=%d", ErrWrongDimensionSize, len(raw), DimensionsLen)
 	}
-	return d, packer.Err()
+	d := Dimensions{}
+	for i := Dimension(0); i < FeeDimensions; i++ {
+		d[i] = binary.BigEndian.Uint64(raw[i*consts.Uint64Len:])
+	}
+	return d, nil
 }
 
 func ParseDimensions(raw []string) (Dimensions, error) {
 	if len(raw) != FeeDimensions {
-		return Dimensions{}, errors.New("invalid dimensions size")
+		return Dimensions{}, ErrWrongDimensionSize
 	}
 	d := Dimensions{}
 	for i := Dimension(0); i < FeeDimensions; i++ {

--- a/chain/processor.go
+++ b/chain/processor.go
@@ -169,8 +169,8 @@ func (p *Processor) Execute(
 		}
 		results = append(results, result)
 
-		// Update block metadata
-		if err := feeManager.Consume(nextUnits); err != nil {
+		// Update block metadata with units actually consumed
+		if err := feeManager.Consume(result.Units); err != nil {
 			return nil, 0, 0, err
 		}
 	}

--- a/chain/processor.go
+++ b/chain/processor.go
@@ -170,7 +170,7 @@ func (p *Processor) Execute(
 		results = append(results, result)
 
 		// Update block metadata with units actually consumed
-		if err := feeManager.Consume(result.Units); err != nil {
+		if err := feeManager.Consume(result.Consumed); err != nil {
 			return nil, 0, 0, err
 		}
 	}

--- a/chain/result.go
+++ b/chain/result.go
@@ -31,11 +31,7 @@ func (r *Result) Size() int {
 func (r *Result) Marshal(p *codec.Packer) error {
 	p.PackBool(r.Success)
 	p.PackBytes(r.Output)
-	usedBytes, err := r.Units.Bytes()
-	if err != nil {
-		return err
-	}
-	p.PackFixedBytes(usedBytes)
+	p.PackFixedBytes(r.Units.Bytes())
 	p.PackUint64(r.Fee)
 	var warpBytes []byte
 	if r.WarpMessage != nil {

--- a/chain/result.go
+++ b/chain/result.go
@@ -12,8 +12,9 @@ import (
 type Result struct {
 	Success bool
 	Output  []byte
-	Units   Dimensions
-	Fee     uint64
+
+	Consumed Dimensions
+	Fee      uint64
 
 	WarpMessage *warp.UnsignedMessage
 }
@@ -31,7 +32,7 @@ func (r *Result) Size() int {
 func (r *Result) Marshal(p *codec.Packer) error {
 	p.PackBool(r.Success)
 	p.PackBytes(r.Output)
-	p.PackFixedBytes(r.Units.Bytes())
+	p.PackFixedBytes(r.Consumed.Bytes())
 	p.PackUint64(r.Fee)
 	var warpBytes []byte
 	if r.WarpMessage != nil {
@@ -62,13 +63,13 @@ func UnmarshalResult(p *codec.Packer) (*Result, error) {
 		// Enforce object standardization
 		result.Output = nil
 	}
-	dimensionsRaw := make([]byte, DimensionsLen)
-	p.UnpackFixedBytes(DimensionsLen, &dimensionsRaw)
-	dimensions, err := UnpackDimensions(dimensionsRaw)
+	consumedRaw := make([]byte, DimensionsLen)
+	p.UnpackFixedBytes(DimensionsLen, &consumedRaw)
+	consumed, err := UnpackDimensions(consumedRaw)
 	if err != nil {
 		return nil, err
 	}
-	result.Units = dimensions
+	result.Consumed = consumed
 	result.Fee = p.UnpackUint64(false)
 	var warpMessage []byte
 	p.UnpackBytes(MaxWarpMessageSize, false, &warpMessage)

--- a/chain/transaction.go
+++ b/chain/transaction.go
@@ -467,7 +467,7 @@ func (t *Transaction) Execute(
 	// to pessimistically precompute the storage it will change.
 	for _, key := range t.Auth.StateKeys() {
 		bk := []byte(key)
-		changed, exists, err := tdb.Exists(ctx, bk)
+		changed, _, err := tdb.Exists(ctx, bk)
 		if err != nil {
 			tdb.Rollback(ctx, actionStart)
 			return &Result{false, utils.ErrBytes(err), maxUnits, maxFee, nil}, nil
@@ -479,14 +479,19 @@ func (t *Transaction) Execute(
 			tdb.Rollback(ctx, actionStart)
 			return &Result{false, utils.ErrBytes(ErrInvalidKeyValue), maxUnits, maxFee, nil}, nil
 		}
-		if !exists {
-			// We pessimistically assume any keys that are referenced will be created
-			// if they don't yet exist.
-			creations[key] = maxChunks
-			continue
-		}
-		if changed {
-			warmModifications[key] = maxChunks
+		// We require that any refunds must not create keys, otherwise, we'd have
+		// to pessimistically charge all transactions for creation.
+		//
+		// If a key is already in [coldModifications], we should still
+		// consider it a [coldModification] even if it is [changed].
+		// This occurs when we modify a key for the second time in
+		// a single transaction.
+		//
+		// If a key is not in [coldModifications] and it is [changed],
+		// it was either created/modified in a different transaction
+		// in the block or created in this transaction.
+		if _, ok := coldModifications[key]; ok || !changed {
+			coldModifications[key] = maxChunks
 			continue
 		}
 		warmModifications[key] = maxChunks
@@ -533,21 +538,32 @@ func (t *Transaction) Execute(
 		return &Result{false, utils.ErrBytes(err), maxUnits, maxFee, nil}, nil
 	}
 	used := Dimensions{uint64(t.Size()), computeUnits, reads, creationUnits, modifications}
-	feeRequired, err := feeManager.MaxFee(used)
-	if err != nil {
-		tdb.Rollback(ctx, actionStart)
-		return &Result{false, utils.ErrBytes(err), maxUnits, maxFee, nil}, nil
+
+	// Check to see if the units consumed are greater than the max units
+	//
+	// This should never be the case but erroring here is better than
+	// underflowing the refund.
+	if !maxUnits.Greater(used) {
+		return nil, fmt.Errorf("%w: max=%+v consumed=%+v", ErrInvalidUnitsConsumed, maxUnits, used)
 	}
 
 	// Return any funds from unused units
 	//
 	// To avoid storage abuse of [Auth.Refund], we precharge for possible usage.
+	feeRequired, err := feeManager.MaxFee(used)
+	if err != nil {
+		tdb.Rollback(ctx, actionStart)
+		return &Result{false, utils.ErrBytes(err), maxUnits, maxFee, nil}, nil
+	}
 	refund := maxFee - feeRequired
 	if refund > 0 {
+		tdb.DisableCreation()
 		if err := t.Auth.Refund(ctx, tdb, refund); err != nil {
+			tdb.EnableCreation()
 			tdb.Rollback(ctx, actionStart)
 			return &Result{false, utils.ErrBytes(err), maxUnits, maxFee, nil}, nil
 		}
+		tdb.EnableCreation()
 	}
 	return &Result{
 		Success: success,

--- a/chain/transaction.go
+++ b/chain/transaction.go
@@ -568,8 +568,9 @@ func (t *Transaction) Execute(
 	return &Result{
 		Success: success,
 		Output:  output,
-		Units:   used,
-		Fee:     feeRequired,
+
+		Consumed: used,
+		Fee:      feeRequired,
 
 		WarpMessage: warpMessage,
 	}, nil

--- a/cli/chain.go
+++ b/cli/chain.go
@@ -222,9 +222,17 @@ func (h *Handler) WatchChain(hideTxs bool, getParser func(string, uint32, ids.ID
 		tpsWindow         = window.Window{}
 	)
 	for ctx.Err() == nil {
-		blk, results, err := scli.ListenBlock(ctx, parser)
+		blk, results, prices, err := scli.ListenBlock(ctx, parser)
 		if err != nil {
 			return err
+		}
+		consumed := chain.Dimensions{}
+		for _, result := range results {
+			nconsumed, err := chain.Add(consumed, result.Consumed)
+			if err != nil {
+				return err
+			}
+			consumed = nconsumed
 		}
 		now := time.Now()
 		if start.IsZero() {
@@ -241,34 +249,31 @@ func (h *Handler) WatchChain(hideTxs bool, getParser func(string, uint32, ids.ID
 			runningDuration := time.Since(start)
 			tpsDivisor := math.Min(window.WindowSize, runningDuration.Seconds())
 			utils.Outf(
-				"{{green}}height:{{/}}%d {{green}}txs:{{/}}%d {{green}}root:{{/}}%s {{green}}size:{{/}}%.2fKB [{{green}}TPS:{{/}}%.2f {{green}}latency:{{/}}%dms {{green}}gap:{{/}}%dms]\n",
+				"{{green}}height:{{/}}%d {{green}}txs:{{/}}%d {{green}}root:{{/}}%s {{green}}size:{{/}}%.2fKB {{green}}units consumed:{{/}} [%s] {{green}}unit prices:{{/}} [%s] [{{green}}TPS:{{/}}%.2f {{green}}latency:{{/}}%dms {{green}}gap:{{/}}%dms]\n",
 				blk.Hght,
 				len(blk.Txs),
 				blk.StateRoot,
 				float64(blk.Size())/units.KiB,
+				ParseDimensions(consumed),
+				ParseDimensions(prices),
 				float64(window.Sum(tpsWindow))/tpsDivisor,
 				time.Now().UnixMilli()-blk.Tmstmp,
 				time.Since(lastBlockDetailed).Milliseconds(),
 			)
 		} else {
 			utils.Outf(
-				"{{green}}height:{{/}}%d {{green}}txs:{{/}}%d {{green}}root:{{/}}%s {{green}}size:{{/}}%.2fKB\n",
+				"{{green}}height:{{/}}%d {{green}}txs:{{/}}%d {{green}}root:{{/}}%s {{green}}size:{{/}}%.2fKB {{green}}units consumed:{{/}} [%s] {{green}}unit prices:{{/}} [%s]\n",
 				blk.Hght,
 				len(blk.Txs),
 				blk.StateRoot,
 				float64(blk.Size())/units.KiB,
+				ParseDimensions(consumed),
+				ParseDimensions(prices),
 			)
 			window.Update(&tpsWindow, window.WindowSliceSize-consts.Uint64Len, uint64(len(blk.Txs)))
 		}
 		lastBlock = now.Unix()
 		lastBlockDetailed = now
-		if blk.Hght%10 == 0 {
-			unitPrices, err := rcli.UnitPrices(ctx)
-			if err != nil {
-				return err
-			}
-			PrintUnitPrices(unitPrices)
-		}
 		if hideTxs {
 			continue
 		}

--- a/examples/morpheusvm/actions/transfer.go
+++ b/examples/morpheusvm/actions/transfer.go
@@ -62,7 +62,7 @@ func (t *Transfer) Execute(
 	if err := storage.SubBalance(ctx, db, actor, t.Value); err != nil {
 		return false, 1, utils.ErrBytes(err), nil, nil
 	}
-	if err := storage.AddBalance(ctx, db, t.To, t.Value); err != nil {
+	if err := storage.AddBalance(ctx, db, t.To, t.Value, true); err != nil {
 		return false, 1, utils.ErrBytes(err), nil, nil
 	}
 	return true, 1, nil, nil, nil

--- a/examples/morpheusvm/auth/ed25519.go
+++ b/examples/morpheusvm/auth/ed25519.go
@@ -110,7 +110,8 @@ func (d *ED25519) Refund(
 	db chain.Database,
 	amount uint64,
 ) error {
-	return storage.AddBalance(ctx, db, d.Signer, amount)
+	// Don't create account if it doesn't exist (may have sent all funds).
+	return storage.AddBalance(ctx, db, d.Signer, amount, false)
 }
 
 var _ chain.AuthFactory = (*ED25519Factory)(nil)

--- a/examples/morpheusvm/cmd/morpheus-cli/cmd/prometheus.go
+++ b/examples/morpheusvm/cmd/morpheus-cli/cmd/prometheus.go
@@ -65,6 +65,9 @@ var generatePrometheusCmd = &cobra.Command{
 			panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hypersdk_vm_txs_received[5s])/5", chainID))
 			utils.Outf("{{yellow}}transactions received per second:{{/}} %s\n", panels[len(panels)-1])
 
+			panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hypersdk_vm_seen_txs_received[5s])/5", chainID))
+			utils.Outf("{{yellow}}seen transactions received per second:{{/}} %s\n", panels[len(panels)-1])
+
 			panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hypersdk_vm_txs_verified[5s])/5", chainID))
 			utils.Outf("{{yellow}}transactions verified per second:{{/}} %s\n", panels[len(panels)-1])
 

--- a/examples/morpheusvm/cmd/morpheus-cli/cmd/resolutions.go
+++ b/examples/morpheusvm/cmd/morpheus-cli/cmd/resolutions.go
@@ -59,7 +59,7 @@ func handleTx(tx *chain.Transaction, result *chain.Result) {
 		}
 	}
 	utils.Outf(
-		"%s {{yellow}}%s{{/}} {{yellow}}actor:{{/}} %s {{yellow}}summary (%s):{{/}} [%s] {{yellow}}fee (max %.2f%%):{{/}} %s %s {{yellow}}units:{{/}} [%s]\n",
+		"%s {{yellow}}%s{{/}} {{yellow}}actor:{{/}} %s {{yellow}}summary (%s):{{/}} [%s] {{yellow}}fee (max %.2f%%):{{/}} %s %s {{yellow}}consumed:{{/}} [%s]\n",
 		status,
 		tx.ID(),
 		tutils.Address(actor),
@@ -68,6 +68,6 @@ func handleTx(tx *chain.Transaction, result *chain.Result) {
 		float64(result.Fee)/float64(tx.Base.MaxFee)*100,
 		handler.Root().ValueString(ids.Empty, result.Fee),
 		handler.Root().AssetString(ids.Empty),
-		cli.ParseDimensions(result.Units),
+		cli.ParseDimensions(result.Consumed),
 	)
 }

--- a/examples/morpheusvm/controller/controller.go
+++ b/examples/morpheusvm/controller/controller.go
@@ -158,7 +158,7 @@ func (c *Controller) Accepted(ctx context.Context, blk *chain.StatelessBlock) er
 				tx.ID(),
 				blk.GetTimestamp(),
 				result.Success,
-				result.Units,
+				result.Consumed,
 				result.Fee,
 			)
 			if err != nil {

--- a/examples/morpheusvm/controller/controller.go
+++ b/examples/morpheusvm/controller/controller.go
@@ -130,7 +130,10 @@ func (c *Controller) Initialize(
 	} else {
 		build = builder.NewTime(inner)
 		gcfg := gossiper.DefaultProposerConfig()
-		gossip = gossiper.NewProposer(inner, gcfg)
+		gossip, err = gossiper.NewProposer(inner, gcfg)
+		if err != nil {
+			return nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, err
+		}
 	}
 	return c.config, c.genesis, build, gossip, blockDB, stateDB, apis, consts.ActionRegistry, consts.AuthRegistry, auth.Engines(), nil
 }

--- a/examples/morpheusvm/tests/e2e/e2e_test.go
+++ b/examples/morpheusvm/tests/e2e/e2e_test.go
@@ -735,7 +735,7 @@ func acceptTransaction(cli *rpc.JSONRPCClient, lcli *lrpc.JSONRPCClient) {
 		// Generate transaction
 		other, err := ed25519.GeneratePrivateKey()
 		gomega.Ω(err).Should(gomega.BeNil())
-		unitPrices, err := cli.UnitPrices(context.Background())
+		unitPrices, err := cli.UnitPrices(context.Background(), false)
 		gomega.Ω(err).Should(gomega.BeNil())
 		submit, tx, maxFee, err := cli.GenerateTransaction(
 			context.Background(),

--- a/examples/morpheusvm/tests/e2e/e2e_test.go
+++ b/examples/morpheusvm/tests/e2e/e2e_test.go
@@ -219,6 +219,7 @@ var _ = ginkgo.BeforeSuite(func() {
 		//
 		// TODO: re-enable profiling
 		runner_sdk.WithGlobalNodeConfig(`{
+				"log-level":"info",
 				"log-display-level":"info",
 				"proposervm-use-current-height":true,
 				"throttler-inbound-validator-alloc-size":"10737418240",

--- a/examples/morpheusvm/tests/integration/integration_test.go
+++ b/examples/morpheusvm/tests/integration/integration_test.go
@@ -418,8 +418,8 @@ var _ = ginkgo.Describe("[Tx Processing]", func() {
 			// read: 2 keys reads, 1 had 0 chunks
 			// create: 1 key created
 			// modify: 1 cold key modified
-			transferTxFee := chain.Dimensions{190, 7, 12, 25, 13}
-			gomega.Ω(results[0].Units).Should(gomega.Equal(transferTxFee))
+			transferTxConsumed := chain.Dimensions{190, 7, 12, 25, 13}
+			gomega.Ω(results[0].Consumed).Should(gomega.Equal(transferTxConsumed))
 
 			// Fee explanation
 			//
@@ -465,8 +465,8 @@ var _ = ginkgo.Describe("[Tx Processing]", func() {
 			// read: 2 keys reads, 1 chunk each
 			// create: 0 key created
 			// modify: 2 cold key modified
-			transferTxFee := chain.Dimensions{190, 7, 14, 0, 26}
-			gomega.Ω(results[0].Units).Should(gomega.Equal(transferTxFee))
+			transferTxConsumed := chain.Dimensions{190, 7, 14, 0, 26}
+			gomega.Ω(results[0].Consumed).Should(gomega.Equal(transferTxConsumed))
 
 			// Fee explanation
 			//
@@ -545,8 +545,8 @@ var _ = ginkgo.Describe("[Tx Processing]", func() {
 			// create: 0 key created
 			// modify: 2 cold key modified
 			gomega.Ω(results[0].Success).Should(gomega.BeTrue())
-			transferTxFee := chain.Dimensions{190, 7, 14, 0, 26}
-			gomega.Ω(results[0].Units).Should(gomega.Equal(transferTxFee))
+			transferTxConsumed := chain.Dimensions{190, 7, 14, 0, 26}
+			gomega.Ω(results[0].Consumed).Should(gomega.Equal(transferTxConsumed))
 			// Fee explanation
 			//
 			// Multiply all unit consumption by 1 and sum
@@ -560,8 +560,8 @@ var _ = ginkgo.Describe("[Tx Processing]", func() {
 			// create: 0 key created
 			// modify: 2 warm keys modified
 			gomega.Ω(results[1].Success).Should(gomega.BeTrue())
-			transferTxFee = chain.Dimensions{190, 7, 4, 0, 16}
-			gomega.Ω(results[1].Units).Should(gomega.Equal(transferTxFee))
+			transferTxConsumed = chain.Dimensions{190, 7, 4, 0, 16}
+			gomega.Ω(results[1].Consumed).Should(gomega.Equal(transferTxConsumed))
 			// Fee explanation
 			//
 			// Multiply all unit consumption by 1 and sum
@@ -575,8 +575,8 @@ var _ = ginkgo.Describe("[Tx Processing]", func() {
 			// create: 1 key created (1 chunk)
 			// modify: 1 warm key modified (1 chunk)
 			gomega.Ω(results[2].Success).Should(gomega.BeTrue())
-			transferTxFee = chain.Dimensions{190, 7, 7, 25, 8}
-			gomega.Ω(results[2].Units).Should(gomega.Equal(transferTxFee))
+			transferTxConsumed = chain.Dimensions{190, 7, 7, 25, 8}
+			gomega.Ω(results[2].Consumed).Should(gomega.Equal(transferTxConsumed))
 			// Fee explanation
 			//
 			// Multiply all unit consumption by 1 and sum
@@ -590,8 +590,8 @@ var _ = ginkgo.Describe("[Tx Processing]", func() {
 			// create: 0 key created
 			// modify: 2 warm keys modified (1 chunk)
 			gomega.Ω(results[3].Success).Should(gomega.BeTrue())
-			transferTxFee = chain.Dimensions{190, 7, 3, 0, 16}
-			gomega.Ω(results[3].Units).Should(gomega.Equal(transferTxFee))
+			transferTxConsumed = chain.Dimensions{190, 7, 3, 0, 16}
+			gomega.Ω(results[3].Consumed).Should(gomega.Equal(transferTxConsumed))
 			// Fee explanation
 			//
 			// Multiply all unit consumption by 1 and sum
@@ -775,12 +775,13 @@ var _ = ginkgo.Describe("[Tx Processing]", func() {
 		gomega.Ω(results[0].Success).Should(gomega.BeTrue())
 
 		// Read item from connection
-		blk, lresults, err := cli.ListenBlock(context.TODO(), parser)
+		blk, lresults, prices, err := cli.ListenBlock(context.TODO(), parser)
 		gomega.Ω(err).Should(gomega.BeNil())
 		gomega.Ω(len(blk.Txs)).Should(gomega.Equal(1))
 		tx := blk.Txs[0].Action.(*actions.Transfer)
 		gomega.Ω(tx.Value).To(gomega.Equal(uint64(1)))
 		gomega.Ω(lresults).Should(gomega.Equal(results))
+		gomega.Ω(prices).Should(gomega.Equal(chain.Dimensions{1, 1, 1, 1, 1}))
 
 		// Check balance modifications are correct
 		balancea, err := instances[0].lcli.Balance(context.TODO(), sender)

--- a/examples/morpheusvm/tests/integration/integration_test.go
+++ b/examples/morpheusvm/tests/integration/integration_test.go
@@ -50,8 +50,6 @@ import (
 	"github.com/ava-labs/hypersdk/examples/morpheusvm/utils"
 )
 
-var transferTxFee = chain.Dimensions{190, 7, 12, 25, 21}
-
 var (
 	logFactory logging.Factory
 	log        logging.Logger
@@ -343,7 +341,7 @@ var _ = ginkgo.Describe("[Tx Processing]", func() {
 		})
 
 		ginkgo.By("send gossip from node 0 to 1", func() {
-			err := instances[0].vm.Gossiper().ForceGossip(context.TODO())
+			err := instances[0].vm.Gossiper().Force(context.TODO())
 			gomega.Ω(err).Should(gomega.BeNil())
 		})
 
@@ -386,7 +384,7 @@ var _ = ginkgo.Describe("[Tx Processing]", func() {
 		})
 
 		ginkgo.By("receive gossip in the node 1, and signal block build", func() {
-			instances[1].vm.Builder().ForceNotify()
+			gomega.Ω(instances[1].vm.Builder().Force(context.TODO())).To(gomega.BeNil())
 			<-instances[1].toEngine
 		})
 
@@ -411,14 +409,28 @@ var _ = ginkgo.Describe("[Tx Processing]", func() {
 			results := blk.(*chain.StatelessBlock).Results()
 			gomega.Ω(results).Should(gomega.HaveLen(1))
 			gomega.Ω(results[0].Success).Should(gomega.BeTrue())
-			gomega.Ω(results[0].Units).Should(gomega.Equal(transferTxFee))
 			gomega.Ω(results[0].Output).Should(gomega.BeNil())
+
+			// Unit explanation
+			//
+			// bandwidth: tx size
+			// compute: 5 for signature, 1 for base, 1 for transfer
+			// read: 2 keys reads, 1 had 0 chunks
+			// create: 1 key created
+			// modify: 1 cold key modified
+			transferTxFee := chain.Dimensions{190, 7, 12, 25, 13}
+			gomega.Ω(results[0].Units).Should(gomega.Equal(transferTxFee))
+
+			// Fee explanation
+			//
+			// Multiply all unit consumption by 1 and sum
+			gomega.Ω(results[0].Fee).Should(gomega.Equal(uint64(247)))
 		})
 
 		ginkgo.By("ensure balance is updated", func() {
 			balance, err := instances[1].lcli.Balance(context.Background(), sender)
 			gomega.Ω(err).To(gomega.BeNil())
-			gomega.Ω(balance).To(gomega.Equal(uint64(9899745)))
+			gomega.Ω(balance).To(gomega.Equal(uint64(9899753)))
 			balance2, err := instances[1].lcli.Balance(context.Background(), sender2)
 			gomega.Ω(err).To(gomega.BeNil())
 			gomega.Ω(balance2).To(gomega.Equal(uint64(100000)))
@@ -446,9 +458,152 @@ var _ = ginkgo.Describe("[Tx Processing]", func() {
 			gomega.Ω(results).Should(gomega.HaveLen(1))
 			gomega.Ω(results[0].Success).Should(gomega.BeTrue())
 
+			// Unit explanation
+			//
+			// bandwidth: tx size
+			// compute: 5 for signature, 1 for base, 1 for transfer
+			// read: 2 keys reads, 1 chunk each
+			// create: 0 key created
+			// modify: 2 cold key modified
+			transferTxFee := chain.Dimensions{190, 7, 14, 0, 26}
+			gomega.Ω(results[0].Units).Should(gomega.Equal(transferTxFee))
+
+			// Fee explanation
+			//
+			// Multiply all unit consumption by 1 and sum
+			gomega.Ω(results[0].Fee).Should(gomega.Equal(uint64(237)))
+
 			balance2, err := instances[1].lcli.Balance(context.Background(), sender2)
 			gomega.Ω(err).To(gomega.BeNil())
 			gomega.Ω(balance2).To(gomega.Equal(uint64(100101)))
+		})
+
+		ginkgo.By("transfer funds again (test storage keys)", func() {
+			parser, err := instances[1].lcli.Parser(context.Background())
+			gomega.Ω(err).Should(gomega.BeNil())
+
+			submit, _, _, err := instances[1].cli.GenerateTransaction(
+				context.Background(),
+				parser,
+				nil,
+				&actions.Transfer{
+					To:    rsender2,
+					Value: 102,
+				},
+				factory,
+			)
+			gomega.Ω(err).Should(gomega.BeNil())
+			gomega.Ω(submit(context.Background())).Should(gomega.BeNil())
+			submit, _, _, err = instances[1].cli.GenerateTransaction(
+				context.Background(),
+				parser,
+				nil,
+				&actions.Transfer{
+					To:    rsender2,
+					Value: 103,
+				},
+				factory,
+			)
+			gomega.Ω(err).Should(gomega.BeNil())
+			gomega.Ω(submit(context.Background())).Should(gomega.BeNil())
+			submit, _, _, err = instances[1].cli.GenerateTransaction(
+				context.Background(),
+				parser,
+				nil,
+				&actions.Transfer{
+					To:    rsender3,
+					Value: 104,
+				},
+				factory,
+			)
+			gomega.Ω(err).Should(gomega.BeNil())
+			gomega.Ω(submit(context.Background())).Should(gomega.BeNil())
+			submit, _, _, err = instances[1].cli.GenerateTransaction(
+				context.Background(),
+				parser,
+				nil,
+				&actions.Transfer{
+					To:    rsender3,
+					Value: 105,
+				},
+				factory,
+			)
+			gomega.Ω(err).Should(gomega.BeNil())
+			gomega.Ω(submit(context.Background())).Should(gomega.BeNil())
+
+			accept := expectBlk(instances[1])
+			results := accept()
+
+			// Check results
+			gomega.Ω(results).Should(gomega.HaveLen(4))
+
+			// Unit explanation
+			//
+			// bandwidth: tx size
+			// compute: 5 for signature, 1 for base, 1 for transfer
+			// read: 2 cold keys reads, 1 chunk each
+			// create: 0 key created
+			// modify: 2 cold key modified
+			gomega.Ω(results[0].Success).Should(gomega.BeTrue())
+			transferTxFee := chain.Dimensions{190, 7, 14, 0, 26}
+			gomega.Ω(results[0].Units).Should(gomega.Equal(transferTxFee))
+			// Fee explanation
+			//
+			// Multiply all unit consumption by 1 and sum
+			gomega.Ω(results[0].Fee).Should(gomega.Equal(uint64(237)))
+
+			// Unit explanation
+			//
+			// bandwidth: tx size
+			// compute: 5 for signature, 1 for base, 1 for transfer
+			// read: 2 warm keys reads, 1 chunk each
+			// create: 0 key created
+			// modify: 2 warm keys modified
+			gomega.Ω(results[1].Success).Should(gomega.BeTrue())
+			transferTxFee = chain.Dimensions{190, 7, 4, 0, 16}
+			gomega.Ω(results[1].Units).Should(gomega.Equal(transferTxFee))
+			// Fee explanation
+			//
+			// Multiply all unit consumption by 1 and sum
+			gomega.Ω(results[1].Fee).Should(gomega.Equal(uint64(217)))
+
+			// Unit explanation
+			//
+			// bandwidth: tx size
+			// compute: 5 for signature, 1 for base, 1 for transfer
+			// read: 1 cold keys read (0 chunk), 1 warm key read (1 chunk)
+			// create: 1 key created (1 chunk)
+			// modify: 1 warm key modified (1 chunk)
+			gomega.Ω(results[2].Success).Should(gomega.BeTrue())
+			transferTxFee = chain.Dimensions{190, 7, 7, 25, 8}
+			gomega.Ω(results[2].Units).Should(gomega.Equal(transferTxFee))
+			// Fee explanation
+			//
+			// Multiply all unit consumption by 1 and sum
+			gomega.Ω(results[2].Fee).Should(gomega.Equal(uint64(237)))
+
+			// Unit explanation
+			//
+			// bandwidth: tx size
+			// compute: 5 for signature, 1 for base, 1 for transfer
+			// read: 2 warm keys reads (1 chunk, 0 chunk) -> note, this is based on disk BEFORE block
+			// create: 0 key created
+			// modify: 2 warm keys modified (1 chunk)
+			gomega.Ω(results[3].Success).Should(gomega.BeTrue())
+			transferTxFee = chain.Dimensions{190, 7, 3, 0, 16}
+			gomega.Ω(results[3].Units).Should(gomega.Equal(transferTxFee))
+			// Fee explanation
+			//
+			// Multiply all unit consumption by 1 and sum
+			gomega.Ω(results[3].Fee).Should(gomega.Equal(uint64(216)))
+
+			// Check end balance
+			balance2, err := instances[1].lcli.Balance(context.Background(), sender2)
+			gomega.Ω(err).To(gomega.BeNil())
+			gomega.Ω(balance2).To(gomega.Equal(uint64(100306)))
+			balance3, err := instances[1].lcli.Balance(context.Background(), sender3)
+			gomega.Ω(err).To(gomega.BeNil())
+			gomega.Ω(balance3).To(gomega.Equal(uint64(209)))
 		})
 	})
 
@@ -514,7 +669,7 @@ var _ = ginkgo.Describe("[Tx Processing]", func() {
 			gomega.Ω(err).Should(gomega.BeNil())
 			gomega.Ω(submit(context.Background())).Should(gomega.BeNil())
 
-			err = instances[1].vm.Gossiper().ForceGossip(context.TODO())
+			err = instances[1].vm.Gossiper().Force(context.TODO())
 			gomega.Ω(err).Should(gomega.BeNil())
 
 			// mempool in 0 should be 1 (old amount), since gossip/submit failed
@@ -694,7 +849,7 @@ func expectBlk(i instance) func() []*chain.Result {
 	ctx := context.TODO()
 
 	// manually signal ready
-	i.vm.Builder().ForceNotify()
+	gomega.Ω(i.vm.Builder().Force(ctx)).Should(gomega.BeNil())
 	// manually ack ready sig as in engine
 	<-i.toEngine
 

--- a/examples/morpheusvm/tests/load/load_test.go
+++ b/examples/morpheusvm/tests/load/load_test.go
@@ -398,8 +398,8 @@ var _ = ginkgo.Describe("load tests vm", func() {
 				log.Debug("block produced", zap.Uint64("height", blk.Hght), zap.Int("txs", len(blk.Txs)))
 				for _, result := range blk.Results() {
 					if !result.Success {
-						// Used for debugging
-						fmt.Println(string(result.Output))
+						unitPrices, _ := instances[0].cli.UnitPrices(context.Background(), false)
+						fmt.Println("tx failed", "unit prices:", unitPrices, "consumed:", result.Consumed, "fee:", result.Fee, "output:", string(result.Output))
 					}
 					gomega.Ω(result.Success).Should(gomega.BeTrue())
 				}

--- a/examples/tokenvm/actions/close_order.go
+++ b/examples/tokenvm/actions/close_order.go
@@ -73,7 +73,7 @@ func (c *CloseOrder) Execute(
 	if err := storage.DeleteOrder(ctx, db, c.Order); err != nil {
 		return false, CloseOrderComputeUnits, utils.ErrBytes(err), nil, nil
 	}
-	if err := storage.AddBalance(ctx, db, actor, c.Out, remaining); err != nil {
+	if err := storage.AddBalance(ctx, db, actor, c.Out, remaining, true); err != nil {
 		return false, CloseOrderComputeUnits, utils.ErrBytes(err), nil, nil
 	}
 	return true, CloseOrderComputeUnits, nil, nil, nil

--- a/examples/tokenvm/actions/fill_order.go
+++ b/examples/tokenvm/actions/fill_order.go
@@ -135,10 +135,10 @@ func (f *FillOrder) Execute(
 	if err := storage.SubBalance(ctx, db, actor, f.In, inputAmount); err != nil {
 		return false, NoFillOrderComputeUnits, utils.ErrBytes(err), nil, nil
 	}
-	if err := storage.AddBalance(ctx, db, f.Owner, f.In, inputAmount); err != nil {
+	if err := storage.AddBalance(ctx, db, f.Owner, f.In, inputAmount, true); err != nil {
 		return false, NoFillOrderComputeUnits, utils.ErrBytes(err), nil, nil
 	}
-	if err := storage.AddBalance(ctx, db, actor, f.Out, outputAmount); err != nil {
+	if err := storage.AddBalance(ctx, db, actor, f.Out, outputAmount, true); err != nil {
 		return false, NoFillOrderComputeUnits, utils.ErrBytes(err), nil, nil
 	}
 	if shouldDelete {

--- a/examples/tokenvm/actions/import_asset.go
+++ b/examples/tokenvm/actions/import_asset.go
@@ -127,11 +127,11 @@ func (i *ImportAsset) executeMint(
 	if err := storage.SetAsset(ctx, db, asset, metadata, newSupply, ed25519.EmptyPublicKey, true); err != nil {
 		return utils.ErrBytes(err)
 	}
-	if err := storage.AddBalance(ctx, db, i.warpTransfer.To, asset, i.warpTransfer.Value); err != nil {
+	if err := storage.AddBalance(ctx, db, i.warpTransfer.To, asset, i.warpTransfer.Value, true); err != nil {
 		return utils.ErrBytes(err)
 	}
 	if i.warpTransfer.Reward > 0 {
-		if err := storage.AddBalance(ctx, db, actor, asset, i.warpTransfer.Reward); err != nil {
+		if err := storage.AddBalance(ctx, db, actor, asset, i.warpTransfer.Reward, true); err != nil {
 			return utils.ErrBytes(err)
 		}
 	}
@@ -152,6 +152,7 @@ func (i *ImportAsset) executeReturn(
 	if err := storage.AddBalance(
 		ctx, db, i.warpTransfer.To,
 		i.warpTransfer.Asset, i.warpTransfer.Value,
+		true,
 	); err != nil {
 		return utils.ErrBytes(err)
 	}
@@ -165,6 +166,7 @@ func (i *ImportAsset) executeReturn(
 		if err := storage.AddBalance(
 			ctx, db, actor,
 			i.warpTransfer.Asset, i.warpTransfer.Reward,
+			true,
 		); err != nil {
 			return utils.ErrBytes(err)
 		}
@@ -220,13 +222,13 @@ func (i *ImportAsset) Execute(
 	if err := storage.SubBalance(ctx, db, i.warpTransfer.To, assetIn, i.warpTransfer.SwapIn); err != nil {
 		return false, ImportAssetComputeUnits, utils.ErrBytes(err), nil, nil
 	}
-	if err := storage.AddBalance(ctx, db, actor, assetIn, i.warpTransfer.SwapIn); err != nil {
+	if err := storage.AddBalance(ctx, db, actor, assetIn, i.warpTransfer.SwapIn, true); err != nil {
 		return false, ImportAssetComputeUnits, utils.ErrBytes(err), nil, nil
 	}
 	if err := storage.SubBalance(ctx, db, actor, i.warpTransfer.AssetOut, i.warpTransfer.SwapOut); err != nil {
 		return false, ImportAssetComputeUnits, utils.ErrBytes(err), nil, nil
 	}
-	if err := storage.AddBalance(ctx, db, i.warpTransfer.To, i.warpTransfer.AssetOut, i.warpTransfer.SwapOut); err != nil {
+	if err := storage.AddBalance(ctx, db, i.warpTransfer.To, i.warpTransfer.AssetOut, i.warpTransfer.SwapOut, true); err != nil {
 		return false, ImportAssetComputeUnits, utils.ErrBytes(err), nil, nil
 	}
 	return true, ImportAssetComputeUnits, nil, nil, nil

--- a/examples/tokenvm/actions/mint_asset.go
+++ b/examples/tokenvm/actions/mint_asset.go
@@ -87,7 +87,7 @@ func (m *MintAsset) Execute(
 	if err := storage.SetAsset(ctx, db, m.Asset, metadata, newSupply, actor, isWarp); err != nil {
 		return false, MintAssetComputeUnits, utils.ErrBytes(err), nil, nil
 	}
-	if err := storage.AddBalance(ctx, db, m.To, m.Asset, m.Value); err != nil {
+	if err := storage.AddBalance(ctx, db, m.To, m.Asset, m.Value, true); err != nil {
 		return false, MintAssetComputeUnits, utils.ErrBytes(err), nil, nil
 	}
 	return true, MintAssetComputeUnits, nil, nil, nil

--- a/examples/tokenvm/actions/transfer.go
+++ b/examples/tokenvm/actions/transfer.go
@@ -65,7 +65,8 @@ func (t *Transfer) Execute(
 	if err := storage.SubBalance(ctx, db, actor, t.Asset, t.Value); err != nil {
 		return false, TransferComputeUnits, utils.ErrBytes(err), nil, nil
 	}
-	if err := storage.AddBalance(ctx, db, t.To, t.Asset, t.Value); err != nil {
+	// TODO: allow sender to configure whether they will pay to create
+	if err := storage.AddBalance(ctx, db, t.To, t.Asset, t.Value, true); err != nil {
 		return false, TransferComputeUnits, utils.ErrBytes(err), nil, nil
 	}
 	return true, TransferComputeUnits, nil, nil, nil

--- a/examples/tokenvm/auth/ed25519.go
+++ b/examples/tokenvm/auth/ed25519.go
@@ -112,7 +112,8 @@ func (d *ED25519) Refund(
 	db chain.Database,
 	amount uint64,
 ) error {
-	return storage.AddBalance(ctx, db, d.Signer, ids.Empty, amount)
+	// Don't create account if it doesn't exist (may have sent all funds).
+	return storage.AddBalance(ctx, db, d.Signer, ids.Empty, amount, false)
 }
 
 var _ chain.AuthFactory = (*ED25519Factory)(nil)

--- a/examples/tokenvm/cmd/token-cli/cmd/prometheus.go
+++ b/examples/tokenvm/cmd/token-cli/cmd/prometheus.go
@@ -64,6 +64,9 @@ var generatePrometheusCmd = &cobra.Command{
 			panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hypersdk_vm_txs_received[5s])/5", chainID))
 			utils.Outf("{{yellow}}transactions received per second:{{/}} %s\n", panels[len(panels)-1])
 
+			panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hypersdk_vm_seen_txs_received[5s])/5", chainID))
+			utils.Outf("{{yellow}}seen transactions received per second:{{/}} %s\n", panels[len(panels)-1])
+
 			panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hypersdk_vm_txs_verified[5s])/5", chainID))
 			utils.Outf("{{yellow}}transactions verified per second:{{/}} %s\n", panels[len(panels)-1])
 

--- a/examples/tokenvm/cmd/token-cli/cmd/resolutions.go
+++ b/examples/tokenvm/cmd/token-cli/cmd/resolutions.go
@@ -160,7 +160,7 @@ func handleTx(tx *chain.Transaction, result *chain.Result) {
 		}
 	}
 	utils.Outf(
-		"%s {{yellow}}%s{{/}} {{yellow}}actor:{{/}} %s {{yellow}}summary (%s):{{/}} [%s] {{yellow}}fee (max %.2f%%):{{/}} %s %s {{yellow}}units:{{/}} [%s]\n",
+		"%s {{yellow}}%s{{/}} {{yellow}}actor:{{/}} %s {{yellow}}summary (%s):{{/}} [%s] {{yellow}}fee (max %.2f%%):{{/}} %s %s {{yellow}}consumed:{{/}} [%s]\n",
 		status,
 		tx.ID(),
 		tutils.Address(actor),
@@ -169,6 +169,6 @@ func handleTx(tx *chain.Transaction, result *chain.Result) {
 		float64(result.Fee)/float64(tx.Base.MaxFee)*100,
 		handler.Root().ValueString(ids.Empty, result.Fee),
 		handler.Root().AssetString(ids.Empty),
-		cli.ParseDimensions(result.Units),
+		cli.ParseDimensions(result.Consumed),
 	)
 }

--- a/examples/tokenvm/config/config.go
+++ b/examples/tokenvm/config/config.go
@@ -34,12 +34,11 @@ type Config struct {
 	*config.Config
 
 	// Gossip
-	GossipInterval      time.Duration `json:"gossipInterval"`
-	GossipMaxSize       int           `json:"gossipMaxSize"`
-	GossipProposerDiff  int           `json:"gossipProposerDiff"`
-	GossipProposerDepth int           `json:"gossipProposerDepth"`
-	NoGossipBuilderDiff int           `json:"noGossipBuilderDiff"`
-	VerifyTimeout       int64         `json:"verifyTimeout"`
+	GossipMaxSize       int   `json:"gossipMaxSize"`
+	GossipProposerDiff  int   `json:"gossipProposerDiff"`
+	GossipProposerDepth int   `json:"gossipProposerDepth"`
+	NoGossipBuilderDiff int   `json:"noGossipBuilderDiff"`
+	VerifyTimeout       int64 `json:"verifyTimeout"`
 
 	// Tracing
 	TraceEnabled    bool    `json:"traceEnabled"`
@@ -104,7 +103,6 @@ func New(nodeID ids.NodeID, b []byte) (*Config, error) {
 func (c *Config) setDefault() {
 	c.LogLevel = c.Config.GetLogLevel()
 	gcfg := gossiper.DefaultProposerConfig()
-	c.GossipInterval = gcfg.GossipInterval
 	c.GossipMaxSize = gcfg.GossipMaxSize
 	c.GossipProposerDiff = gcfg.GossipProposerDiff
 	c.GossipProposerDepth = gcfg.GossipProposerDepth

--- a/examples/tokenvm/controller/controller.go
+++ b/examples/tokenvm/controller/controller.go
@@ -169,7 +169,7 @@ func (c *Controller) Accepted(ctx context.Context, blk *chain.StatelessBlock) er
 				tx.ID(),
 				blk.GetTimestamp(),
 				result.Success,
-				result.Units,
+				result.Consumed,
 				result.Fee,
 			)
 			if err != nil {

--- a/examples/tokenvm/controller/controller.go
+++ b/examples/tokenvm/controller/controller.go
@@ -138,7 +138,10 @@ func (c *Controller) Initialize(
 		gcfg.GossipProposerDepth = c.config.GossipProposerDepth
 		gcfg.NoGossipBuilderDiff = c.config.NoGossipBuilderDiff
 		gcfg.VerifyTimeout = c.config.VerifyTimeout
-		gossip = gossiper.NewProposer(inner, gcfg)
+		gossip, err = gossiper.NewProposer(inner, gcfg)
+		if err != nil {
+			return nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, err
+		}
 	}
 
 	// Initialize order book used to track all open orders

--- a/examples/tokenvm/controller/controller.go
+++ b/examples/tokenvm/controller/controller.go
@@ -133,7 +133,6 @@ func (c *Controller) Initialize(
 	} else {
 		build = builder.NewTime(inner)
 		gcfg := gossiper.DefaultProposerConfig()
-		gcfg.GossipInterval = c.config.GossipInterval
 		gcfg.GossipMaxSize = c.config.GossipMaxSize
 		gcfg.GossipProposerDiff = c.config.GossipProposerDiff
 		gcfg.GossipProposerDepth = c.config.GossipProposerDepth

--- a/examples/tokenvm/storage/storage.go
+++ b/examples/tokenvm/storage/storage.go
@@ -100,11 +100,7 @@ func StoreTransaction(
 	} else {
 		v[consts.Uint64Len] = failureByte
 	}
-	unitBytes, err := units.Bytes()
-	if err != nil {
-		return err
-	}
-	copy(v[consts.Uint64Len+1:], unitBytes)
+	copy(v[consts.Uint64Len+1:], units.Bytes())
 	binary.BigEndian.PutUint64(v[consts.Uint64Len+1+chain.DimensionsLen:], fee)
 	return db.Put(k, v)
 }
@@ -127,7 +123,7 @@ func GetTransaction(
 	if v[consts.Uint64Len] == failureByte {
 		success = false
 	}
-	d, err := chain.UnpackDimensions(v[consts.Uint64Len+1:])
+	d, err := chain.UnpackDimensions(v[consts.Uint64Len+1 : consts.Uint64Len+1+chain.DimensionsLen])
 	if err != nil {
 		return false, 0, false, chain.Dimensions{}, 0, err
 	}
@@ -152,7 +148,7 @@ func GetBalance(
 	pk ed25519.PublicKey,
 	asset ids.ID,
 ) (uint64, error) {
-	dbKey, bal, err := getBalance(ctx, db, pk, asset)
+	dbKey, bal, _, err := getBalance(ctx, db, pk, asset)
 	balanceKeyPool.Put(dbKey)
 	return bal, err
 }
@@ -162,10 +158,10 @@ func getBalance(
 	db chain.Database,
 	pk ed25519.PublicKey,
 	asset ids.ID,
-) ([]byte, uint64, error) {
+) ([]byte, uint64, bool, error) {
 	k := BalanceKey(pk, asset)
-	bal, err := innerGetBalance(db.GetValue(ctx, k))
-	return k, bal, err
+	bal, exists, err := innerGetBalance(db.GetValue(ctx, k))
+	return k, bal, exists, err
 }
 
 // Used to serve RPC queries
@@ -177,7 +173,7 @@ func GetBalanceFromState(
 ) (uint64, error) {
 	k := BalanceKey(pk, asset)
 	values, errs := f(ctx, [][]byte{k})
-	bal, err := innerGetBalance(values[0], errs[0])
+	bal, _, err := innerGetBalance(values[0], errs[0])
 	balanceKeyPool.Put(k)
 	return bal, err
 }
@@ -185,14 +181,14 @@ func GetBalanceFromState(
 func innerGetBalance(
 	v []byte,
 	err error,
-) (uint64, error) {
+) (uint64, bool, error) {
 	if errors.Is(err, database.ErrNotFound) {
-		return 0, nil
+		return 0, false, nil
 	}
 	if err != nil {
-		return 0, err
+		return 0, false, err
 	}
-	return binary.BigEndian.Uint64(v), nil
+	return binary.BigEndian.Uint64(v), true, nil
 }
 
 func SetBalance(
@@ -230,10 +226,16 @@ func AddBalance(
 	pk ed25519.PublicKey,
 	asset ids.ID,
 	amount uint64,
+	create bool,
 ) error {
-	dbKey, bal, err := getBalance(ctx, db, pk, asset)
+	dbKey, bal, exists, err := getBalance(ctx, db, pk, asset)
 	if err != nil {
 		return err
+	}
+	// Don't add balance if account doesn't exist. This
+	// can be useful when processing fee refunds.
+	if !exists && !create {
+		return nil
 	}
 	nbal, err := smath.Add64(bal, amount)
 	if err != nil {
@@ -256,7 +258,7 @@ func SubBalance(
 	asset ids.ID,
 	amount uint64,
 ) error {
-	dbKey, bal, err := getBalance(ctx, db, pk, asset)
+	dbKey, bal, _, err := getBalance(ctx, db, pk, asset)
 	if err != nil {
 		return err
 	}

--- a/examples/tokenvm/tests/e2e/e2e_test.go
+++ b/examples/tokenvm/tests/e2e/e2e_test.go
@@ -1582,7 +1582,7 @@ func acceptTransaction(cli *rpc.JSONRPCClient, tcli *trpc.JSONRPCClient) {
 		// Generate transaction
 		other, err := ed25519.GeneratePrivateKey()
 		gomega.Ω(err).Should(gomega.BeNil())
-		unitPrices, err := cli.UnitPrices(context.Background())
+		unitPrices, err := cli.UnitPrices(context.Background(), false)
 		gomega.Ω(err).Should(gomega.BeNil())
 		submit, tx, maxFee, err := cli.GenerateTransaction(
 			context.Background(),

--- a/examples/tokenvm/tests/integration/integration_test.go
+++ b/examples/tokenvm/tests/integration/integration_test.go
@@ -51,8 +51,6 @@ import (
 	"github.com/ava-labs/hypersdk/examples/tokenvm/utils"
 )
 
-var transferTxFee = chain.Dimensions{222, 7, 12, 25, 21}
-
 var (
 	logFactory logging.Factory
 	log        logging.Logger
@@ -345,7 +343,7 @@ var _ = ginkgo.Describe("[Tx Processing]", func() {
 		})
 
 		ginkgo.By("send gossip from node 0 to 1", func() {
-			err := instances[0].vm.Gossiper().ForceGossip(context.TODO())
+			err := instances[0].vm.Gossiper().Force(context.TODO())
 			gomega.Ω(err).Should(gomega.BeNil())
 		})
 
@@ -388,7 +386,7 @@ var _ = ginkgo.Describe("[Tx Processing]", func() {
 		})
 
 		ginkgo.By("receive gossip in the node 1, and signal block build", func() {
-			instances[1].vm.Builder().ForceNotify()
+			gomega.Ω(instances[1].vm.Builder().Force(context.TODO())).To(gomega.BeNil())
 			<-instances[1].toEngine
 		})
 
@@ -413,14 +411,28 @@ var _ = ginkgo.Describe("[Tx Processing]", func() {
 			results := blk.(*chain.StatelessBlock).Results()
 			gomega.Ω(results).Should(gomega.HaveLen(1))
 			gomega.Ω(results[0].Success).Should(gomega.BeTrue())
-			gomega.Ω(results[0].Units).Should(gomega.Equal(transferTxFee))
 			gomega.Ω(results[0].Output).Should(gomega.BeNil())
+
+			// Unit explanation
+			//
+			// bandwidth: tx size
+			// compute: 5 for signature, 1 for base, 1 for transfer
+			// read: 2 keys reads, 1 had 0 chunks
+			// create: 1 key created
+			// modify: 1 cold key modified
+			transferTxFee := chain.Dimensions{222, 7, 12, 25, 13}
+			gomega.Ω(results[0].Units).Should(gomega.Equal(transferTxFee))
+
+			// Fee explanation
+			//
+			// Multiply all unit consumption by 1 and sum
+			gomega.Ω(results[0].Fee).Should(gomega.Equal(uint64(279)))
 		})
 
 		ginkgo.By("ensure balance is updated", func() {
 			balance, err := instances[1].tcli.Balance(context.Background(), sender, ids.Empty)
 			gomega.Ω(err).To(gomega.BeNil())
-			gomega.Ω(balance).To(gomega.Equal(uint64(9899713)))
+			gomega.Ω(balance).To(gomega.Equal(uint64(9899721)))
 			balance2, err := instances[1].tcli.Balance(context.Background(), sender2, ids.Empty)
 			gomega.Ω(err).To(gomega.BeNil())
 			gomega.Ω(balance2).To(gomega.Equal(uint64(100000)))
@@ -519,7 +531,7 @@ var _ = ginkgo.Describe("[Tx Processing]", func() {
 			gomega.Ω(err).Should(gomega.BeNil())
 			gomega.Ω(submit(context.Background())).Should(gomega.BeNil())
 
-			err = instances[1].vm.Gossiper().ForceGossip(context.TODO())
+			err = instances[1].vm.Gossiper().Force(context.TODO())
 			gomega.Ω(err).Should(gomega.BeNil())
 
 			// mempool in 0 should be 1 (old amount), since gossip/submit failed
@@ -1810,7 +1822,7 @@ var _ = ginkgo.Describe("[Tx Processing]", func() {
 		gomega.Ω(submit(context.Background())).Should(gomega.BeNil())
 
 		// Build block with no context (should fail)
-		instances[0].vm.Builder().ForceNotify()
+		gomega.Ω(instances[0].vm.Builder().Force(context.TODO())).To(gomega.BeNil())
 		<-instances[0].toEngine
 		blk, err := instances[0].vm.BuildBlock(context.TODO())
 		gomega.Ω(err).To(gomega.Not(gomega.BeNil()))
@@ -1915,7 +1927,7 @@ func expectBlk(i instance) func() []*chain.Result {
 	ctx := context.TODO()
 
 	// manually signal ready
-	i.vm.Builder().ForceNotify()
+	gomega.Ω(i.vm.Builder().Force(ctx)).To(gomega.BeNil())
 	// manually ack ready sig as in engine
 	<-i.toEngine
 
@@ -1945,7 +1957,7 @@ func expectBlkWithContext(i instance) func() []*chain.Result {
 	ctx := context.TODO()
 
 	// manually signal ready
-	i.vm.Builder().ForceNotify()
+	gomega.Ω(i.vm.Builder().Force(ctx)).To(gomega.BeNil())
 	// manually ack ready sig as in engine
 	<-i.toEngine
 

--- a/examples/tokenvm/tests/integration/integration_test.go
+++ b/examples/tokenvm/tests/integration/integration_test.go
@@ -420,8 +420,8 @@ var _ = ginkgo.Describe("[Tx Processing]", func() {
 			// read: 2 keys reads, 1 had 0 chunks
 			// create: 1 key created
 			// modify: 1 cold key modified
-			transferTxFee := chain.Dimensions{222, 7, 12, 25, 13}
-			gomega.Ω(results[0].Units).Should(gomega.Equal(transferTxFee))
+			transferTxConsumed := chain.Dimensions{222, 7, 12, 25, 13}
+			gomega.Ω(results[0].Consumed).Should(gomega.Equal(transferTxConsumed))
 
 			// Fee explanation
 			//
@@ -648,13 +648,14 @@ var _ = ginkgo.Describe("[Tx Processing]", func() {
 		gomega.Ω(results[0].Success).Should(gomega.BeTrue())
 
 		// Read item from connection
-		blk, lresults, err := cli.ListenBlock(context.TODO(), parser)
+		blk, lresults, prices, err := cli.ListenBlock(context.TODO(), parser)
 		gomega.Ω(err).Should(gomega.BeNil())
 		gomega.Ω(len(blk.Txs)).Should(gomega.Equal(1))
 		tx := blk.Txs[0].Action.(*actions.Transfer)
 		gomega.Ω(tx.Asset).To(gomega.Equal(ids.Empty))
 		gomega.Ω(tx.Value).To(gomega.Equal(uint64(1)))
 		gomega.Ω(lresults).Should(gomega.Equal(results))
+		gomega.Ω(prices).Should(gomega.Equal(chain.Dimensions{1, 1, 1, 1, 1}))
 
 		// Check balance modifications are correct
 		balancea, err := instances[0].tcli.Balance(context.TODO(), sender, ids.Empty)

--- a/examples/tokenvm/tests/load/load_test.go
+++ b/examples/tokenvm/tests/load/load_test.go
@@ -398,9 +398,8 @@ var _ = ginkgo.Describe("load tests vm", func() {
 				log.Debug("block produced", zap.Uint64("height", blk.Hght), zap.Int("txs", len(blk.Txs)))
 				for _, result := range blk.Results() {
 					if !result.Success {
-						// Used for debugging
-						unitPrices, _ := instances[0].cli.UnitPrices(context.Background())
-						fmt.Println("unit prices:", unitPrices, "used:", result.Units, "fee:", result.Fee, "output:", string(result.Output))
+						unitPrices, _ := instances[0].cli.UnitPrices(context.Background(), false)
+						fmt.Println("tx failed", "unit prices:", unitPrices, "consumed:", result.Consumed, "fee:", result.Fee, "output:", string(result.Output))
 					}
 					gomega.Ω(result.Success).Should(gomega.BeTrue())
 				}

--- a/gossiper/dependencies.go
+++ b/gossiper/dependencies.go
@@ -29,8 +29,10 @@ type VM interface {
 	NodeID() ids.NodeID
 	Rules(int64) chain.Rules
 	Submit(ctx context.Context, verify bool, txs []*chain.Transaction) []error
-	RecordTxsGossiped(int)
-	RecordTxsReceived(int)
 	GetAuthBatchVerifier(authTypeID uint8, cores int, count int) (chain.AuthBatchVerifier, bool)
 	StateManager() chain.StateManager
+
+	RecordTxsGossiped(int)
+	RecordSeenTxsReceived(int)
+	RecordTxsReceived(int)
 }

--- a/gossiper/dependencies.go
+++ b/gossiper/dependencies.go
@@ -28,7 +28,7 @@ type VM interface {
 	Registry() (chain.ActionRegistry, chain.AuthRegistry)
 	NodeID() ids.NodeID
 	Rules(int64) chain.Rules
-	Submit(ctx context.Context, validator bool, verify bool, txs []*chain.Transaction) []error
+	Submit(ctx context.Context, verify bool, txs []*chain.Transaction) []error
 	RecordTxsGossiped(int)
 	RecordTxsReceived(int)
 	GetAuthBatchVerifier(authTypeID uint8, cores int, count int) (chain.AuthBatchVerifier, bool)

--- a/gossiper/dependencies.go
+++ b/gossiper/dependencies.go
@@ -28,7 +28,7 @@ type VM interface {
 	Registry() (chain.ActionRegistry, chain.AuthRegistry)
 	NodeID() ids.NodeID
 	Rules(int64) chain.Rules
-	Submit(ctx context.Context, verify bool, txs []*chain.Transaction) []error
+	Submit(ctx context.Context, validator bool, verify bool, txs []*chain.Transaction) []error
 	RecordTxsGossiped(int)
 	RecordTxsReceived(int)
 	GetAuthBatchVerifier(authTypeID uint8, cores int, count int) (chain.AuthBatchVerifier, bool)

--- a/gossiper/gossiper.go
+++ b/gossiper/gossiper.go
@@ -12,7 +12,7 @@ import (
 
 type Gossiper interface {
 	Run(common.AppSender)
-	Queue(context.Context) error
+	Queue(context.Context)
 	Force(context.Context) error // may be triggered by run already
 	HandleAppGossip(ctx context.Context, nodeID ids.NodeID, msg []byte) error
 	BlockVerified(int64)

--- a/gossiper/gossiper.go
+++ b/gossiper/gossiper.go
@@ -12,8 +12,9 @@ import (
 
 type Gossiper interface {
 	Run(common.AppSender)
-	ForceGossip(context.Context) error // may be triggered by run already
-	HandleAppGossip(ctx context.Context, nodeID ids.NodeID, msg []byte) error
+	Queue()
+	Force(context.Context) error // may be triggered by run already
+	Handle(ctx context.Context, nodeID ids.NodeID, msg []byte) error
 	BlockVerified(int64)
 	Done() // wait after stop
 }

--- a/gossiper/gossiper.go
+++ b/gossiper/gossiper.go
@@ -12,9 +12,9 @@ import (
 
 type Gossiper interface {
 	Run(common.AppSender)
-	Queue()
+	Queue(context.Context) error
 	Force(context.Context) error // may be triggered by run already
-	Handle(ctx context.Context, nodeID ids.NodeID, msg []byte) error
+	HandleAppGossip(ctx context.Context, nodeID ids.NodeID, msg []byte) error
 	BlockVerified(int64)
 	Done() // wait after stop
 }

--- a/gossiper/manual.go
+++ b/gossiper/manual.go
@@ -36,7 +36,7 @@ func (g *Manual) Run(appSender common.AppSender) {
 	close(g.doneGossip)
 }
 
-func (g *Manual) ForceGossip(ctx context.Context) error {
+func (g *Manual) Force(ctx context.Context) error {
 	// Gossip highest paying txs
 	var (
 		txs  = []*chain.Transaction{}
@@ -121,3 +121,6 @@ func (*Manual) BlockVerified(int64) {}
 func (g *Manual) Done() {
 	<-g.doneGossip
 }
+
+// Queue is a no-op in [Manual].
+func (*Manual) Queue(context.Context) {}

--- a/gossiper/proposer.go
+++ b/gossiper/proposer.go
@@ -213,19 +213,22 @@ func (g *Proposer) HandleAppGossip(ctx context.Context, nodeID ids.NodeID, msg [
 
 	// Submit incoming gossip to mempool
 	start := time.Now()
-	for _, err := range g.vm.Submit(ctx, isValidator, false, txs) {
+	for _, err := range g.vm.Submit(ctx, false, txs) {
 		if err == nil || errors.Is(err, chain.ErrDuplicateTx) {
 			continue
 		}
 		g.vm.Logger().Debug(
 			"failed to submit gossiped txs",
-			zap.Stringer("nodeID", nodeID), zap.Error(err),
+			zap.Stringer("nodeID", nodeID),
+			zap.Bool("validator", isValidator),
+			zap.Error(err),
 		)
 	}
 	g.vm.Logger().Info(
 		"tx gossip received",
 		zap.Int("txs", len(txs)),
 		zap.Stringer("nodeID", nodeID),
+		zap.Bool("validator", isValidator),
 		zap.Duration("t", time.Since(start)),
 	)
 

--- a/gossiper/proposer.go
+++ b/gossiper/proposer.go
@@ -61,7 +61,7 @@ func DefaultProposerConfig() *ProposerConfig {
 }
 
 func NewProposer(vm VM, cfg *ProposerConfig) *Proposer {
-	return &Proposer{
+	g := &Proposer{
 		vm:         vm,
 		cfg:        cfg,
 		doneGossip: make(chan struct{}),
@@ -71,6 +71,8 @@ func NewProposer(vm VM, cfg *ProposerConfig) *Proposer {
 		q:         make(chan struct{}),
 		lastQueue: -1,
 	}
+	g.timer = timer.NewTimer(g.handleTimerNotify)
+	return g
 }
 
 func (g *Proposer) Force(ctx context.Context) error {
@@ -222,7 +224,7 @@ func (g *Proposer) notify() {
 	}
 }
 
-func (g *Proposer) handleNotify() {
+func (g *Proposer) handleTimerNotify() {
 	g.notify()
 	g.waiting.Store(false)
 }
@@ -294,6 +296,7 @@ func (g *Proposer) BlockVerified(t int64) {
 }
 
 func (g *Proposer) Done() {
+	g.timer.Stop()
 	<-g.doneGossip
 }
 

--- a/gossiper/proposer.go
+++ b/gossiper/proposer.go
@@ -96,7 +96,12 @@ func (g *Proposer) Force(ctx context.Context) error {
 	// Gossip newest transactions
 	//
 	// We remove these transactions from the mempool
-	// so they cannot be used for building.
+	// otherwise we'll just keep sending the same FIFO txs
+	// to the network over and over.
+	//
+	// If we are going to build, we should never be attempting
+	// to gossip and we should hold on to the txs we
+	// could execute.
 	var (
 		txs   = []*chain.Transaction{}
 		size  = 0

--- a/gossiper/proposer.go
+++ b/gossiper/proposer.go
@@ -214,6 +214,14 @@ func (g *Proposer) HandleAppGossip(ctx context.Context, nodeID ids.NodeID, msg [
 	return nil
 }
 
+func (g *Proposer) notify() {
+	select {
+	case g.q <- struct{}{}:
+		g.lastQueue = time.Now().UnixMilli()
+	default:
+	}
+}
+
 func (g *Proposer) handleNotify() {
 	g.notify()
 	g.waiting.Store(false)
@@ -321,12 +329,4 @@ func (g *Proposer) sendTxs(ctx context.Context, txs []*chain.Transaction) error 
 		recipients.Add(proposer)
 	}
 	return g.appSender.SendAppGossipSpecific(ctx, recipients, b)
-}
-
-func (g *Proposer) notify() {
-	select {
-	case g.q <- struct{}{}:
-		g.lastQueue = time.Now().UnixMilli()
-	default:
-	}
 }

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -33,7 +33,7 @@ func (mti *TestItem) Expiry() int64 {
 	return mti.timestamp
 }
 
-func (mti *TestItem) Size() int {
+func (*TestItem) Size() int {
 	return 2 // distinguish from len
 }
 

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -33,6 +33,10 @@ func (mti *TestItem) Expiry() int64 {
 	return mti.timestamp
 }
 
+func (mti *TestItem) Size() int {
+	return 2 // distinguish from len
+}
+
 func GenerateTestItem(payer string, t int64) *TestItem {
 	id := ids.GenerateTestID()
 	return &TestItem{
@@ -60,6 +64,7 @@ func TestMempool(t *testing.T) {
 	require.True(ok)
 	require.Equal(int64(100), next.Expiry())
 	require.Equal(3, txm.Len(ctx))
+	require.Equal(6, txm.Size(ctx))
 }
 
 func TestMempoolAddDuplicates(t *testing.T) {

--- a/rpc/jsonrpc_client.go
+++ b/rpc/jsonrpc_client.go
@@ -88,8 +88,8 @@ func (cli *JSONRPCClient) Accepted(ctx context.Context) (ids.ID, uint64, int64, 
 	return resp.BlockID, resp.Height, resp.Timestamp, err
 }
 
-func (cli *JSONRPCClient) UnitPrices(ctx context.Context) (chain.Dimensions, error) {
-	if time.Since(cli.lastUnitPrices) < unitPricesCacheRefresh {
+func (cli *JSONRPCClient) UnitPrices(ctx context.Context, useCache bool) (chain.Dimensions, error) {
+	if useCache && time.Since(cli.lastUnitPrices) < unitPricesCacheRefresh {
 		return cli.unitPrices, nil
 	}
 
@@ -169,7 +169,7 @@ func (cli *JSONRPCClient) GenerateTransaction(
 	modifiers ...Modifier,
 ) (func(context.Context) error, *chain.Transaction, uint64, error) {
 	// Get latest fee info
-	unitPrices, err := cli.UnitPrices(ctx)
+	unitPrices, err := cli.UnitPrices(ctx, true)
 	if err != nil {
 		return nil, nil, 0, err
 	}

--- a/rpc/websocket_client.go
+++ b/rpc/websocket_client.go
@@ -141,14 +141,14 @@ func (c *WebSocketClient) RegisterBlocks() error {
 func (c *WebSocketClient) ListenBlock(
 	ctx context.Context,
 	parser chain.Parser,
-) (*chain.StatefulBlock, []*chain.Result, error) {
+) (*chain.StatefulBlock, []*chain.Result, chain.Dimensions, error) {
 	select {
 	case msg := <-c.pendingBlocks:
 		return UnpackBlockMessage(msg, parser)
 	case <-c.readStopped:
-		return nil, nil, c.err
+		return nil, nil, chain.Dimensions{}, c.err
 	case <-ctx.Done():
-		return nil, nil, ctx.Err()
+		return nil, nil, chain.Dimensions{}, ctx.Err()
 	}
 }
 

--- a/tstate/errors.go
+++ b/tstate/errors.go
@@ -6,7 +6,8 @@ package tstate
 import "errors"
 
 var (
-	ErrNewKeysDisabled = errors.New("new keys disabled")
-	ErrKeyNotSpecified = errors.New("key not specified")
-	ErrInvalidKeyValue = errors.New("invalid key or value")
+	ErrNewKeysDisabled  = errors.New("new keys disabled")
+	ErrKeyNotSpecified  = errors.New("key not specified")
+	ErrInvalidKeyValue  = errors.New("invalid key or value")
+	ErrCreationDisabled = errors.New("creation disabled")
 )

--- a/tstate/tstate.go
+++ b/tstate/tstate.go
@@ -48,6 +48,7 @@ type TState struct {
 
 	// Store which keys are modified and how large their values were. Reset
 	// whenever setting scope.
+	canCreate         bool
 	creations         map[string]uint16
 	coldModifications map[string]uint16
 	warmModifications map[string]uint16
@@ -62,6 +63,8 @@ func New(changedSize int) *TState {
 		fetchCache: map[string]*cacheItem{},
 
 		ops: make([]*op, 0, changedSize),
+
+		canCreate: true,
 	}
 }
 
@@ -145,6 +148,24 @@ func (ts *TState) SetScope(_ context.Context, keys set.Set[string], storage map[
 	ts.warmModifications = map[string]uint16{}
 }
 
+// DisableCreation causes [Insert] to return an error if
+// it would create a new key. This can be useful for constraining
+// what a transaction can do during block execution (to allow for
+// cheaper fees).
+//
+// Note, creation defaults to true.
+func (ts *TState) DisableCreation() {
+	ts.canCreate = false
+}
+
+// EnableCreation removes the forcer error case in [Insert]
+// if a new key is created.
+//
+// Note, creation defaults to true.
+func (ts *TState) EnableCreation() {
+	ts.canCreate = true
+}
+
 // checkScope returns whether [k] is in ts.readScope.
 func (ts *TState) checkScope(_ context.Context, k []byte) bool {
 	return ts.scope.Contains(string(k))
@@ -160,6 +181,31 @@ func (ts *TState) Insert(ctx context.Context, key []byte, value []byte) error {
 	}
 	k := string(key)
 	past, changed, exists := ts.getValue(ctx, k)
+	var err error
+	if exists {
+		// If a key is already in [coldModifications], we should still
+		// consider it a [coldModification] even if it is [changed].
+		// This occurs when we modify a key for the second time in
+		// a single transaction.
+		//
+		// If a key is not in [coldModifications] and it is [changed],
+		// it was either created/modified in a different transaction
+		// in the block or created in this transaction.
+		if _, ok := ts.coldModifications[k]; ok || !changed {
+			err = updateChunks(ts.coldModifications, k, value)
+		} else {
+			err = updateChunks(ts.warmModifications, k, value)
+		}
+	} else {
+		if !ts.canCreate {
+			err = ErrCreationDisabled
+		} else {
+			err = updateChunks(ts.creations, k, value)
+		}
+	}
+	if err != nil {
+		return err
+	}
 	ts.ops = append(ts.ops, &op{
 		k:           k,
 		pastExists:  exists,
@@ -167,17 +213,7 @@ func (ts *TState) Insert(ctx context.Context, key []byte, value []byte) error {
 		pastChanged: changed,
 	})
 	ts.changedKeys[k] = &tempStorage{value, false}
-	var err error
-	if exists {
-		if changed {
-			err = updateChunks(ts.warmModifications, k, value)
-		} else {
-			err = updateChunks(ts.coldModifications, k, value)
-		}
-	} else {
-		err = updateChunks(ts.creations, k, value)
-	}
-	return err
+	return nil
 }
 
 // Remove deletes a key-value pair from ts.storage.
@@ -191,6 +227,23 @@ func (ts *TState) Remove(ctx context.Context, key []byte) error {
 		// We do not update modificaations if the key does not exist.
 		return nil
 	}
+	// If a key is already in [coldModifications], we should still
+	// consider it a [coldModification] even if it is [changed].
+	// This occurs when we modify a key for the second time in
+	// a single transaction.
+	//
+	// If a key is not in [coldModifications] and it is [changed],
+	// it was either created/modified in a different transaction
+	// in the block or created in this transaction.
+	var err error
+	if _, ok := ts.coldModifications[k]; ok || !changed {
+		err = updateChunks(ts.coldModifications, k, nil)
+	} else {
+		err = updateChunks(ts.warmModifications, k, nil)
+	}
+	if err != nil {
+		return err
+	}
 	ts.ops = append(ts.ops, &op{
 		k:           k,
 		pastExists:  true,
@@ -198,13 +251,7 @@ func (ts *TState) Remove(ctx context.Context, key []byte) error {
 		pastChanged: changed,
 	})
 	ts.changedKeys[k] = &tempStorage{nil, true}
-	var err error
-	if changed {
-		err = updateChunks(ts.warmModifications, k, nil)
-	} else {
-		err = updateChunks(ts.coldModifications, k, nil)
-	}
-	return err
+	return nil
 }
 
 // OpIndex returns the number of operations done on ts.

--- a/vm/metrics.go
+++ b/vm/metrics.go
@@ -12,6 +12,7 @@ import (
 type Metrics struct {
 	txsSubmitted       prometheus.Counter // includes gossip
 	txsReceived        prometheus.Counter
+	seenTxsReceived    prometheus.Counter
 	txsGossiped        prometheus.Counter
 	txsVerified        prometheus.Counter
 	txsAccepted        prometheus.Counter
@@ -113,6 +114,11 @@ func newMetrics() (*prometheus.Registry, *Metrics, error) {
 			Name:      "txs_received",
 			Help:      "number of txs received over gossip",
 		}),
+		seenTxsReceived: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: "vm",
+			Name:      "seen_txs_received",
+			Help:      "number of txs received over gossip that we've already seen",
+		}),
 		txsGossiped: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: "vm",
 			Name:      "txs_gossiped",
@@ -195,6 +201,7 @@ func newMetrics() (*prometheus.Registry, *Metrics, error) {
 	errs.Add(
 		r.Register(m.txsSubmitted),
 		r.Register(m.txsReceived),
+		r.Register(m.seenTxsReceived),
 		r.Register(m.txsGossiped),
 		r.Register(m.txsVerified),
 		r.Register(m.txsAccepted),

--- a/vm/resolutions.go
+++ b/vm/resolutions.go
@@ -108,7 +108,7 @@ func (vm *VM) Verified(ctx context.Context, b *chain.StatelessBlock) {
 	vm.parsedBlocks.Evict(b.ID())
 	vm.mempool.Remove(ctx, b.Txs)
 	vm.gossiper.BlockVerified(b.Tmstmp)
-	vm.builder.QueueNotify()
+	vm.checkActivity(ctx)
 	vm.snowCtx.Log.Info(
 		"verified block",
 		zap.Stringer("blkID", b.ID()),

--- a/vm/resolutions.go
+++ b/vm/resolutions.go
@@ -410,6 +410,10 @@ func (vm *VM) RecordTxsReceived(c int) {
 	vm.metrics.txsReceived.Add(float64(c))
 }
 
+func (vm *VM) RecordSeenTxsReceived(c int) {
+	vm.metrics.seenTxsReceived.Add(float64(c))
+}
+
 func (vm *VM) RecordBuildCapped() {
 	vm.metrics.buildCapped.Inc()
 }

--- a/vm/resolutions.go
+++ b/vm/resolutions.go
@@ -109,13 +109,29 @@ func (vm *VM) Verified(ctx context.Context, b *chain.StatelessBlock) {
 	vm.mempool.Remove(ctx, b.Txs)
 	vm.gossiper.BlockVerified(b.Tmstmp)
 	vm.checkActivity(ctx)
-	vm.snowCtx.Log.Info(
-		"verified block",
-		zap.Stringer("blkID", b.ID()),
-		zap.Uint64("height", b.Hght),
-		zap.Int("txs", len(b.Txs)),
-		zap.Bool("state ready", vm.StateReady()),
-	)
+
+	if b.Processed() {
+		fm := b.FeeManager()
+		vm.snowCtx.Log.Info(
+			"verified block",
+			zap.Stringer("blkID", b.ID()),
+			zap.Uint64("height", b.Hght),
+			zap.Int("txs", len(b.Txs)),
+			zap.Bool("state ready", vm.StateReady()),
+			zap.Any("unit prices", fm.UnitPrices()),
+			zap.Any("units consumed", fm.UnitsConsumed()),
+		)
+	} else {
+		// [b.FeeManager] is not populated if the block
+		// has not been processed.
+		vm.snowCtx.Log.Info(
+			"skipped block verification",
+			zap.Stringer("blkID", b.ID()),
+			zap.Uint64("height", b.Hght),
+			zap.Int("txs", len(b.Txs)),
+			zap.Bool("state ready", vm.StateReady()),
+		)
+	}
 }
 
 func (vm *VM) Rejected(ctx context.Context, b *chain.StatelessBlock) {


### PR DESCRIPTION
Resolves: #354 
Resolves: #398 

<img width="2048" alt="image" src="https://github.com/ava-labs/hypersdk/assets/13023275/a758be2f-8f72-4e23-aa85-947002bc9796">

100% inclusion rate and we get no return gossip that we already sent

## TODO
- [x] Avoid gossip cycling (use FIFO)
- [x] Add comment that we remove from FIFO because we don't want to resend the same things
- [x] Bypass cache for fee lookup during watch/spam
- [x] Add metric for gossip received that already sent
- [x] Add items to gossip cache when receive
- [x] Align no gossip depth with proposer gossip lookahead