### PR TITLE
fix vm readme link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ---
 
-The freedom to create your own [Virtual Machine (VM)](https://docs.avax.network/subnets#virtual-machines),
+The freedom to create your own [Virtual Machine (VM)](https://docs.avax.network/learn/avalanche/virtual-machines),
 or blockchain runtime, is one of the most exciting and powerful aspects of building
 on Avalanche, however, it is difficult and time-intensive to do from scratch. Forking
 existing Avalanche VMs makes it easier to get started, like [spacesvm](https://github.com/ava-labs/spacesvm)


### PR DESCRIPTION
Currently, the VM link mentioned in the first sentence of the HyperSDK README directs users to the Subnet Documentation on the Avalanche Documentation website.

This PR corrects this by directing users to the Virtual Machine section on the Avalanche Documentation website.