### PR TITLE
[x/programs/rust] Use clippy::pedantic in the SDK

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "x/programs/rust/examples/lottery",
     "x/programs/rust/examples/pokemon",
 ]
+resolver = "2"
 
 [profile.release]
 opt-level = 3

--- a/x/programs/rust/examples/lottery/src/lib.rs
+++ b/x/programs/rust/examples/lottery/src/lib.rs
@@ -38,11 +38,12 @@ fn play(ctx: Context, player: Address) -> bool {
     };
 
     // Transfer
-    ctx.program_invoke(
-        &call_ctx,
+    let _ = ctx.program_invoke(
+        call_ctx,
         "transfer",
         &[Box::new(lotto_addy), Box::new(player), Box::new(num)],
     );
+
     true
 }
 

--- a/x/programs/rust/expose_macro/src/lib.rs
+++ b/x/programs/rust/expose_macro/src/lib.rs
@@ -7,7 +7,7 @@ use proc_macro2::Span;
 use quote::{quote, ToTokens};
 use syn::{parse_macro_input, parse_str, FnArg, Ident, ItemFn, Pat, PatType, Type};
 /// An attribute procedural macro that can be used to expose a function to the host.
-/// It does so by wrapping the [item] tokenstream in a new function that can be called by the host.
+/// It does so by wrapping the `item` tokenstream in a new function that can be called by the host.
 /// The wrapper function will have the same name as the original function, but with "_guest" appended to it.
 /// The wrapper functions parameters will be converted to WASM supported types. When called, the wrapper function
 /// calls the original function by converting the parameters back to their intended types using .into().

--- a/x/programs/rust/wasmlanche_sdk/src/host/mod.rs
+++ b/x/programs/rust/wasmlanche_sdk/src/host/mod.rs
@@ -32,13 +32,14 @@ extern "C" {
     ) -> i64;
 }
 
-/// Stores the bytes at value_ptr to the bytes at key ptr on the host.
+/// Stores the bytes at `value_ptr` to the bytes at key ptr on the host.
 ///
 /// # Safety
-/// The caller must ensure that key_ptr + key_len and
-/// value_ptr + value_len point to valid memory locations.
+/// The caller must ensure that `key_ptr` + `key_len` and
+/// `value_ptr` + `value_len` point to valid memory locations.
+#[must_use]
 pub unsafe fn store_bytes(
-    ctx: &Context,
+    ctx: Context,
     key_ptr: *const u8,
     key_len: usize,
     value_ptr: *const u8,
@@ -50,21 +51,24 @@ pub unsafe fn store_bytes(
 /// Gets the length of the bytes associated with the key from the host.
 ///
 /// # Safety
-/// The caller must ensure that key_ptr + key_len points to valid memory locations.
-pub unsafe fn get_bytes_len(ctx: &Context, key_ptr: *const u8, key_len: usize) -> i32 {
+/// The caller must ensure that `key_ptr` + `key_len` points to valid memory locations.
+#[must_use]
+pub unsafe fn get_bytes_len(ctx: Context, key_ptr: *const u8, key_len: usize) -> i32 {
     unsafe { _get_bytes_len(ctx.program_id, key_ptr, key_len) }
 }
 
 /// Gets the bytes associated with the key from the host.
 ///
 /// # Safety
-/// The caller must ensure that key_ptr + key_len points to valid memory locations.
-pub unsafe fn get_bytes(ctx: &Context, key_ptr: *const u8, key_len: usize, val_len: i32) -> i32 {
+/// The caller must ensure that `key_ptr` + `key_len` points to valid memory locations.
+#[must_use]
+pub unsafe fn get_bytes(ctx: Context, key_ptr: *const u8, key_len: usize, val_len: i32) -> i32 {
     unsafe { _get_bytes(ctx.program_id, key_ptr, key_len, val_len) }
 }
 
 /// Invokes another program and returns the result.
-pub fn host_program_invoke(call_ctx: &Context, method_name: &str, args: &[u8]) -> i64 {
+#[must_use]
+pub fn program_invoke(call_ctx: Context, method_name: &str, args: &[u8]) -> i64 {
     let method_name_bytes = method_name.as_bytes();
     unsafe {
         _invoke_program(
@@ -83,7 +87,7 @@ pub fn host_program_invoke(call_ctx: &Context, method_name: &str, args: &[u8]) -
 /// Allocate memory into the module's linear memory
 /// and return the offset to the start of the block.
 #[no_mangle]
-pub fn alloc(len: usize) -> *mut u8 {
+pub extern "C" fn alloc(len: usize) -> *mut u8 {
     // create a new mutable buffer with capacity `len`
     let mut buf = Vec::with_capacity(len);
     // take a mutable pointer to the buffer
@@ -103,7 +107,7 @@ pub fn alloc(len: usize) -> *mut u8 {
 ///
 /// deallocates the memory block at `ptr` with a given `capacity`.
 #[no_mangle]
-pub unsafe fn dealloc(ptr: *mut u8, capacity: usize) {
+pub unsafe extern "C" fn dealloc(ptr: *mut u8, capacity: usize) {
     // always deallocate the full capacity, initialize vs uninitialized memory is irrelevant here
     let data = Vec::from_raw_parts(ptr, capacity, capacity);
     std::mem::drop(data);

--- a/x/programs/rust/wasmlanche_sdk/src/lib.rs
+++ b/x/programs/rust/wasmlanche_sdk/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(clippy::pedantic)]
+
 pub mod errors;
 pub mod host;
 pub mod store;

--- a/x/programs/rust/wasmlanche_sdk/src/store/mod.rs
+++ b/x/programs/rust/wasmlanche_sdk/src/store/mod.rs
@@ -64,7 +64,7 @@ impl Context {
         let key_bytes = key.as_bytes();
 
         match store_key_value(self, key_bytes, value) {
-            Ok(_) => StoreResult::Ok(self),
+            Ok(()) => StoreResult::Ok(self),
             Err(e) => StoreResult::Err(e),
         }
     }
@@ -80,7 +80,7 @@ impl Context {
         };
 
         match store_key_value(self, &key_bytes, value) {
-            Ok(_) => StoreResult::Ok(self),
+            Ok(()) => StoreResult::Ok(self),
             Err(e) => StoreResult::Err(e),
         }
     }

--- a/x/programs/rust/wasmlanche_sdk/src/store/mod.rs
+++ b/x/programs/rust/wasmlanche_sdk/src/store/mod.rs
@@ -87,7 +87,7 @@ impl Context {
 
     /// Returns the value of the field `name` from the host.
     /// # Errors
-    /// Returns a `StorageError` if the field does not exist or if the bytes are invalid.
+    /// Returns a `StorageError` if there was an error retrieving from the host or the retrieved bytes are invalid.
     pub fn get_value<T>(self, name: &str) -> Result<T, StorageError>
     where
         T: DeserializeOwned,

--- a/x/programs/rust/wasmlanche_sdk/src/store/mod.rs
+++ b/x/programs/rust/wasmlanche_sdk/src/store/mod.rs
@@ -167,7 +167,7 @@ fn get_field_as_bytes(ctx: Context, name: &[u8]) -> Result<Vec<u8>, StorageError
     Ok(bytes)
 }
 
-/// Gets the field [name] from the host and returns it as a `ProgramValue`.
+/// Gets the field `name` from the host and returns it as a `ProgramValue`.
 fn get_field<T>(ctx: Context, name: &str) -> Result<T, StorageError>
 where
     T: DeserializeOwned,
@@ -176,7 +176,7 @@ where
     from_slice(&bytes).map_err(|_| StorageError::InvalidBytes)
 }
 
-/// Gets the correct key to in the host storage for a [`map_name`] and [key] within that map  
+/// Gets the correct key to in the host storage for a `map_name` and `key` within that map
 fn get_map_key<T>(map_name: &str, key: &T) -> Result<Vec<u8>, StorageError>
 where
     T: Serialize,

--- a/x/programs/rust/wasmlanche_sdk/src/store/mod.rs
+++ b/x/programs/rust/wasmlanche_sdk/src/store/mod.rs
@@ -97,7 +97,7 @@ impl Context {
 
     /// Returns the value of the field `key` from the map `map_name` from the host.
     /// # Errors
-    /// Returns a `StorageError` if the field does not exist or if the bytes are invalid.
+    /// Returns a `StorageError` if there was an error retrieving from the host or the retrieved bytes are invalid.
     pub fn get_map_value<T, U>(self, map_name: &str, key: &T) -> Result<U, StorageError>
     where
         T: Serialize,

--- a/x/programs/rust/wasmlanche_sdk/src/store/mod.rs
+++ b/x/programs/rust/wasmlanche_sdk/src/store/mod.rs
@@ -1,5 +1,5 @@
 use crate::errors::StorageError;
-use crate::host::host_program_invoke;
+use crate::host::program_invoke;
 use crate::host::{get_bytes, get_bytes_len, store_bytes};
 use crate::types::Argument;
 use serde::de::DeserializeOwned;
@@ -7,21 +7,25 @@ use serde::{Deserialize, Serialize};
 use serde_bare::{from_slice, to_vec};
 use std::str;
 
-pub enum StoreResult<'a> {
-    Ok(&'a Context),
+#[allow(clippy::module_name_repetitions)]
+pub enum StoreResult {
+    Ok(Context),
     Err(StorageError),
 }
 
-impl StoreResult<'_> {
+impl StoreResult {
+    #[must_use]
     pub fn store_value<T>(self, key: &str, value: &T) -> Self
     where
         T: Serialize + ?Sized,
     {
         match self {
             Self::Ok(ctx) => ctx.store_value(key, value),
-            err => err,
+            err @ Self::Err(_) => err,
         }
     }
+
+    #[must_use]
     pub fn store_map_value<T, U>(self, map_name: &str, key: &U, value: &T) -> Self
     where
         T: Serialize + ?Sized,
@@ -29,12 +33,16 @@ impl StoreResult<'_> {
     {
         match self {
             Self::Ok(ctx) => ctx.store_map_value(map_name, key, value),
-            err => err,
+            err @ Self::Err(_) => err,
         }
     }
+
+    #[must_use]
     pub fn is_ok(self) -> bool {
         matches!(self, Self::Ok(_))
     }
+
+    #[must_use]
     pub fn is_err(self) -> bool {
         matches!(self, Self::Err(_))
     }
@@ -49,18 +57,19 @@ pub struct Context {
 
 /// Fails if we are storing a map with non-string keys
 impl Context {
-    pub fn store_value<T>(&self, key: &str, value: &T) -> StoreResult<'_>
+    pub fn store_value<T>(self, key: &str, value: &T) -> StoreResult
     where
         T: Serialize + ?Sized,
     {
         let key_bytes = key.as_bytes();
-        match store_key_value(self, key_bytes.to_vec(), value) {
+
+        match store_key_value(self, key_bytes, value) {
             Ok(_) => StoreResult::Ok(self),
             Err(e) => StoreResult::Err(e),
         }
     }
 
-    pub fn store_map_value<T, U>(&self, map_name: &str, key: &U, value: &T) -> StoreResult<'_>
+    pub fn store_map_value<T, U>(self, map_name: &str, key: &U, value: &T) -> StoreResult
     where
         T: Serialize + ?Sized,
         U: Serialize,
@@ -69,18 +78,27 @@ impl Context {
             Ok(bytes) => bytes,
             Err(e) => return StoreResult::Err(e),
         };
-        match store_key_value(self, key_bytes, value) {
+
+        match store_key_value(self, &key_bytes, value) {
             Ok(_) => StoreResult::Ok(self),
             Err(e) => StoreResult::Err(e),
         }
     }
-    pub fn get_value<T>(&self, name: &str) -> Result<T, StorageError>
+
+    /// Returns the value of the field `name` from the host.
+    /// # Errors
+    /// Returns a `StorageError` if the field does not exist or if the bytes are invalid.
+    pub fn get_value<T>(self, name: &str) -> Result<T, StorageError>
     where
         T: DeserializeOwned,
     {
         get_field(self, name)
     }
-    pub fn get_map_value<T, U>(&self, map_name: &str, key: &T) -> Result<U, StorageError>
+
+    /// Returns the value of the field `key` from the map `map_name` from the host.
+    /// # Errors
+    /// Returns a `StorageError` if the field does not exist or if the bytes are invalid.
+    pub fn get_map_value<T, U>(self, map_name: &str, key: &T) -> Result<U, StorageError>
     where
         T: Serialize,
         U: DeserializeOwned,
@@ -102,7 +120,7 @@ impl From<i64> for Context {
     }
 }
 
-fn store_key_value<T>(ctx: &Context, key_bytes: Vec<u8>, value: &T) -> Result<(), StorageError>
+fn store_key_value<T>(ctx: Context, key_bytes: &[u8], value: &T) -> Result<(), StorageError>
 where
     T: Serialize + ?Sized,
 {
@@ -121,7 +139,7 @@ where
     }
 }
 
-fn get_field_as_bytes(ctx: &Context, name: &[u8]) -> Result<Vec<u8>, StorageError> {
+fn get_field_as_bytes(ctx: Context, name: &[u8]) -> Result<Vec<u8>, StorageError> {
     let name_ptr = name.as_ptr();
     let name_len = name.len();
     // First get the length of the bytes from the host.
@@ -139,12 +157,18 @@ fn get_field_as_bytes(ctx: &Context, name: &[u8]) -> Result<Vec<u8>, StorageErro
     let bytes_ptr = bytes_ptr as *mut u8;
 
     // Take ownership of those bytes grabbed from the host. We want Rust to manage the memory.
-    let bytes = unsafe { Vec::from_raw_parts(bytes_ptr, bytes_len as usize, bytes_len as usize) };
+    let bytes = unsafe {
+        Vec::from_raw_parts(
+            bytes_ptr,
+            bytes_len.try_into().unwrap(),
+            bytes_len.try_into().unwrap(),
+        )
+    };
     Ok(bytes)
 }
 
-/// Gets the field [name] from the host and returns it as a ProgramValue.
-fn get_field<T>(ctx: &Context, name: &str) -> Result<T, StorageError>
+/// Gets the field [name] from the host and returns it as a `ProgramValue`.
+fn get_field<T>(ctx: Context, name: &str) -> Result<T, StorageError>
 where
     T: DeserializeOwned,
 {
@@ -152,7 +176,7 @@ where
     from_slice(&bytes).map_err(|_| StorageError::InvalidBytes)
 }
 
-/// Gets the correct key to in the host storage for a [map_name] and [key] within that map  
+/// Gets the correct key to in the host storage for a [`map_name`] and [key] within that map  
 fn get_map_key<T>(map_name: &str, key: &T) -> Result<Vec<u8>, StorageError>
 where
     T: Serialize,
@@ -163,7 +187,7 @@ where
 }
 
 // Gets the value from the map [name] with key [key] from the host and returns it as a ProgramValue.
-fn get_map_field<T, U>(ctx: &Context, name: &str, key: &T) -> Result<U, StorageError>
+fn get_map_field<T, U>(ctx: Context, name: &str, key: &T) -> Result<U, StorageError>
 where
     T: Serialize,
     U: DeserializeOwned,
@@ -173,16 +197,17 @@ where
     from_slice(&map_value).map_err(|_| StorageError::HostRetrieveError)
 }
 
-/// Implement the program_invoke function for the Context which allows a program to
+/// Implement the `program_invoke` function for the Context which allows a program to
 /// call another program.
 impl Context {
+    #[must_use]
     pub fn program_invoke(
         &self,
-        call_ctx: &Context,
+        call_ctx: Context,
         fn_name: &str,
         call_args: &[Box<dyn Argument>],
     ) -> i64 {
-        host_program_invoke(call_ctx, fn_name, &Self::marshal_args(call_args))
+        program_invoke(call_ctx, fn_name, &Self::marshal_args(call_args))
     }
 
     fn marshal_args(args: &[Box<dyn Argument>]) -> Vec<u8> {
@@ -200,7 +225,7 @@ impl Context {
             // if we want to be efficient we dont need to add length of bytes if its an int
             let len = i64::try_from(arg.len()).expect("Error converting to i64");
             bytes.extend_from_slice(&len.as_bytes());
-            bytes.extend_from_slice(&[arg.is_primitive() as u8]);
+            bytes.extend_from_slice(&[u8::from(arg.is_primitive())]);
             bytes.extend_from_slice(&arg.as_bytes());
         }
         bytes

--- a/x/programs/rust/wasmlanche_sdk/src/types/mod.rs
+++ b/x/programs/rust/wasmlanche_sdk/src/types/mod.rs
@@ -9,9 +9,11 @@ pub struct Address(Bytes32);
 impl Address {
     pub const LEN: usize = 32;
     // Constructor function for Address
+    #[must_use]
     pub fn new(bytes: [u8; Self::LEN]) -> Self {
         Self(Bytes32::new(bytes))
     }
+    #[must_use]
     pub fn as_bytes(&self) -> &[u8] {
         self.0.as_bytes()
     }
@@ -29,16 +31,18 @@ impl From<i64> for Address {
 pub struct Bytes32([u8; Self::LEN]);
 impl Bytes32 {
     pub const LEN: usize = 32;
+    #[must_use]
     pub fn new(bytes: [u8; Self::LEN]) -> Self {
         Self(bytes)
     }
+    #[must_use]
     pub fn as_bytes(&self) -> &[u8] {
         &self.0
     }
 }
 
 /// Implement the Display trait for Bytes32 so that we can print it.
-/// Enables to_string() on Bytes32.
+/// Enables `to_string()` on Bytes32.
 impl std::fmt::Display for Bytes32 {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         // Find the first null byte and only print up to that point.


### PR DESCRIPTION
`Clippy::pendantic` saves you from yourself. I recommend this for any open-source Rust (then ignore rules where it's overkill).

