### PR TITLE
[x/programs] add runtime client

### DIFF
--- a/x/programs/runtime/client.go
+++ b/x/programs/runtime/client.go
@@ -47,9 +47,6 @@ func (c *client) call(ctx context.Context, name string, params ...uint64) ([]uin
 	if !ok {
 		return nil, fmt.Errorf("failed to find exported function: %s", name)
 	}
-	if api == nil {
-		return nil, fmt.Errorf("failed to register an api module for function: %s", name)
-	}
 	return api.Call(ctx, params...)
 }
 

--- a/x/programs/runtime/client.go
+++ b/x/programs/runtime/client.go
@@ -1,0 +1,110 @@
+// Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package runtime
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/tetratelabs/wazero/api"
+	"go.uber.org/zap"
+
+	"github.com/ava-labs/avalanchego/utils/logging"
+
+	"github.com/ava-labs/hypersdk/x/programs/utils"
+)
+
+const (
+	allocFnName   = "alloc"
+	deallocFnName = "dealloc"
+)
+
+// newClient returns a new runtime client capable of making calls to exported
+// functions of the guest. All clients must be closed when no longer in use.
+func newClient(log logging.Logger, mod api.Module, functions []string) *client {
+	// initialize exported functions
+	exported := make(map[string]api.Function)
+
+	// default functions
+	exported[allocFnName] = mod.ExportedFunction(allocFnName)
+	exported[deallocFnName] = mod.ExportedFunction(deallocFnName)
+
+	for _, name := range functions {
+		exported[name] = mod.ExportedFunction(utils.GetGuestFnName(name))
+	}
+
+	return &client{
+		log:      log,
+		mod:      mod,
+		exported: exported,
+		allocs:   make([]*alloc, 0),
+	}
+}
+
+type client struct {
+	// allocations managed by this client
+	allocs   []*alloc
+	exported map[string]api.Function
+	mod      api.Module
+	log      logging.Logger
+}
+
+type alloc struct {
+	offset uint64
+	len    uint64
+}
+
+func (c *client) call(ctx context.Context, name string, params ...uint64) ([]uint64, error) {
+	api, ok := c.exported[name]
+	if !ok {
+		return nil, fmt.Errorf("failed to find exported function: %s", name)
+	}
+	if api == nil {
+		return nil, fmt.Errorf("failed to register an api module for function: %s", name)
+	}
+	return api.Call(ctx, params...)
+}
+
+// TODO: ensure properly metered
+func (c *client) alloc(ctx context.Context, length uint64) (uint64, error) {
+	result, err := c.call(ctx, allocFnName, length)
+	if err != nil {
+		return 0, err
+	}
+	return result[0], nil
+}
+
+func (c *client) dealloc(ctx context.Context, offset uint64, length uint64) error {
+	_, err := c.call(ctx, deallocFnName, offset, length)
+	return err
+}
+
+// TODO: ensure properly metered
+func (c *client) readMemory(offset uint32, length uint32) ([]byte, bool) {
+	return c.mod.Memory().Read(offset, length)
+}
+
+// TODO: ensure properly metered
+func (c *client) writeMemory(offset uint32, buf []byte) error {
+	ok := c.mod.Memory().Write(offset, buf)
+	if !ok {
+		return fmt.Errorf("failed to write at offset: %d size: %d", offset, c.mod.Memory().Size())
+	}
+	return nil
+}
+
+func (c *client) Close(ctx context.Context) {
+	// deallocate all allocations made by this client
+	for _, alloc := range c.allocs {
+		err := c.dealloc(ctx, alloc.offset, alloc.len)
+		c.log.Error("failed to deallocate memory",
+			zap.Error(err),
+		)
+	}
+	if err := c.mod.Close(ctx); err != nil {
+		c.log.Error("failed to close wasm module",
+			zap.Error(err),
+		)
+	}
+}

--- a/x/programs/runtime/client.go
+++ b/x/programs/runtime/client.go
@@ -11,8 +11,6 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/ava-labs/avalanchego/utils/logging"
-
-	"github.com/ava-labs/hypersdk/x/programs/utils"
 )
 
 const (
@@ -22,18 +20,7 @@ const (
 
 // newClient returns a new runtime client capable of making calls to exported
 // functions of the guest. All clients must be closed when no longer in use.
-func newClient(log logging.Logger, mod api.Module, functions []string) *client {
-	// initialize exported functions
-	exported := make(map[string]api.Function)
-
-	// default functions
-	exported[allocFnName] = mod.ExportedFunction(allocFnName)
-	exported[deallocFnName] = mod.ExportedFunction(deallocFnName)
-
-	for _, name := range functions {
-		exported[name] = mod.ExportedFunction(utils.GetGuestFnName(name))
-	}
-
+func newClient(log logging.Logger, mod api.Module, exported map[string]api.Function) *client {
 	return &client{
 		log:      log,
 		mod:      mod,

--- a/x/programs/runtime/dependencies.go
+++ b/x/programs/runtime/dependencies.go
@@ -19,7 +19,7 @@ type Runtime interface {
 	// WriteGuestBuffer allocates buf to the heap on the guest and returns the offset.
 	WriteGuestBuffer(context.Context, []byte) (uint64, error)
 	// Stop performs a shutdown of the engine.
-	Stop(context.Context) error
+	Stop(context.Context)
 }
 
 type Storage interface {

--- a/x/programs/runtime/meter_test.go
+++ b/x/programs/runtime/meter_test.go
@@ -45,6 +45,7 @@ func TestMeterInsufficientBalance(t *testing.T) {
 
 	meter := NewMeter(log, maxFee, costMap)
 	runtime := New(log, meter, storage)
+	defer runtime.Stop(ctx)
 	err := runtime.Initialize(ctx, tokenProgramBytes, []string{"get"})
 	require.NoError(err)
 
@@ -71,8 +72,7 @@ func TestMeterRuntimeStop(t *testing.T) {
 	require.NoError(err)
 
 	// shutdown runtime
-	err = runtime.Stop(ctx)
-	require.NoError(err)
+	runtime.Stop(ctx)
 
 	// meter should be independent to runtime
 	err = meter.AddCost(ctx, "ConstI32 0x0")

--- a/x/programs/runtime/runtime.go
+++ b/x/programs/runtime/runtime.go
@@ -98,7 +98,7 @@ func (r *runtime) Initialize(ctx context.Context, programBytes []byte, functions
 		exported[name] = mod.ExportedFunction(utils.GetGuestFnName(name))
 	}
 
-	r.client = newClient(r.log, mod, functions)
+	r.client = newClient(r.log, mod, exported)
 
 	return nil
 }

--- a/x/programs/runtime/runtime.go
+++ b/x/programs/runtime/runtime.go
@@ -95,7 +95,7 @@ func (r *runtime) Initialize(ctx context.Context, programBytes []byte, functions
 		if m == nil {
 			return fmt.Errorf("failed to find exported function: %s", name)
 		}
-		exported[name] = mod.ExportedFunction(utils.GetGuestFnName(name))
+		exported[name] = m
 	}
 
 	r.client = newClient(r.log, mod, exported)


### PR DESCRIPTION
This PR adds a client abstraction around the wazero api.Module for managing exported functions of the guest. This PR also adds memory management for any allocations made during the client life cycle.