### PR TITLE
[x/programs] add metering benchmarks

### DIFF
--- a/x/programs/examples/token.go
+++ b/x/programs/examples/token.go
@@ -15,25 +15,19 @@ import (
 	"go.uber.org/zap"
 )
 
-func NewToken(log logging.Logger, programBytes []byte, maxFee uint64, costMap map[string]uint64) *Token {
+func NewToken(log logging.Logger, programBytes []byte) *Token {
 	return &Token{
 		log:          log,
 		programBytes: programBytes,
-		maxFee:       maxFee,
-		costMap:      costMap,
 	}
 }
 
 type Token struct {
 	log          logging.Logger
 	programBytes []byte
-
-	// metering
-	maxFee  uint64
-	costMap map[string]uint64
 }
 
-func (t *Token) Run(ctx context.Context) error {
+func (t *Token) Run(ctx context.Context, meter runtime.Meter) error {
 	// functions exported in this example
 	functions := []string{
 		"get_total_supply",
@@ -45,7 +39,6 @@ func (t *Token) Run(ctx context.Context) error {
 		"init_program",
 	}
 
-	meter := runtime.NewMeter(t.log, t.maxFee, t.costMap)
 	db := utils.NewTestDB()
 	store := newProgramStorage(db)
 

--- a/x/programs/examples/token_test.go
+++ b/x/programs/examples/token_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/utils/logging"
+
 	"github.com/ava-labs/hypersdk/x/programs/runtime"
 )
 
@@ -54,7 +55,7 @@ func BenchmarkTokenProgram(b *testing.B) {
 		program := NewToken(log, tokenProgramBytes)
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			var meter runtime.Meter
+			var meter runtime.Meter // disabled
 			err := program.Run(context.Background(), meter)
 			require.NoError(err)
 		}


### PR DESCRIPTION
This PR adds a benchmark with metering disabled to understand current perf for the token contract. ~8% CPU time overhead currently.

```sh
goos: linux
goarch: amd64
pkg: github.com/ava-labs/hypersdk/x/programs/examples
cpu: Intel(R) Core(TM) i7-10750H CPU @ 2.60GHz
BenchmarkTokenProgram/benchmark_token_program-12         	      72	  15810518 ns/op	 5038119 B/op	   43264 allocs/op
BenchmarkTokenProgram/benchmark_token_program_no_metering-12         	      92	  14548991 ns/op	 5036648 B/op	   43261 allocs/op
``` 