### PR TITLE
[chain] Remove Parent Block Dependency during Verify

### DIFF
--- a/chain/block.go
+++ b/chain/block.go
@@ -430,6 +430,8 @@ func (b *StatelessBlock) innerVerify(ctx context.Context, vctx VerifyContext) er
 	}
 
 	// Fetch view where we will apply block state transitions
+	//
+	// This call may result in our ancestry being verified.
 	parentView, err := vctx.View(ctx, &b.StateRoot)
 	if err != nil {
 		return err

--- a/chain/block.go
+++ b/chain/block.go
@@ -362,7 +362,7 @@ func (b *StatelessBlock) verify(ctx context.Context, stateReady bool) error {
 		// context. Otherwise, the parent block will be used as execution context.
 		vctx, err := b.vm.GetVerifyContext(ctx, b.Hght, b.Prnt)
 		if err != nil {
-			return err
+			return fmt.Errorf("%w: unable to load verify context", err)
 		}
 
 		// Parent block may not be processed when we verify this block, so [innerVerify] may
@@ -435,7 +435,7 @@ func (b *StatelessBlock) innerVerify(ctx context.Context, vctx VerifyContext) er
 	// This call may result in our ancestry being verified.
 	parentView, err := vctx.View(ctx, &b.StateRoot, true)
 	if err != nil {
-		return err
+		return fmt.Errorf("%w: unable to load parent view", err)
 	}
 
 	// Fetch parent height key and ensure block height is valid

--- a/chain/block.go
+++ b/chain/block.go
@@ -582,7 +582,7 @@ func (b *StatelessBlock) innerVerify(ctx context.Context, vctx VerifyContext) er
 	heightKeyStr := string(heightKey)
 	timestampKeyStr := string(timestampKey)
 	feeKeyStr := string(feeKey)
-	ts.SetScope(ctx, set.Of(heightKeyStr, feeKeyStr), map[string][]byte{
+	ts.SetScope(ctx, set.Of(heightKeyStr, timestampKeyStr, feeKeyStr), map[string][]byte{
 		heightKeyStr:    parentHeightRaw,
 		timestampKeyStr: parentTimestampRaw,
 		feeKeyStr:       parentFeeManager.Bytes(),

--- a/chain/block.go
+++ b/chain/block.go
@@ -861,9 +861,11 @@ func (b *StatelessBlock) View(ctx context.Context, blockRoot *ids.ID, verify boo
 	)
 	vctx, err := b.vm.GetVerifyContext(ctx, b.Hght, b.Prnt)
 	if err != nil {
+		b.vm.Logger().Error("unable to get verify context", zap.Error(err))
 		return nil, err
 	}
 	if err := b.innerVerify(ctx, vctx); err != nil {
+		b.vm.Logger().Error("unable to verify block", zap.Error(err))
 		return nil, err
 	}
 	if b.st != choices.Accepted {
@@ -879,6 +881,7 @@ func (b *StatelessBlock) View(ctx context.Context, blockRoot *ids.ID, verify boo
 	// is not the child of the block whose post-execution state
 	// is currently stored on disk, so it is safe to call [CommitToDB].
 	if err := b.view.CommitToDB(ctx); err != nil {
+		b.vm.Logger().Error("unable to commit to DB", zap.Error(err))
 		return nil, err
 	}
 	return b.vm.State()

--- a/chain/block.go
+++ b/chain/block.go
@@ -426,6 +426,9 @@ func (b *StatelessBlock) innerVerify(ctx context.Context) (merkledb.TrieView, er
 	//
 	// TODO: remove assumption that parent will be accessible here, we should store
 	// all info we need to verify a block in state
+	//
+	// TODO: parent will only be acessible if processing to check "IsRepeat" or
+	// to get a View of pending state
 	parent, err := b.vm.GetStatelessBlock(ctx, b.Prnt)
 	if err != nil {
 		log.Debug("could not get parent", zap.Stringer("id", b.Prnt))

--- a/chain/block.go
+++ b/chain/block.go
@@ -433,7 +433,7 @@ func (b *StatelessBlock) innerVerify(ctx context.Context, vctx VerifyContext) er
 	// Fetch view where we will apply block state transitions
 	//
 	// This call may result in our ancestry being verified.
-	parentView, err := vctx.View(ctx, b.StateRoot)
+	parentView, err := vctx.View(ctx, &b.StateRoot, true)
 	if err != nil {
 		return err
 	}

--- a/chain/builder.go
+++ b/chain/builder.go
@@ -454,7 +454,7 @@ func BuildBlock(
 		vm.RecordEmptyBlockBuilt()
 	}
 
-	// Set scope for [tstate] changes
+	// Update chain metadata
 	heightKey := HeightKey(sm.HeightKey())
 	heightKeyStr := string(heightKey)
 	timestampKey := TimestampKey(b.vm.StateManager().TimestampKey())
@@ -465,18 +465,12 @@ func BuildBlock(
 		timestampKeyStr: binary.BigEndian.AppendUint64(nil, uint64(parent.Tmstmp)),
 		feeKeyStr:       parentFeeManager.Bytes(),
 	})
-
-	// Store height in state to prevent duplicate roots
 	if err := ts.Insert(ctx, heightKey, binary.BigEndian.AppendUint64(nil, b.Hght)); err != nil {
 		return nil, fmt.Errorf("%w: unable to insert height", err)
 	}
-
-	// Store timestamp in block
 	if err := ts.Insert(ctx, timestampKey, binary.BigEndian.AppendUint64(nil, uint64(b.Tmstmp))); err != nil {
 		return nil, fmt.Errorf("%w: unable to insert timestamp", err)
 	}
-
-	// Store fee parameters
 	if err := ts.Insert(ctx, feeKey, feeManager.Bytes()); err != nil {
 		return nil, fmt.Errorf("%w: unable to insert fees", err)
 	}

--- a/chain/builder.go
+++ b/chain/builder.go
@@ -460,7 +460,7 @@ func BuildBlock(
 	timestampKey := TimestampKey(b.vm.StateManager().TimestampKey())
 	timestampKeyStr := string(timestampKey)
 	feeKeyStr := string(feeKey)
-	ts.SetScope(ctx, set.Of(heightKeyStr, feeKeyStr), map[string][]byte{
+	ts.SetScope(ctx, set.Of(heightKeyStr, timestampKeyStr, feeKeyStr), map[string][]byte{
 		heightKeyStr:    binary.BigEndian.AppendUint64(nil, parent.Hght),
 		timestampKeyStr: binary.BigEndian.AppendUint64(nil, uint64(parent.Tmstmp)),
 		feeKeyStr:       parentFeeManager.Bytes(),

--- a/chain/consts.go
+++ b/chain/consts.go
@@ -32,11 +32,16 @@ const (
 	// ranges (so, we can't expose a way to modify this over time).
 	MaxOutgoingWarpChunks = 4
 	HeightKeyChunks       = 1
+	TimestampKeyChunks    = 1
 	FeeKeyChunks          = 8 // 96 (per dimension) * 5 (num dimensions)
 )
 
 func HeightKey(prefix []byte) []byte {
 	return keys.EncodeChunks(prefix, HeightKeyChunks)
+}
+
+func TimestampKey(prefix []byte) []byte {
+	return keys.EncodeChunks(prefix, TimestampKeyChunks)
 }
 
 func FeeKey(prefix []byte) []byte {

--- a/chain/dependencies.go
+++ b/chain/dependencies.go
@@ -48,7 +48,7 @@ type VM interface {
 	SetLastAccepted(*StatelessBlock) error
 	GetStatelessBlock(context.Context, ids.ID) (*StatelessBlock, error)
 
-	GetVerifyContext(ctx context.Context, height uint64, parent ids.ID, parentRoot ids.ID) (VerifyContext, error)
+	GetVerifyContext(ctx context.Context, blockHeight uint64, parent ids.ID, parentRoot ids.ID) (VerifyContext, error)
 
 	State() (merkledb.MerkleDB, error)
 	StateManager() StateManager

--- a/chain/dependencies.go
+++ b/chain/dependencies.go
@@ -85,7 +85,7 @@ type VM interface {
 }
 
 type VerifyContext interface {
-	View(ctx context.Context, blockRoot ids.ID) (state.View, error)
+	View(ctx context.Context, blockRoot *ids.ID) (state.View, error)
 	IsRepeat(ctx context.Context, oldestAllowed int64, txs []*Transaction, marker set.Bits, stop bool) (set.Bits, error)
 }
 

--- a/chain/dependencies.go
+++ b/chain/dependencies.go
@@ -85,7 +85,7 @@ type VM interface {
 }
 
 type VerifyContext interface {
-	View(ctx context.Context, blockRoot *ids.ID) (state.View, error)
+	View(ctx context.Context, blockRoot *ids.ID, verify bool) (state.View, error)
 	IsRepeat(ctx context.Context, oldestAllowed int64, txs []*Transaction, marker set.Bits, stop bool) (set.Bits, error)
 }
 

--- a/chain/dependencies.go
+++ b/chain/dependencies.go
@@ -82,6 +82,11 @@ type VM interface {
 	RecordClearedMempool()
 }
 
+type VerifyContext interface {
+	View(ctx context.Context, blockRoot *ids.ID) (state.View, error)
+	IsRepeat(ctx context.Context, oldestAllowed int64, txs []*Transaction, marker set.Bits, stop bool) (set.Bits, error)
+}
+
 type Mempool interface {
 	Len(context.Context) int  // items
 	Size(context.Context) int // bytes

--- a/chain/dependencies.go
+++ b/chain/dependencies.go
@@ -156,6 +156,7 @@ type Rules interface {
 // use. This will be handled by the hypersdk.
 type StateManager interface {
 	HeightKey() []byte
+	TimestampKey() []byte
 	FeeKey() []byte
 
 	IncomingWarpKeyPrefix(sourceChainID ids.ID, msgID ids.ID) []byte

--- a/chain/dependencies.go
+++ b/chain/dependencies.go
@@ -48,6 +48,8 @@ type VM interface {
 	SetLastAccepted(*StatelessBlock) error
 	GetStatelessBlock(context.Context, ids.ID) (*StatelessBlock, error)
 
+	GetVerifyContext(ctx context.Context, height uint64, parent ids.ID, parentRoot ids.ID) (VerifyContext, error)
+
 	State() (merkledb.MerkleDB, error)
 	StateManager() StateManager
 	ValidatorState() validators.State

--- a/chain/dependencies.go
+++ b/chain/dependencies.go
@@ -48,7 +48,7 @@ type VM interface {
 	SetLastAccepted(*StatelessBlock) error
 	GetStatelessBlock(context.Context, ids.ID) (*StatelessBlock, error)
 
-	GetVerifyContext(ctx context.Context, blockHeight uint64, parent ids.ID, parentRoot ids.ID) (VerifyContext, error)
+	GetVerifyContext(ctx context.Context, blockHeight uint64, parent ids.ID) (VerifyContext, error)
 
 	State() (merkledb.MerkleDB, error)
 	StateManager() StateManager
@@ -85,7 +85,7 @@ type VM interface {
 }
 
 type VerifyContext interface {
-	View(ctx context.Context, blockRoot *ids.ID) (state.View, error)
+	View(ctx context.Context, blockRoot ids.ID) (state.View, error)
 	IsRepeat(ctx context.Context, oldestAllowed int64, txs []*Transaction, marker set.Bits, stop bool) (set.Bits, error)
 }
 

--- a/chain/errors.go
+++ b/chain/errors.go
@@ -27,6 +27,7 @@ var (
 	ErrInvalidSurplus       = errors.New("invalid surplus fee")
 	ErrStateRootMismatch    = errors.New("state root mismatch")
 	ErrInvalidResult        = errors.New("invalid result")
+	ErrInvalidBlockHeight   = errors.New("invalid block height")
 
 	// Tx Correctness
 	ErrInvalidSignature     = errors.New("invalid signature")

--- a/examples/morpheusvm/storage/state_manager.go
+++ b/examples/morpheusvm/storage/state_manager.go
@@ -13,6 +13,10 @@ func (*StateManager) HeightKey() []byte {
 	return HeightKey()
 }
 
+func (*StateManager) TimestampKey() []byte {
+	return TimestampKey()
+}
+
 func (*StateManager) FeeKey() []byte {
 	return FeeKey()
 }

--- a/examples/morpheusvm/storage/storage.go
+++ b/examples/morpheusvm/storage/storage.go
@@ -33,9 +33,10 @@ type ReadState func(context.Context, [][]byte) ([][]byte, []error)
 // 0x0/ (balance)
 //   -> [owner] => balance
 // 0x1/ (hypersdk-height)
-// 0x2/ (hypersdk-fee)
-// 0x3/ (hypersdk-incoming warp)
-// 0x4/ (hypersdk-outgoing warp)
+// 0x2/ (hypersdk-timestamp)
+// 0x3/ (hypersdk-fee)
+// 0x4/ (hypersdk-incoming warp)
+// 0x5/ (hypersdk-outgoing warp)
 
 const (
 	// metaDB
@@ -44,18 +45,20 @@ const (
 	// stateDB
 	balancePrefix      = 0x0
 	heightPrefix       = 0x1
-	feePrefix          = 0x2
-	incomingWarpPrefix = 0x3
-	outgoingWarpPrefix = 0x4
+	timestampPrefix    = 0x2
+	feePrefix          = 0x3
+	incomingWarpPrefix = 0x4
+	outgoingWarpPrefix = 0x5
 )
 
 const BalanceChunks uint16 = 1
 
 var (
-	failureByte = byte(0x0)
-	successByte = byte(0x1)
-	heightKey   = []byte{heightPrefix}
-	feeKey      = []byte{feePrefix}
+	failureByte  = byte(0x0)
+	successByte  = byte(0x1)
+	heightKey    = []byte{heightPrefix}
+	timestampKey = []byte{timestampPrefix}
+	feeKey       = []byte{feePrefix}
 
 	balanceKeyPool = sync.Pool{
 		New: func() any {
@@ -254,6 +257,10 @@ func SubBalance(
 
 func HeightKey() (k []byte) {
 	return heightKey
+}
+
+func TimestampKey() (k []byte) {
+	return timestampKey
 }
 
 func FeeKey() (k []byte) {

--- a/examples/morpheusvm/tests/e2e/e2e_test.go
+++ b/examples/morpheusvm/tests/e2e/e2e_test.go
@@ -219,7 +219,7 @@ var _ = ginkgo.BeforeSuite(func() {
 		//
 		// TODO: re-enable profiling
 		runner_sdk.WithGlobalNodeConfig(`{
-				"log-level":"info",
+				"log-level":"debug",
 				"log-display-level":"info",
 				"proposervm-use-current-height":true,
 				"throttler-inbound-validator-alloc-size":"10737418240",

--- a/examples/morpheusvm/tests/e2e/e2e_test.go
+++ b/examples/morpheusvm/tests/e2e/e2e_test.go
@@ -219,7 +219,7 @@ var _ = ginkgo.BeforeSuite(func() {
 		//
 		// TODO: re-enable profiling
 		runner_sdk.WithGlobalNodeConfig(`{
-				"log-level":"debug",
+				"log-level":"info",
 				"log-display-level":"info",
 				"proposervm-use-current-height":true,
 				"throttler-inbound-validator-alloc-size":"10737418240",

--- a/examples/tokenvm/controller/state_manager.go
+++ b/examples/tokenvm/controller/state_manager.go
@@ -14,6 +14,10 @@ func (*StateManager) HeightKey() []byte {
 	return storage.HeightKey()
 }
 
+func (*StateManager) TimestampKey() []byte {
+	return storage.TimestampKey()
+}
+
 func (*StateManager) FeeKey() []byte {
 	return storage.HeightKey()
 }

--- a/examples/tokenvm/storage/storage.go
+++ b/examples/tokenvm/storage/storage.go
@@ -37,9 +37,10 @@ type ReadState func(context.Context, [][]byte) ([][]byte, []error)
 // 0x3/ (loans)
 //   -> [assetID|destination] => amount
 // 0x4/ (hypersdk-height)
-// 0x5/ (hypersdk-fee)
-// 0x6/ (hypersdk-incoming warp)
-// 0x7/ (hypersdk-outgoing warp)
+// 0x5/ (hypersdk-timestamp)
+// 0x6/ (hypersdk-fee)
+// 0x7/ (hypersdk-incoming warp)
+// 0x8/ (hypersdk-outgoing warp)
 
 const (
 	// metaDB
@@ -51,9 +52,10 @@ const (
 	orderPrefix        = 0x2
 	loanPrefix         = 0x3
 	heightPrefix       = 0x4
-	feePrefix          = 0x5
-	incomingWarpPrefix = 0x6
-	outgoingWarpPrefix = 0x7
+	timestampPrefix    = 0x5
+	feePrefix          = 0x6
+	incomingWarpPrefix = 0x7
+	outgoingWarpPrefix = 0x8
 )
 
 const (
@@ -64,10 +66,11 @@ const (
 )
 
 var (
-	failureByte = byte(0x0)
-	successByte = byte(0x1)
-	heightKey   = []byte{heightPrefix}
-	feeKey      = []byte{feePrefix}
+	failureByte  = byte(0x0)
+	successByte  = byte(0x1)
+	heightKey    = []byte{heightPrefix}
+	timestampKey = []byte{timestampPrefix}
+	feeKey       = []byte{feePrefix}
 
 	balanceKeyPool = sync.Pool{
 		New: func() any {
@@ -536,6 +539,10 @@ func SubLoan(
 
 func HeightKey() (k []byte) {
 	return heightKey
+}
+
+func TimestampKey() (k []byte) {
+	return timestampKey
 }
 
 func FeeKey() (k []byte) {

--- a/vm/errors.go
+++ b/vm/errors.go
@@ -8,9 +8,10 @@ import (
 )
 
 var (
-	ErrNotAdded     = errors.New("not added")
-	ErrDropped      = errors.New("dropped")
-	ErrNotReady     = errors.New("not ready")
-	ErrStateMissing = errors.New("state missing")
-	ErrStateSyncing = errors.New("state still syncing")
+	ErrNotAdded            = errors.New("not added")
+	ErrDropped             = errors.New("dropped")
+	ErrNotReady            = errors.New("not ready")
+	ErrStateMissing        = errors.New("state missing")
+	ErrStateSyncing        = errors.New("state still syncing")
+	ErrUnexpectedStateRoot = errors.New("unexpected state root")
 )

--- a/vm/resolutions.go
+++ b/vm/resolutions.go
@@ -116,6 +116,7 @@ func (vm *VM) Verified(ctx context.Context, b *chain.StatelessBlock) {
 			zap.Stringer("blkID", b.ID()),
 			zap.Uint64("height", b.Hght),
 			zap.Int("txs", len(b.Txs)),
+			zap.Stringer("parent root", b.StateRoot),
 			zap.Bool("state ready", vm.StateReady()),
 			zap.Any("unit prices", fm.UnitPrices()),
 			zap.Any("units consumed", fm.UnitsConsumed()),
@@ -128,6 +129,7 @@ func (vm *VM) Verified(ctx context.Context, b *chain.StatelessBlock) {
 			zap.Stringer("blkID", b.ID()),
 			zap.Uint64("height", b.Hght),
 			zap.Int("txs", len(b.Txs)),
+			zap.Stringer("parent root", b.StateRoot),
 			zap.Bool("state ready", vm.StateReady()),
 		)
 	}
@@ -301,6 +303,7 @@ func (vm *VM) Accepted(ctx context.Context, b *chain.StatelessBlock) {
 		zap.Stringer("blkID", b.ID()),
 		zap.Uint64("height", b.Hght),
 		zap.Int("txs", len(b.Txs)),
+		zap.Stringer("parent root", b.StateRoot),
 		zap.Int("size", len(b.Bytes())),
 		zap.Int("dropped mempool txs", len(removed)),
 		zap.Bool("state ready", vm.StateReady()),

--- a/vm/verify_context.go
+++ b/vm/verify_context.go
@@ -14,17 +14,34 @@ var _ chain.VerifyContext = (*AcceptedVerifyContext)(nil)
 var _ chain.VerifyContext = (*PendingVerifyContext)(nil)
 
 func (vm *VM) GetVerifyContext(ctx context.Context, blockHeight uint64, parent ids.ID) (chain.VerifyContext, error) {
+	// If [blockHeight] is 0, we throw an error because there is no pre-genesis verification context.
 	if blockHeight == 0 {
 		return nil, errors.New("cannot get context of genesis block")
 	}
-	// If last accepted block is not processed, we need to process it. This will happen when we call [View] on the parent.
-	if (!vm.lastAccepted.Processed() && parent == vm.lastAccepted.ID()) || blockHeight-1 > vm.lastAccepted.Hght {
+
+	// If the last accepted block is not yet processed, we can't use the accepted state for the
+	// verification context. This could happen if state sync finishes with no processing blocks (we
+	// sync to the post-execution state of the parent of the last accepted block, not the post-execution
+	// state of the last accepted block).
+	//
+	// Invariant: When [View] is called on [vm.lastAccepted], the block will be verified and the accepted
+	// state will be updated.
+	if !vm.lastAccepted.Processed() && parent == vm.lastAccepted.ID() {
+		return &PendingVerifyContext{vm.lastAccepted}, nil
+	}
+
+	// If the parent block is not yet accepted, we should return the block's verified but not accepted
+	// parent.
+	if blockHeight-1 > vm.lastAccepted.Hght {
 		blk, err := vm.GetStatelessBlock(ctx, parent)
 		if err != nil {
 			return nil, err
 		}
 		return &PendingVerifyContext{blk}, nil
 	}
+
+	// If the parent block is accepted and processed, we should
+	// just use the accepted state as the verification context.
 	return &AcceptedVerifyContext{vm}, nil
 }
 
@@ -44,9 +61,26 @@ type AcceptedVerifyContext struct {
 	vm *VM
 }
 
-// The caller of this should check for equality with the root during verification.
-func (a *AcceptedVerifyContext) View(ctx context.Context, _ ids.ID) (state.View, error) {
-	return a.vm.State()
+func (a *AcceptedVerifyContext) View(ctx context.Context, blockRoot ids.ID) (state.View, error) {
+	state, err := a.vm.State()
+	if err != nil {
+		return nil, err
+	}
+	// This does not make deferred root generation less
+	// efficient because the root must have already
+	// been calculated before the latest state was written
+	// to disk.
+	root, err := state.GetMerkleRoot(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if root != blockRoot {
+		// This should never happen but we check
+		// this to check subtle state handling bugs
+		// in the [chain] package.
+		return nil, ErrUnexpectedStateRoot
+	}
+	return state, nil
 }
 
 func (a *AcceptedVerifyContext) IsRepeat(ctx context.Context, oldestAllowed int64, txs []*chain.Transaction, marker set.Bits, stop bool) (set.Bits, error) {

--- a/vm/verify_context.go
+++ b/vm/verify_context.go
@@ -1,0 +1,65 @@
+package vm
+
+import (
+	"context"
+	"errors"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/set"
+	"github.com/ava-labs/hypersdk/chain"
+	"github.com/ava-labs/hypersdk/state"
+)
+
+var _ chain.VerifyContext = (*AcceptedVerifyContext)(nil)
+var _ chain.VerifyContext = (*PendingVerifyContext)(nil)
+
+func (vm *VM) GetVerifyContext(ctx context.Context, blockHeight uint64, parent ids.ID, parentRoot ids.ID) (chain.VerifyContext, error) {
+	// Get processing block
+	if blockHeight > vm.lastAccepted.Hght {
+		blk, err := vm.GetStatelessBlock(ctx, parent)
+		if err != nil {
+			return nil, err
+		}
+		return &PendingVerifyContext{blk}, nil
+	}
+	return &AcceptedVerifyContext{vm}, nil
+}
+
+type PendingVerifyContext struct {
+	blk *chain.StatelessBlock
+}
+
+func (p *PendingVerifyContext) View(ctx context.Context, blockRoot *ids.ID) (state.View, error) {
+	return p.blk.View(ctx, blockRoot)
+}
+func (p *PendingVerifyContext) IsRepeat(ctx context.Context, oldestAllowed int64, txs []*chain.Transaction, marker set.Bits, stop bool) (set.Bits, error) {
+	return p.blk.IsRepeat(ctx, oldestAllowed, txs, marker, stop)
+}
+
+type AcceptedVerifyContext struct {
+	vm *VM
+}
+
+func (a *AcceptedVerifyContext) View(ctx context.Context, blockRoot *ids.ID) (state.View, error) {
+	// TODO: confirm this handling
+	state, err := a.vm.State()
+	if err != nil {
+		return nil, err
+	}
+	if blockRoot == nil {
+		return state, nil
+	}
+	root, err := state.GetMerkleRoot(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if root != *blockRoot {
+		return nil, errors.New("TODO")
+	}
+	return state, nil
+}
+
+func (a *AcceptedVerifyContext) IsRepeat(ctx context.Context, oldestAllowed int64, txs []*chain.Transaction, marker set.Bits, stop bool) (set.Bits, error) {
+	bits := a.vm.IsRepeat(ctx, txs, marker, stop)
+	return bits, nil
+}

--- a/vm/verify_context.go
+++ b/vm/verify_context.go
@@ -83,7 +83,7 @@ func (a *AcceptedVerifyContext) View(ctx context.Context, blockRoot ids.ID) (sta
 	return state, nil
 }
 
-func (a *AcceptedVerifyContext) IsRepeat(ctx context.Context, oldestAllowed int64, txs []*chain.Transaction, marker set.Bits, stop bool) (set.Bits, error) {
+func (a *AcceptedVerifyContext) IsRepeat(ctx context.Context, _ int64, txs []*chain.Transaction, marker set.Bits, stop bool) (set.Bits, error) {
 	bits := a.vm.IsRepeat(ctx, txs, marker, stop)
 	return bits, nil
 }

--- a/vm/verify_context.go
+++ b/vm/verify_context.go
@@ -61,7 +61,9 @@ type AcceptedVerifyContext struct {
 	vm *VM
 }
 
-func (a *AcceptedVerifyContext) View(ctx context.Context, blockRoot *ids.ID, verify bool) (state.View, error) {
+// We disregard [verify] because [GetVerifyContext] ensures
+// we will never need to verify a block if [AcceptedVerifyContext] is returned.
+func (a *AcceptedVerifyContext) View(ctx context.Context, blockRoot *ids.ID, _ bool) (state.View, error) {
 	state, err := a.vm.State()
 	if err != nil {
 		return nil, err

--- a/vm/verify_context.go
+++ b/vm/verify_context.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package vm
 
 import (
@@ -10,8 +13,10 @@ import (
 	"github.com/ava-labs/hypersdk/state"
 )
 
-var _ chain.VerifyContext = (*AcceptedVerifyContext)(nil)
-var _ chain.VerifyContext = (*PendingVerifyContext)(nil)
+var (
+	_ chain.VerifyContext = (*AcceptedVerifyContext)(nil)
+	_ chain.VerifyContext = (*PendingVerifyContext)(nil)
+)
 
 func (vm *VM) GetVerifyContext(ctx context.Context, blockHeight uint64, parent ids.ID) (chain.VerifyContext, error) {
 	// If [blockHeight] is 0, we throw an error because there is no pre-genesis verification context.

--- a/vm/verify_context.go
+++ b/vm/verify_context.go
@@ -35,8 +35,8 @@ func (vm *VM) GetVerifyContext(ctx context.Context, blockHeight uint64, parent i
 		return &PendingVerifyContext{vm.lastAccepted}, nil
 	}
 
-	// If the parent block is not yet accepted, we should return the block's verified but not accepted
-	// parent.
+	// If the parent block is not yet accepted, we should return the block's processing parent (it may
+	// or may not be verified yet).
 	if blockHeight-1 > vm.lastAccepted.Hght {
 		blk, err := vm.GetStatelessBlock(ctx, parent)
 		if err != nil {

--- a/vm/verify_context.go
+++ b/vm/verify_context.go
@@ -2,6 +2,7 @@ package vm
 
 import (
 	"context"
+	"errors"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/set"
@@ -13,8 +14,11 @@ var _ chain.VerifyContext = (*AcceptedVerifyContext)(nil)
 var _ chain.VerifyContext = (*PendingVerifyContext)(nil)
 
 func (vm *VM) GetVerifyContext(ctx context.Context, blockHeight uint64, parent ids.ID) (chain.VerifyContext, error) {
+	if blockHeight == 0 {
+		return nil, errors.New("cannot get context of genesis block")
+	}
 	// If last accepted block is not processed, we need to process it. This will happen when we call [View] on the parent.
-	if blockHeight != 0 && ((!vm.lastAccepted.Processed() && parent == vm.lastAccepted.ID()) || blockHeight-1 > vm.lastAccepted.Hght) {
+	if (!vm.lastAccepted.Processed() && parent == vm.lastAccepted.ID()) || blockHeight-1 > vm.lastAccepted.Hght {
 		blk, err := vm.GetStatelessBlock(ctx, parent)
 		if err != nil {
 			return nil, err

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -280,6 +280,10 @@ func (vm *VM) Initialize(
 		if err := sps.Insert(ctx, chain.HeightKey(vm.StateManager().HeightKey()), binary.BigEndian.AppendUint64(nil, 0)); err != nil {
 			return err
 		}
+		// Set last timestamp
+		if err := sps.Insert(ctx, chain.HeightKey(vm.StateManager().TimestampKey()), binary.BigEndian.AppendUint64(nil, 0)); err != nil {
+			return err
+		}
 		// Set fee parameters
 		genesisRules := vm.c.Rules(0)
 		feeManager := chain.NewFeeManager(nil)
@@ -294,6 +298,8 @@ func (vm *VM) Initialize(
 		if err := sps.Commit(ctx); err != nil {
 			return err
 		}
+		// TODO: root should be pre-genesis info but we should commit height/timestamp/fee changes after to get a different root
+		// for the first child block
 		root, err := vm.stateDB.GetMerkleRoot(ctx)
 		if err != nil {
 			snowCtx.Log.Error("could not get merkle root", zap.Error(err))

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -270,7 +270,7 @@ func (vm *VM) Initialize(
 		vm.preferred, vm.lastAccepted = blkID, blk
 		snowCtx.Log.Info("initialized vm from last accepted", zap.Stringer("block", blkID))
 	} else {
-		// Set balances and generate genesis root
+		// Set balances and compute genesis root
 		sps := state.NewSimpleMutable(vm.stateDB)
 		if err := vm.genesis.Load(ctx, vm.tracer, sps); err != nil {
 			snowCtx.Log.Error("could not set genesis allocation", zap.Error(err))
@@ -299,18 +299,14 @@ func (vm *VM) Initialize(
 			return err
 		}
 
-		// Set last height
+		// Update chain metadata
 		sps = state.NewSimpleMutable(vm.stateDB)
 		if err := sps.Insert(ctx, chain.HeightKey(vm.StateManager().HeightKey()), binary.BigEndian.AppendUint64(nil, 0)); err != nil {
 			return err
 		}
-
-		// Set last timestamp
 		if err := sps.Insert(ctx, chain.HeightKey(vm.StateManager().TimestampKey()), binary.BigEndian.AppendUint64(nil, 0)); err != nil {
 			return err
 		}
-
-		// Set fee parameters
 		genesisRules := vm.c.Rules(0)
 		feeManager := chain.NewFeeManager(nil)
 		minUnitPrice := genesisRules.GetMinUnitPrice()
@@ -322,7 +318,7 @@ func (vm *VM) Initialize(
 			return err
 		}
 
-		// Commit genesis block post-execution state and generate root
+		// Commit genesis block post-execution state and compute root
 		if err := sps.Commit(ctx); err != nil {
 			return err
 		}

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -931,6 +931,9 @@ func (*VM) VerifyHeightIndex(context.Context) error { return nil }
 
 // GetBlockIDAtHeight implements snowmanblock.HeightIndexedChainVM
 // Note: must return database.ErrNotFound if the index at height is unknown.
+//
+// This is ONLY called pre-ProposerVM fork. If we fork immediately after
+// genesis, we only need to be return the blockID of genesis.
 func (vm *VM) GetBlockIDAtHeight(_ context.Context, height uint64) (ids.ID, error) {
 	return vm.GetDiskBlockIDAtHeight(height)
 }

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -950,9 +950,15 @@ func (*VM) VerifyHeightIndex(context.Context) error { return nil }
 // GetBlockIDAtHeight implements snowmanblock.HeightIndexedChainVM
 // Note: must return database.ErrNotFound if the index at height is unknown.
 //
-// This is ONLY called pre-ProposerVM fork. If we fork immediately after
+// This is ONLY called pre-ProposerVM fork. Since we fork immediately after
 // genesis, we only need to be return the blockID of genesis.
 func (vm *VM) GetBlockIDAtHeight(_ context.Context, height uint64) (ids.ID, error) {
+	if height != 0 {
+		return ids.ID{}, database.ErrNotFound
+	}
+
+	// TODO: remove support for looking up blockIDs by height
+	// and store genesis ID in memory.
 	return vm.GetDiskBlockIDAtHeight(height)
 }
 

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -390,7 +390,8 @@ func (vm *VM) markReady() {
 	// we don't yet have a full [ValidityWindow].
 	vm.snowCtx.Log.Info("state sync client ready")
 
-	// Wait for a full [ValidityWindow]
+	// Wait for a full [ValidityWindow] before
+	// we are willing to vote on blocks.
 	select {
 	case <-vm.stop:
 		return

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -665,7 +665,11 @@ func (vm *VM) buildBlock(ctx context.Context, blockContext *smblock.Context) (sn
 	defer vm.checkActivity(ctx)
 
 	// Build block and store as parsed
-	blk, err := chain.BuildBlock(ctx, vm, vm.preferred, blockContext)
+	preferredBlk, err := vm.GetStatelessBlock(ctx, vm.preferred)
+	if err != nil {
+		return nil, err
+	}
+	blk, err := chain.BuildBlock(ctx, vm, preferredBlk, blockContext)
 	if err != nil {
 		vm.snowCtx.Log.Warn("BuildBlock failed", zap.Error(err))
 		return nil, err
@@ -721,7 +725,7 @@ func (vm *VM) Submit(
 	if err != nil {
 		return []error{err}
 	}
-	view, err := blk.View(ctx, nil)
+	view, err := blk.View(ctx, nil, false)
 	if err != nil {
 		// This will error if a block does not yet have processed state.
 		return []error{err}


### PR DESCRIPTION
### TODO
- [x] update comments/handling around where a block reprocessing could get triggered
- [x] Add comment to `GetBlockIDAtHeight` that this is only called pre-ProposerVM fork
- [x] Fix genesis block init (roots are messed up)
- [ ] ~Can we just verify the last accepted block when state sync finishes? otherwise we may not be able to build (right now we consider verifying blocks in 3 places) -> won't be able to ensure no repeats but should be able to process already accepted block~ -> Because we don't control when state sync will finish (may be during `Verify/Accept`), we can't get away from having to handle parent verification during child verify/accept.
- [x] Don't check for duplicate txs if block is already accepted