### PR TITLE
add links for community projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -991,9 +991,9 @@ _This is a collection of posts from the community about the `hypersdk` and how t
 ## HyperSDK Projects 👀
 _This is a gallery of community projects currently building on top of the HyperSDK._
 
-* [NodeKit: Decentralizing The L2 Sequencer on a Subnet]()
-* [OracleVM: Providing OffChain Data to the Avalanche Ecosystem]()
-* [ShuttleVM: Trusted Execution Environment for Wasm Programs to run distributed workloads on a subnet]()
+* [NodeKit: Decentralizing The L2 Sequencer on a Subnet](https://github.com/AnomalyFi/nodekit-seq)
+* [OracleVM: Providing OffChain Data to the Avalanche Ecosystem](https://github.com/bianyuanop/oraclevm)
+* ShuttleVM: Trusted Execution Environment for Wasm Programs to run distributed workloads on a subnet
 
 
 


### PR DESCRIPTION
Was reading through the Readme on the homepage and noticed the docs had empty links. Added the projects here, although I couldn't find ShuttleVM. 