### PR TITLE
[x/programs] add cargo fmt to rust linter

### DIFF
--- a/scripts/rust/tests.lint.sh
+++ b/scripts/rust/tests.lint.sh
@@ -9,6 +9,10 @@ fi
 # https://rust-lang.github.io/rustup/installation/index.html
 # rustup toolchain install nightly --allow-downgrade --profile minimal --component clippy
 
+rustup default stable
+
+cargo fmt --all --verbose -- --check
+
 rustup default nightly
 
 # use rust nightly clippy to check tests and all crate features


### PR DESCRIPTION
This PR adds `cargo fmt` to the rust linter which was missed when originally added.