### PR TITLE
[x/programs] [poc] validate wasmtime-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.20
 require (
 	github.com/ava-labs/avalanche-network-runner v1.7.2-0.20230825184751-fbe081616f02
 	github.com/ava-labs/avalanchego v1.10.10-rc.0.0.20230831160820-2eabd228952b
+	github.com/bytecodealliance/wasmtime-go/v12 v12.0.0
 	github.com/cockroachdb/pebble v0.0.0-20230224221607-fccb83b60d5c
 	github.com/golang/mock v1.6.0
 	github.com/gorilla/rpc v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -95,6 +95,8 @@ github.com/btcsuite/snappy-go v0.0.0-20151229074030-0bdef8d06723/go.mod h1:8woku
 github.com/btcsuite/snappy-go v1.0.0/go.mod h1:8woku9dyThutzjeg+3xrA5iCpBRH8XEEg3lh6TiUghc=
 github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtEyQwv5/p4Mg4C0fgbePVuGr935/5ddU9Z3TmDRY=
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
+github.com/bytecodealliance/wasmtime-go/v12 v12.0.0 h1:Wga02UaZXYF3p0LIeL5xFp09/RI7UhjfT2uB0mLrwlw=
+github.com/bytecodealliance/wasmtime-go/v12 v12.0.0/go.mod h1:a3PRoftJxxUzkQvgjC6sv7pKyJJK0ZsFVmH+eeEKQC4=
 github.com/cenkalti/backoff/v4 v4.2.0 h1:HN5dHm3WBOgndBH6E8V0q2jIYIR3s9yglV8k/+MN3u4=
 github.com/cenkalti/backoff/v4 v4.2.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/x/programs/examples/lottery.go
+++ b/x/programs/examples/lottery.go
@@ -15,8 +15,9 @@ import (
 	"go.uber.org/zap"
 )
 
-func NewLottery(log logging.Logger, lotteryProgramBytes []byte, tokenProgramBytes []byte, maxFee uint64, costMap map[string]uint64) *Lottery {
-	return &Lottery{
+// NewWazeroLottery is an example of the lottery program unsing the wazero runtime.
+func NewWazeroLottery(log logging.Logger, lotteryProgramBytes []byte, tokenProgramBytes []byte, maxFee uint64, costMap map[string]uint64) *WazeroLottery {
+	return &WazeroLottery{
 		log:                 log,
 		lotteryProgramBytes: lotteryProgramBytes,
 		tokenProgramBytes:   tokenProgramBytes,
@@ -25,7 +26,7 @@ func NewLottery(log logging.Logger, lotteryProgramBytes []byte, tokenProgramByte
 	}
 }
 
-type Lottery struct {
+type WazeroLottery struct {
 	log                 logging.Logger
 	lotteryProgramBytes []byte
 	tokenProgramBytes   []byte
@@ -35,12 +36,12 @@ type Lottery struct {
 	costMap map[string]uint64
 }
 
-func (t *Lottery) Run(ctx context.Context) error {
+func (t *WazeroLottery) Run(ctx context.Context) error {
 	meter := runtime.NewMeter(t.log, t.maxFee, t.costMap)
 	db := utils.NewTestDB()
 	store := newProgramStorage(db)
 
-	tokenRuntime := runtime.New(t.log, meter, store)
+	tokenRuntime := runtime.NewWazero(t.log, meter, store)
 	tokenProgramId, err := tokenRuntime.Create(ctx, t.tokenProgramBytes)
 	if err != nil {
 		return err
@@ -116,7 +117,7 @@ func (t *Lottery) Run(ctx context.Context) error {
 	)
 
 	// initialize lottery program
-	lotteryRuntime := runtime.New(t.log, meter, store)
+	lotteryRuntime := runtime.NewWazero(t.log, meter, store)
 	lotteryProgramId, err := lotteryRuntime.Create(ctx, t.lotteryProgramBytes)
 	if err != nil {
 		return err

--- a/x/programs/examples/lottery_test.go
+++ b/x/programs/examples/lottery_test.go
@@ -17,7 +17,7 @@ var lotteryProgramBytes []byte
 // go test -v -timeout 30s -run ^TestLotteryProgram$ github.com/ava-labs/hypersdk/x/programs/examples
 func TestLotteryProgram(t *testing.T) {
 	require := require.New(t)
-	program := NewLottery(log, lotteryProgramBytes, tokenProgramBytes, maxGas, costMap)
+	program := NewWazeroLottery(log, lotteryProgramBytes, tokenProgramBytes, maxGas, costMap)
 	err := program.Run(context.Background())
 	require.NoError(err)
 }

--- a/x/programs/examples/pokemon.go
+++ b/x/programs/examples/pokemon.go
@@ -38,7 +38,7 @@ func (t *Pokemon) Run(ctx context.Context) error {
 	db := utils.NewTestDB()
 	store := newProgramStorage(db)
 
-	runtime := runtime.New(t.log, meter, store)
+	runtime := runtime.NewWazero(t.log, meter, store)
 	contractId, err := runtime.Create(ctx, t.programBytes)
 	if err != nil {
 		return err

--- a/x/programs/examples/token.go
+++ b/x/programs/examples/token.go
@@ -194,7 +194,7 @@ func (t *TokenWasmtime) Run(ctx context.Context) error {
 	}
 
 	// get programId
-	programID := runtime.InitProgramStorage()
+	programID := uint64(runtime.InitProgramStorage())
 
 	// call initialize if it exists
 	result, err := rt.Call(ctx, "init", uint64(programID))
@@ -219,97 +219,81 @@ func (t *TokenWasmtime) Run(ctx context.Context) error {
 		zap.Uint64("minted", result[0]),
 	)
 
-	// // generate alice keys
-	// alicePtr, _, err := newKeyPtr(ctx, runtime)
-	// if err != nil {
-	// 	return err
-	// }
+	// generate alice keys
+	alicePtr, _, err := newKeyPtr(ctx, rt)
+	if err != nil {
+		return err
+	}
 
-	// // generate bob keys
-	// bobPtr, _, err := newKeyPtr(ctx, runtime)
-	// if err != nil {
-	// 	return err
-	// }
+	// generate bob keys
+	bobPtr, _, err := newKeyPtr(ctx, rt)
+	if err != nil {
+		return err
+	}
 
-	// // check balance of alice
-	// result, err = runtime.Call(ctx, "get_balance", contractId, bobPtr)
-	// if err != nil {
-	// 	return err
-	// }
-	// t.log.Debug("balance",
-	// 	zap.Int64("bob", int64(result[0])),
-	// )
+	// check balance of alice
+	result, err = rt.Call(ctx, "get_balance", programID, bobPtr)
+	if err != nil {
+		return err
+	}
+	t.log.Debug("balance",
+		zap.Int64("bob", int64(result[0])),
+	)
 
-	// // mint 100 tokens to alice
-	// mintAlice := uint64(100)
-	// _, err = runtime.Call(ctx, "mint_to", contractId, alicePtr, mintAlice)
-	// if err != nil {
-	// 	return err
-	// }
-	// t.log.Debug("minted",
-	// 	zap.Uint64("alice", mintAlice),
-	// )
+	// mint 100 tokens to alice
+	mintAlice := uint64(100)
+	_, err = rt.Call(ctx, "mint_to", programID, alicePtr, mintAlice)
+	if err != nil {
+		return err
+	}
+	t.log.Debug("minted",
+		zap.Uint64("alice", mintAlice),
+	)
 
-	// // check balance of alice
-	// result, err = runtime.Call(ctx, "get_balance", contractId, alicePtr)
-	// if err != nil {
-	// 	return err
-	// }
-	// t.log.Debug("balance",
-	// 	zap.Int64("alice", int64(result[0])),
-	// )
+	// check balance of alice
+	result, err = rt.Call(ctx, "get_balance", programID, alicePtr)
+	if err != nil {
+		return err
+	}
+	t.log.Debug("balance",
+		zap.Int64("alice", int64(result[0])),
+	)
 
-	// // deallocate bytes
-	// defer func() {
-	// 	_, err = runtime.Call(ctx, "dealloc", alicePtr, ed25519.PublicKeyLen)
-	// 	if err != nil {
-	// 		t.log.Error("failed to deallocate alice ptr",
-	// 			zap.Error(err),
-	// 		)
-	// 	}
-	// 	_, err = runtime.Call(ctx, "dealloc", bobPtr, ed25519.PublicKeyLen)
-	// 	if err != nil {
-	// 		t.log.Error("failed to deallocate bob ptr",
-	// 			zap.Error(err),
-	// 		)
-	// 	}
-	// }()
+	// check balance of bob
+	result, err = rt.Call(ctx, "get_balance", programID, bobPtr)
+	if err != nil {
+		return err
+	}
+	t.log.Debug("balance",
+		zap.Int64("bob", int64(result[0])),
+	)
 
-	// // check balance of bob
-	// result, err = runtime.Call(ctx, "get_balance", contractId, bobPtr)
-	// if err != nil {
-	// 	return err
-	// }
-	// t.log.Debug("balance",
-	// 	zap.Int64("bob", int64(result[0])),
-	// )
+	// transfer 50 from alice to bob
+	transferToBob := uint64(50)
+	_, err = rt.Call(ctx, "transfer", programID, alicePtr, bobPtr, transferToBob)
+	if err != nil {
+		return err
+	}
+	t.log.Debug("transferred",
+		zap.Uint64("alice", transferToBob),
+		zap.Uint64("to bob", transferToBob),
+	)
 
-	// // transfer 50 from alice to bob
-	// transferToBob := uint64(50)
-	// _, err = runtime.Call(ctx, "transfer", contractId, alicePtr, bobPtr, transferToBob)
-	// if err != nil {
-	// 	return err
-	// }
-	// t.log.Debug("transferred",
-	// 	zap.Uint64("alice", transferToBob),
-	// 	zap.Uint64("to bob", transferToBob),
-	// )
+	// get balance alice
+	result, err = rt.Call(ctx, "get_balance", programID, alicePtr)
+	if err != nil {
+		return err
+	}
+	t.log.Debug("balance",
+		zap.Int64("alice", int64(result[0])),
+	)
 
-	// // get balance alice
-	// result, err = runtime.Call(ctx, "get_balance", contractId, alicePtr)
-	// if err != nil {
-	// 	return err
-	// }
-	// t.log.Debug("balance",
-	// 	zap.Int64("alice", int64(result[0])),
-	// )
-
-	// // get balance bob
-	// result, err = runtime.Call(ctx, "get_balance", contractId, bobPtr)
-	// if err != nil {
-	// 	return err
-	// }
-	// t.log.Debug("balance", zap.Int64("bob", int64(result[0])))
+	// get balance bob
+	result, err = rt.Call(ctx, "get_balance", programID, bobPtr)
+	if err != nil {
+		return err
+	}
+	t.log.Debug("balance", zap.Int64("bob", int64(result[0])))
 
 	return nil
 }

--- a/x/programs/examples/token.go
+++ b/x/programs/examples/token.go
@@ -164,7 +164,6 @@ func newKeyPtr(ctx context.Context, runtime runtime.Runtime) (uint64, ed25519.Pu
 	return ptr, pk, err
 }
 
-
 func NewTokenWasmtime(log logging.Logger, programBytes []byte, maxFee uint64, costMap map[string]uint64) *TokenWasmtime {
 	return &TokenWasmtime{
 		log:          log,
@@ -194,7 +193,7 @@ func (t *TokenWasmtime) Run(ctx context.Context) error {
 		return err
 	}
 
-    // get programId
+	// get programId
 	programID := runtime.InitProgramStorage()
 
 	// call initialize if it exists

--- a/x/programs/examples/token_test.go
+++ b/x/programs/examples/token_test.go
@@ -27,24 +27,33 @@ var (
 	log           = logging.NewLogger(
 		"",
 		logging.NewWrappedCore(
-			logging.Debug,
+			logging.Info,
 			os.Stderr,
 			logging.Plain.ConsoleEncoder(),
 		))
 )
 
-// go test -v -timeout 30s -run ^TestTokenProgram$ github.com/ava-labs/hypersdk/x/programs/examples
-func TestTokenProgram(t *testing.T) {
+// go test -v -timeout 30s -run ^TestTokenWazeroProgram$ github.com/ava-labs/hypersdk/x/programs/examples
+func TestTokenWazeroProgram(t *testing.T) {
 	require := require.New(t)
-	program := NewToken(log, tokenProgramBytes, maxGas, costMap)
+	program := NewTokenWazero(log, tokenProgramBytes, maxGas, costMap)
 	err := program.Run(context.Background())
 	require.NoError(err)
 }
 
+// go test -v -timeout 30s -run ^TestTokenWazeroProgram$ github.com/ava-labs/hypersdk/x/programs/examples
+func TestTokenWasmtimeProgram(t *testing.T) {
+	require := require.New(t)
+	program := NewTokenWasmtime(log, tokenProgramBytes, maxGas, costMap)
+	err := program.Run(context.Background())
+	require.NoError(err)
+}
+
+
 // go test -v -benchmem -run=^$ -bench ^BenchmarkTokenProgram$ github.com/ava-labs/hypersdk/x/programs/examples -memprofile benchvset.mem -cpuprofile benchvset.cpu
-func BenchmarkTokenProgram(b *testing.B) {
+func BenchmarkTokenWazeroProgram(b *testing.B) {
 	require := require.New(b)
-	program := NewToken(log, tokenProgramBytes, maxGas, costMap)
+	program := NewTokenWazero(log, tokenProgramBytes, maxGas, costMap)
 	b.ResetTimer()
 	b.Run("benchmark_token_program", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
@@ -53,6 +62,3 @@ func BenchmarkTokenProgram(b *testing.B) {
 		}
 	})
 }
-
-// BenchmarkTokenProgram/benchmark_token_program-10                      46          22319237 ns/op         7989180 B/op     116432 allocs/op
-// BenchmarkTokenProgram/benchmark_token_program-10                     100          10157392 ns/op         4967247 B/op      46825 allocs/op

--- a/x/programs/examples/token_test.go
+++ b/x/programs/examples/token_test.go
@@ -49,7 +49,6 @@ func TestTokenWasmtimeProgram(t *testing.T) {
 	require.NoError(err)
 }
 
-
 // go test -v -benchmem -run=^$ -bench ^BenchmarkTokenProgram$ github.com/ava-labs/hypersdk/x/programs/examples -memprofile benchvset.mem -cpuprofile benchvset.cpu
 func BenchmarkTokenWazeroProgram(b *testing.B) {
 	require := require.New(b)
@@ -62,7 +61,6 @@ func BenchmarkTokenWazeroProgram(b *testing.B) {
 		}
 	})
 }
-
 
 func BenchmarkTokenWasmtimeProgram(b *testing.B) {
 	require := require.New(b)

--- a/x/programs/examples/token_test.go
+++ b/x/programs/examples/token_test.go
@@ -55,7 +55,20 @@ func BenchmarkTokenWazeroProgram(b *testing.B) {
 	require := require.New(b)
 	program := NewTokenWazero(log, tokenProgramBytes, maxGas, costMap)
 	b.ResetTimer()
-	b.Run("benchmark_token_program", func(b *testing.B) {
+	b.Run("benchmark_token_program_wazero", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			err := program.Run(context.Background())
+			require.NoError(err)
+		}
+	})
+}
+
+
+func BenchmarkTokenWasmtimeProgram(b *testing.B) {
+	require := require.New(b)
+	program := NewTokenWasmtime(log, tokenProgramBytes, maxGas, costMap)
+	b.ResetTimer()
+	b.Run("benchmark_token_program_wasmtime", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			err := program.Run(context.Background())
 			require.NoError(err)

--- a/x/programs/runtime/invoke_program.go
+++ b/x/programs/runtime/invoke_program.go
@@ -75,7 +75,7 @@ func (m *InvokeModule) invokeProgramFn(
 	}
 
 	// create new runtime for the program invoke call
-	runtime := New(m.log, m.meter, m.storage)
+	runtime := NewWazero(m.log, m.meter, m.storage)
 
 	err := runtime.Initialize(ctx, data)
 	if err != nil {

--- a/x/programs/runtime/map.go
+++ b/x/programs/runtime/map.go
@@ -37,7 +37,7 @@ type MapModule struct {
 	log   logging.Logger
 
 	Mod   *wasmtime.Instance
-	Store  *wasmtime.Store
+	Store *wasmtime.Store
 }
 
 // NewMapModule returns a new map host module which can manage in memory state.
@@ -47,7 +47,6 @@ func NewMapModule(log logging.Logger, meter Meter) *MapModule {
 	return &MapModule{
 		meter: meter,
 		log:   log,
-		
 	}
 }
 
@@ -125,7 +124,6 @@ func (m *MapModule) storeBytesWasmtimeFn(id int64, keyPtr int32, keyLength int32
 	copy(copiedValue, valBuf)
 	GlobalStorage.state[id][string(keyBuf)] = copiedValue
 
-
 	// fmt.Printf("store bytes after: %v", GlobalStorage.state[id])
 	return 0
 }
@@ -153,7 +151,7 @@ func (m *MapModule) getBytesLenWasmtimeFn(id int64, keyPtr int32, keyLength int3
 		m.log.Error("failed to find program id in storage")
 		return mapErr
 	}
-	buf, ok := utils.GetBufferWasmtime(m.Mod,m.Store, uint32(keyPtr), uint32(keyLength))
+	buf, ok := utils.GetBufferWasmtime(m.Mod, m.Store, uint32(keyPtr), uint32(keyLength))
 	if !ok {
 		return mapErr
 	}
@@ -210,7 +208,7 @@ func (m *MapModule) getBytesWasmtimeFn(id int64, keyPtr int32, keyLength int32, 
 		m.log.Error("failed to find program id in storage")
 		return mapErr
 	}
-	buf, ok := utils.GetBufferWasmtime(m.Mod,m.Store, uint32(keyPtr), uint32(keyLength))
+	buf, ok := utils.GetBufferWasmtime(m.Mod, m.Store, uint32(keyPtr), uint32(keyLength))
 	if !ok {
 		return mapErr
 	}
@@ -220,12 +218,11 @@ func (m *MapModule) getBytesWasmtimeFn(id int64, keyPtr int32, keyLength int32, 
 	}
 
 	// write to memory
-	ptr, err:= utils.WriteBufferWasmtime(m.Mod, m.Store, val)
+	ptr, err := utils.WriteBufferWasmtime(m.Mod, m.Store, val)
 	if err != nil {
-       m.log.Error("failed to find program id in storage", zap.Error(err))
+		m.log.Error("failed to find program id in storage", zap.Error(err))
 		return mapErr
 	}
-	
 
 	return int32(ptr)
 }

--- a/x/programs/runtime/map.go
+++ b/x/programs/runtime/map.go
@@ -64,7 +64,7 @@ func (m *MapModule) Instantiate(ctx context.Context, r wazero.Runtime) error {
 	return err
 }
 
-func initProgramStorage() int64 {
+func InitProgramStorage() int64 {
 	GlobalStorage.counter++
 	GlobalStorage.state[GlobalStorage.counter] = make(map[string][]byte)
 	return GlobalStorage.counter
@@ -93,6 +93,15 @@ func (m *MapModule) storeBytesFn(_ context.Context, mod api.Module, id int64, ke
 	GlobalStorage.state[id][string(keyBuf)] = copiedValue
 
 	return mapOk
+}
+
+func (m *MapModule) storeBytesWasmtime(id int64, keyPtr int32, keyLength int32, valuePtr int32, valueLength int32) int32 {
+	_, ok := GlobalStorage.state[int64(id)]
+	if !ok {
+		m.log.Error("failed to find program id in storage")
+		return mapErr
+	}
+	return 0
 }
 
 func (m *MapModule) getBytesLenFn(_ context.Context, mod api.Module, id int64, keyPtr uint32, keyLength uint32) int32 {

--- a/x/programs/runtime/meter_test.go
+++ b/x/programs/runtime/meter_test.go
@@ -44,7 +44,7 @@ func TestMeterInsufficientBalance(t *testing.T) {
 	defer cancel()
 
 	meter := NewMeter(log, maxFee, costMap)
-	runtime := New(log, meter, storage)
+	runtime := NewWazero(log, meter, storage)
 	err := runtime.Initialize(ctx, tokenProgramBytes)
 	require.NoError(err)
 
@@ -66,7 +66,7 @@ func TestMeterRuntimeStop(t *testing.T) {
 	defer cancel()
 
 	meter := NewMeter(log, maxFee, costMap)
-	runtime := New(log, meter, storage)
+	runtime := NewWazero(log, meter, storage)
 	err := runtime.Initialize(ctx, tokenProgramBytes)
 	require.NoError(err)
 

--- a/x/programs/runtime/runtime_wasmtime.go
+++ b/x/programs/runtime/runtime_wasmtime.go
@@ -1,0 +1,176 @@
+// Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package runtime
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+
+	"github.com/bytecodealliance/wasmtime-go/v12"
+
+	"github.com/ava-labs/avalanchego/utils/logging"
+	"github.com/ava-labs/hypersdk/x/programs/utils"
+)
+
+const (
+	allocFnName   = "alloc"
+	deallocFnName = "dealloc"
+)
+
+func NewWasmtime(log logging.Logger, meter Meter, storage Storage) *runtime {
+	return &runtime{
+		log:     log,
+		meter:   meter,
+		storage: storage,
+	}
+}
+
+type runtime struct {
+	cancelFn context.CancelFunc
+	mod      *wasmtime.Instance
+	store    *wasmtime.Store
+	meter    Meter
+	storage  Storage
+
+	closed bool
+	log    logging.Logger
+}
+
+func (r *runtime) Create(ctx context.Context, programBytes []byte) (uint64, error) {
+	err := r.Initialize(ctx, programBytes)
+	if err != nil {
+		return 0, err
+	}
+	// get programId
+	programID := InitProgramStorage()
+
+	// call initialize if it exists
+	result, err := r.Call(ctx, "init", uint64(programID))
+	if err != nil {
+		if !errors.Is(err, ErrMissingExportedFunction) {
+			return 0, err
+		}
+	} else {
+		// check boolean result from init
+		if result[0] == 0 {
+			return 0, fmt.Errorf("failed to initialize program")
+		}
+	}
+	return uint64(programID), nil
+}
+
+func (r *runtime) Initialize(ctx context.Context, programBytes []byte) error {
+    cfg := wasmtime.NewConfig()
+	cfg.SetConsumeFuel(true)
+	r.store = wasmtime.NewStore(wasmtime.NewEngineWithConfig(cfg))
+	err := r.store.AddFuel(10000)
+	if err != nil {
+		return err
+	}
+
+	module, err := wasmtime.NewModule(r.store.Engine, programBytes)
+	if err != nil {
+		return err
+	}
+
+	linker := wasmtime.NewLinker(r.store.Engine)
+
+	f1 := func(id int64, keyPtr int32, keyLength int32) int32 {
+		return 0
+	}
+
+	f2 := func(id int64, keyPtr int32, keyLength int32, something int32) int32 {
+		return 0
+	}
+
+	// TODO: remove
+	// initialize wasi
+	wcfg := wasmtime.NewWasiConfig()
+	wcfg.InheritStderr()
+	wcfg.InheritStdout()
+	r.store.SetWasi(wcfg)
+
+	err = linker.DefineWasi()
+	if err != nil {
+		return err
+	}
+
+	mapMod := NewMapModule(r.log, nil)
+
+	linker.DefineFunc(r.store, "map", "store_bytes", mapMod.storeBytesWasmtime)
+	linker.DefineFunc(r.store, "map", "get_bytes_len", f1)
+	linker.DefineFunc(r.store, "map", "get_bytes", f2)
+
+	r.mod, err = linker.Instantiate(r.store,module)
+	if err != nil {
+		return err
+	}
+
+
+	return nil
+}
+
+func (r *runtime) Call(ctx context.Context, name string, params ...uint64) ([]uint64, error) {
+	if r.closed {
+		return nil, fmt.Errorf("failed to call: %s: runtime closed", name)
+	}
+
+
+	var api *wasmtime.Func
+
+	if name == allocFnName || name == deallocFnName {
+		api = r.mod.GetFunc(r.store, name)
+	} else {
+		api = r.mod.GetFunc(r.store, utils.GetGuestFnName(name))
+	}
+
+    if api == nil {
+		return nil, ErrMissingExportedFunction
+	}
+
+	// why []interface....
+	var p []interface{}
+	for _, param := range params {
+		p = append(p, int64(param))
+	}
+
+	result, err := api.Call(r.store, p...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to call %s: %w", name, err)
+	}
+
+	return []uint64{uint64(result.(int32))}, nil
+}
+
+func (r *runtime) GetGuestBuffer(offset uint32, length uint32) ([]byte, bool) {
+	return []byte{}, false	
+}
+
+// TODO: ensure deallocate on Stop.
+func (r *runtime) WriteGuestBuffer(ctx context.Context, buf []byte) (uint64, error) {
+	// allocate to guest and return offset
+	result, err := r.Call(ctx, allocFnName, uint64(len(buf)))
+	if err != nil {
+		return 0, err
+	}
+
+	mem := r.mod.GetExport(r.store, "memory").Memory().UnsafeData(r.store)
+	addr := int32(result[0])
+	binary.BigEndian.PutUint32(mem[addr:], uint32(len(buf)))
+	copy(mem[addr+4:], buf)
+
+	return uint64(addr), nil
+}
+
+func (r *runtime) Stop(ctx context.Context) error {
+	defer r.cancelFn()
+	if r.closed {
+		return nil
+	}
+	r.closed = true
+
+	return nil
+}

--- a/x/programs/rust/examples/counter/Cargo.toml
+++ b/x/programs/rust/examples/counter/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 wasmlanche_sdk = { version = "0.1.0", path = "../../wasmlanche_sdk" }
+getrandom = { version = "0.2", features = ["js"] }
 
 [lib]
 crate-type = ["cdylib"] # set the crate(needed for cargo build to work properly)

--- a/x/programs/rust/scripts/build.sh
+++ b/x/programs/rust/scripts/build.sh
@@ -6,4 +6,4 @@ CARGO_TARGET_DIR=../examples/testdata/target
 
 rm -r $CARGO_TARGET_DIR
 
-cargo build --target wasm32-wasi --target-dir $CARGO_TARGET_DIR --release
+cargo build --target wasm32-unknown-unknown --target-dir $CARGO_TARGET_DIR --release

--- a/x/programs/rust/wasmlanche_sdk/Cargo.toml
+++ b/x/programs/rust/wasmlanche_sdk/Cargo.toml
@@ -10,5 +10,6 @@ thiserror = "1.0.46"
 serde = { version = "1.0.185", features = ["derive"] }
 serde_bare = "0.5.0"
 sdk_macros = { version = "0.1.0", path = "../sdk_macros" }
+getrandom = { version = "0.2", features = ["js"] }
 
 [lib]

--- a/x/programs/utils/utils.go
+++ b/x/programs/utils/utils.go
@@ -7,8 +7,7 @@ import (
 	"context"
 	"fmt"
 	"os"
-		"runtime"
-
+	"runtime"
 
 	"github.com/bytecodealliance/wasmtime-go/v12"
 
@@ -79,7 +78,7 @@ func WriteBufferWasmtime(mod *wasmtime.Instance, store *wasmtime.Store, buffer [
 
 	ptr := result.(int32)
 
-    memory := mod.GetExport(store, "memory").Memory()
+	memory := mod.GetExport(store, "memory").Memory()
 	size := memory.DataSize(store)
 
 	// verify available memory is large enough
@@ -93,7 +92,6 @@ func WriteBufferWasmtime(mod *wasmtime.Instance, store *wasmtime.Store, buffer [
 
 	return uint64(ptr), nil
 }
-
 
 // GetBuffer returns the buffer at [ptr] with length [length]. Returns
 // false if out of range.
@@ -113,7 +111,7 @@ func GetBufferWasmtime(mod *wasmtime.Instance, store *wasmtime.Store, offset uin
 	runtime.KeepAlive(memory)
 	buf := memory.UnsafeData(store)
 
-	return buf[offset:offset+length], true
+	return buf[offset : offset+length], true
 }
 
 func GetProgramBytes(filePath string) ([]byte, error) {


### PR DESCRIPTION
POC hack PR please do not review. The goal is to evaluate performance of wasmtime-go with fuel metering.

wazero in the slower interpreter mode appears faster than wasmtime-go with only a partial token example.


>goos: linux
goarch: amd64
pkg: github.com/ava-labs/hypersdk/x/programs/examples
cpu: Intel(R) Core(TM) i7-10750H CPU @ 2.60GHz
BenchmarkTokenWazeroProgram/benchmark_token_program_wazero-12         	      78	  15678089 ns/op	 4653056 B/op	   42360 allocs/op

>cpu: Intel(R) Core(TM) i7-10750H CPU @ 2.60GHz
BenchmarkTokenWasmtimeProgram/benchmark_token_program-12         	      55	  18746760 ns/op	  104953 B/op	     394 allocs/op
