### PR TITLE
[crypto] `secp256r1` (P-256) Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,9 +397,11 @@ for a single account and ensure they are ordered) and makes the network layer
 more efficient (we can gossip any valid transaction to any node instead of just
 the transactions for each account that can be executed at the moment).
 
-// TODO: finish
-_Because transaction ID is used exclusively to prevent replay, it is critical
-that `Auth` signatures are [not malleable](https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki)._
+_Because transaction IDs are used to prevent replay, it is critical that any signatures used
+in `Auth` are [not malleable](https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki).
+If malleable signatures are used, it would be trivial for an attacker to generate additional, valid
+transactions from an existing transaction and submit it to the network (duplicating whatever `Action` was
+specified by the sender)._
 
 ### Avalanche Warp Messaging Support
 `hypersdk` provides support for Avalanche Warp Messaging (AWM) out-of-the-box. AWM enables any

--- a/README.md
+++ b/README.md
@@ -397,6 +397,10 @@ for a single account and ensure they are ordered) and makes the network layer
 more efficient (we can gossip any valid transaction to any node instead of just
 the transactions for each account that can be executed at the moment).
 
+// TODO: finish
+_Because transaction ID is used exclusively to prevent replay, it is critical
+that `Auth` signatures are [not malleable](https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki)._
+
 ### Avalanche Warp Messaging Support
 `hypersdk` provides support for Avalanche Warp Messaging (AWM) out-of-the-box. AWM enables any
 Avalanche Subnet to send arbitrary messages to any other Avalanche Subnet in just a few

--- a/chain/mock_action.go
+++ b/chain/mock_action.go
@@ -15,7 +15,7 @@ import (
 	warp "github.com/ava-labs/avalanchego/vms/platformvm/warp"
 	codec "github.com/ava-labs/hypersdk/codec"
 	state "github.com/ava-labs/hypersdk/state"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockAction is a mock of Action interface.

--- a/chain/mock_auth.go
+++ b/chain/mock_auth.go
@@ -13,7 +13,7 @@ import (
 
 	codec "github.com/ava-labs/hypersdk/codec"
 	state "github.com/ava-labs/hypersdk/state"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockAuth is a mock of Auth interface.

--- a/chain/mock_auth_factory.go
+++ b/chain/mock_auth_factory.go
@@ -10,7 +10,7 @@ package chain
 import (
 	reflect "reflect"
 
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockAuthFactory is a mock of AuthFactory interface.

--- a/chain/mock_rules.go
+++ b/chain/mock_rules.go
@@ -11,7 +11,7 @@ import (
 	reflect "reflect"
 
 	ids "github.com/ava-labs/avalanchego/ids"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockRules is a mock of Rules interface.

--- a/crypto/P256/P256.go
+++ b/crypto/P256/P256.go
@@ -15,6 +15,7 @@ import (
 // -> https://eips.ethereum.org/EIPS/eip-7212#elliptic-curve-signature-verification-steps
 // -> https://github.com/ethereum/go-ethereum/pull/27540
 // -> https://github.com/ethereum/EIPs/pull/7676 (malleability check removed)
+// ->-> https://github.com/ethereum/go-ethereum/pull/27540/files/7e0bc9271bc8ede1ca96c199d506368b7552ea51..cec0b058115282168c5afc5197de3f6b5479dc4a#diff-42aa89445835b22ad5e89bbea13ecfe2fa10b69084397e2dca6a826194f542e0
 
 type (
 	PublicKey  [ed25519.PublicKeySize]byte

--- a/crypto/P256/P256.go
+++ b/crypto/P256/P256.go
@@ -137,3 +137,5 @@ func HexToKey(key string) (PrivateKey, error) {
 	}
 	return PrivateKey(bytes), nil
 }
+
+// TODO: offer DER to fixed conversion as utility

--- a/crypto/ed25519/ed25519_test.go
+++ b/crypto/ed25519/ed25519_test.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/ava-labs/hypersdk/crypto"
 	oed25519 "github.com/oasisprotocol/curve25519-voi/primitives/ed25519"
 	"github.com/oasisprotocol/curve25519-voi/primitives/ed25519/extra/cache"
 
@@ -98,7 +99,7 @@ func TestAddress(t *testing.T) {
 func TestParseAddressIncorrectHrt(t *testing.T) {
 	require := require.New(t)
 	pubkey, err := ParseAddress("wronghrt", TestAddressString)
-	require.ErrorIs(err, ErrIncorrectHrp, "ErrIncorrectHrp not returned")
+	require.ErrorIs(err, crypto.ErrIncorrectHrp, "ErrIncorrectHrp not returned")
 	require.Equal(
 		pubkey,
 		PublicKey(EmptyPublicKey),
@@ -166,7 +167,7 @@ func TestLoadKeyIncorrectKey(t *testing.T) {
 	privKey, err := LoadKey(fileName)
 
 	// Validate
-	require.ErrorIs(err, ErrInvalidPrivateKey,
+	require.ErrorIs(err, crypto.ErrInvalidPrivateKey,
 		"ErrInvalidPrivateKey was not returned")
 	require.Equal(privKey, PrivateKey(EmptyPrivateKey))
 
@@ -241,7 +242,7 @@ func TestHexToKeyInvalidKey(t *testing.T) {
 	require := require.New(t)
 	invalidHex := "1234"
 	hex, err := HexToKey(invalidHex)
-	require.ErrorIs(err, ErrInvalidPrivateKey, "Incorrect error returned")
+	require.ErrorIs(err, crypto.ErrInvalidPrivateKey, "Incorrect error returned")
 	require.Equal(PrivateKey(EmptyPrivateKey), hex)
 }
 

--- a/crypto/errors.go
+++ b/crypto/errors.go
@@ -1,7 +1,7 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-package ed25519
+package crypto
 
 import "errors"
 

--- a/crypto/secp256r1/secp256r1.go
+++ b/crypto/secp256r1/secp256r1.go
@@ -79,7 +79,7 @@ func GeneratePrivateKey() (PrivateKey, error) {
 		return EmptyPrivateKey, err
 	}
 
-	// We aren't always guranteed that this will be 32 bytes,
+	// We aren't always guaranteed that this will be 32 bytes,
 	// so we use fill.
 	b := make([]byte, PrivateKeyLen)
 	k.D.FillBytes(b)

--- a/crypto/secp256r1/secp256r1.go
+++ b/crypto/secp256r1/secp256r1.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package secp256r1
 
 import (

--- a/crypto/secp256r1/secp256r1.go
+++ b/crypto/secp256r1/secp256r1.go
@@ -20,7 +20,7 @@ import (
 const (
 	PublicKeyLen  = 33 // compressed form (SEC 1, Version 2.0, Section 2.3.3)
 	PrivateKeyLen = 32
-	SignatureLen  = 64 // r || s
+	SignatureLen  = 64 // R || S
 
 	rsLen = 32
 )

--- a/crypto/secp256r1/secp256r1.go
+++ b/crypto/secp256r1/secp256r1.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"math/big"
 	"os"
 
@@ -120,7 +121,12 @@ func GeneratePrivateKey() (PrivateKey, error) {
 	if err != nil {
 		return EmptyPrivateKey, err
 	}
-	return PrivateKey(k.D.Bytes()), nil
+
+	// We aren't always guranteed that this will be 32 bytes,
+	// so we use fill.
+	b := make([]byte, PrivateKeyLen)
+	k.D.FillBytes(b)
+	return PrivateKey(b), nil
 }
 
 // generateCoordintes recovers the public key coordinates
@@ -201,9 +207,11 @@ func Sign(msg []byte, pk PrivateKey) (Signature, error) {
 func Verify(msg []byte, p PublicKey, sig Signature) bool {
 	// Perform sanity checks
 	if len(p) != PublicKeyLen {
+		fmt.Println("invalid pk len")
 		return false
 	}
 	if len(sig) != SignatureLen {
+		fmt.Println("invalid sig len")
 		return false
 	}
 

--- a/crypto/secp256r1/secp256r1.go
+++ b/crypto/secp256r1/secp256r1.go
@@ -16,6 +16,27 @@ import (
 	"golang.org/x/crypto/cryptobyte/asn1"
 )
 
+const (
+	PublicKeyLen  = 64 // x || y
+	PrivateKeyLen = 32
+	SignatureLen  = 64 // r || s
+
+	coordinateLen = 32
+	rsLen         = 32
+)
+
+type (
+	PublicKey  [PublicKeyLen]byte
+	PrivateKey [PrivateKeyLen]byte
+	Signature  [SignatureLen]byte
+)
+
+var (
+	EmptyPublicKey  = [PublicKeyLen]byte{}
+	EmptyPrivateKey = [PrivateKeyLen]byte{}
+	EmptySignature  = [SignatureLen]byte{}
+)
+
 // secp256r1Order returns the curve order for the secp256r1 (P-256) curve.
 //
 // source: https://github.com/cosmos/cosmos-sdk/blob/b71ec62807628b9a94bef32071e1c8686fcd9d36/crypto/keys/internal/ecdsa/privkey.go#L12-L37
@@ -64,27 +85,6 @@ func ParseASN1Signature(sig []byte) (r, s []byte, err error) {
 	}
 	return r, s, nil
 }
-
-const (
-	PublicKeyLen  = 64 // x || y
-	PrivateKeyLen = 32
-	SignatureLen  = 64 // r || s
-
-	coordinateLen = 32
-	rsLen         = 32
-)
-
-type (
-	PublicKey  [PublicKeyLen]byte
-	PrivateKey [PrivateKeyLen]byte
-	Signature  [SignatureLen]byte
-)
-
-var (
-	EmptyPublicKey  = [PublicKeyLen]byte{}
-	EmptyPrivateKey = [PrivateKeyLen]byte{}
-	EmptySignature  = [SignatureLen]byte{}
-)
 
 // Address returns a Bech32 address from hrp and p.
 // This function uses avalanchego's FormatBech32 function.

--- a/crypto/secp256r1/secp256r1_test.go
+++ b/crypto/secp256r1/secp256r1_test.go
@@ -28,6 +28,7 @@ func TestSignVerify(t *testing.T) {
 	require.NoError(err)
 
 	// Verify signature
+	require.True(IsNormalized(new(big.Int).SetBytes(sig[rsLen:])))
 	require.True(Verify(msg, priv.PublicKey(), sig))
 }
 

--- a/crypto/secp256r1/secp256r1_test.go
+++ b/crypto/secp256r1/secp256r1_test.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package secp256r1
 
 import (

--- a/crypto/secp256r1/secp256r1_test.go
+++ b/crypto/secp256r1/secp256r1_test.go
@@ -18,7 +18,7 @@ func TestGeneratePrivateKey(t *testing.T) {
 
 func TestSignVerify(t *testing.T) {
 	require := require.New(t)
-	for i := 0; i < 500; i++ {
+	for i := 0; i < 1000; i++ {
 		// Generate private key
 		priv, err := GeneratePrivateKey()
 		require.NoError(err)
@@ -29,15 +29,13 @@ func TestSignVerify(t *testing.T) {
 		require.NoError(err)
 
 		// Verify signature
-		require.True(IsNormalized(new(big.Int).SetBytes(sig[rsLen:])))
 		require.True(Verify(msg, priv.PublicKey(), sig))
 	}
 }
 
 func TestNormalization(t *testing.T) {
 	require := require.New(t)
-
-	for i := 0; i < 500; i++ {
+	for i := 0; i < 1000; i++ {
 		// Generate private key
 		priv, err := GeneratePrivateKey()
 		require.NoError(err)
@@ -50,16 +48,15 @@ func TestNormalization(t *testing.T) {
 		// Verify signature
 		r := new(big.Int).SetBytes(sig[:rsLen])
 		s := new(big.Int).SetBytes(sig[rsLen:])
-		require.False(IsNormalized(s))
+		require.False(normalizedS(s))
 		require.False(Verify(msg, priv.PublicKey(), sig))
 
 		// Normalize signature
-		ns := NormalizeSignature(s)
-		nsig := signatureRaw(r, ns)
+		ns := normalizeS(s)
 
 		// Verify fixed signature
-		require.True(IsNormalized(ns))
-		require.True(Verify(msg, priv.PublicKey(), Signature(nsig)))
+		require.True(normalizedS(ns))
+		require.True(Verify(msg, priv.PublicKey(), generateSignature(r, ns)))
 	}
 }
 
@@ -86,6 +83,5 @@ func TestASN1Parsing(t *testing.T) {
 
 	// Verify signature
 	msg := []byte("aaa")
-	require.True(IsNormalized(new(big.Int).SetBytes(s)))
 	require.True(Verify(msg, PublicKey(cpk), Signature(append(r, s...))))
 }

--- a/crypto/secp256r1/secp256r1_test.go
+++ b/crypto/secp256r1/secp256r1_test.go
@@ -1,0 +1,42 @@
+package secp256r1
+
+import (
+	"crypto/elliptic"
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGeneratePrivateKey(t *testing.T) {
+	require := require.New(t)
+	priv, err := GeneratePrivateKey()
+	require.NoError(err)
+	require.Len(priv, PrivateKeyLen)
+}
+
+func TestASN1Parsing(t *testing.T) {
+	// PublicKey/Signature source: https://kjur.github.io/jsrsasign/sample/sample-ecdsa.html
+	ssig := "304502210099086f10c8fc0b32e83f6f0280997950b4f6fe376479334fab2ab12f652b767a02203c53f459a2c35ee274cff20e27461f919dd891475dcd59bab7e2e5db3bad05be"
+	hpk := "04306b5d823340e69712cd1feff3b31ae48f60e6f8d62d9e4248d630969b1e7c85c7425fed4efd200c102ac1d93e5bbe37b8c027fa63bd58be298734d33bda53c3"
+
+	// Parse uncompressed public key
+	require := require.New(t)
+	rpk, err := hex.DecodeString(hpk)
+	require.NoError(err)
+	x, y := elliptic.Unmarshal(elliptic.P256(), rpk)
+	cpk := elliptic.MarshalCompressed(elliptic.P256(), x, y)
+	require.Len(cpk, PublicKeyLen)
+
+	// Parse signature
+	sig, err := hex.DecodeString(ssig)
+	require.NoError(err)
+	r, s, err := ParseASN1Signature(sig)
+	require.NoError(err)
+	require.Len(r, rsLen)
+	require.Len(s, rsLen)
+
+	// Verify signature
+	msg := []byte("aaa")
+	require.True(Verify(msg, PublicKey(cpk), Signature(append(r, s...))))
+}

--- a/crypto/secp256r1/secp256r1_test.go
+++ b/crypto/secp256r1/secp256r1_test.go
@@ -16,6 +16,21 @@ func TestGeneratePrivateKey(t *testing.T) {
 	require.Len(priv, PrivateKeyLen)
 }
 
+func TestSignVerify(t *testing.T) {
+	// Generate private key
+	require := require.New(t)
+	priv, err := GeneratePrivateKey()
+	require.NoError(err)
+
+	// Sign message
+	msg := []byte("hello")
+	sig, err := Sign(msg, priv)
+	require.NoError(err)
+
+	// Verify signature
+	require.True(Verify(msg, priv.PublicKey(), sig))
+}
+
 func TestASN1Parsing(t *testing.T) {
 	// PublicKey/Signature source: https://kjur.github.io/jsrsasign/sample/sample-ecdsa.html
 	ssig := "304502210099086f10c8fc0b32e83f6f0280997950b4f6fe376479334fab2ab12f652b767a02203c53f459a2c35ee274cff20e27461f919dd891475dcd59bab7e2e5db3bad05be"
@@ -68,4 +83,37 @@ func TestASN1ParsingUpperOrder(t *testing.T) {
 	msg := []byte("aaa")
 	require.False(IsNormalized(new(big.Int).SetBytes(s)))
 	require.False(Verify(msg, PublicKey(cpk), Signature(append(r, s...))))
+}
+
+func TestNormalization(t *testing.T) {
+	// Parse uncompressed public key
+	require := require.New(t)
+	hpk := "04306b5d823340e69712cd1feff3b31ae48f60e6f8d62d9e4248d630969b1e7c85c7425fed4efd200c102ac1d93e5bbe37b8c027fa63bd58be298734d33bda53c3"
+	rpk, err := hex.DecodeString(hpk)
+	require.NoError(err)
+	x, y := elliptic.Unmarshal(elliptic.P256(), rpk)
+	cpk := elliptic.MarshalCompressed(elliptic.P256(), x, y)
+	require.Len(cpk, PublicKeyLen)
+
+	// Parse upper half signature
+	upperHalfSig := "c8e58be6d0f1a14543441f13e091befe44d6f50ae3674e52ea4a83878f52a0a6eb55aec89ae2caa868c0326df2e35546d163c1ddf0e9afd65d8b3c83883c8388"
+	rsig, err := hex.DecodeString(upperHalfSig)
+	require.NoError(err)
+	sig := Signature(rsig)
+	s := new(big.Int).SetBytes(sig[rsLen:])
+
+	// Ensure not normalized
+	require.False(IsNormalized(s))
+
+	// Normalize s and construct new signature
+	ns := NormalizeSignature(s)
+	require.True(IsNormalized(ns))
+	require.Zero(ns.Cmp(NormalizeSignature(ns)))
+	nsig := make([]byte, SignatureLen)
+	copy(nsig[:rsLen], sig[:rsLen])
+	copy(nsig[rsLen:], ns.Bytes())
+
+	// Verify signature passes
+	msg := []byte("aaa")
+	require.True(Verify(msg, PublicKey(cpk), Signature(nsig)))
 }

--- a/crypto/secp256r1/secp256r1_test.go
+++ b/crypto/secp256r1/secp256r1_test.go
@@ -63,6 +63,32 @@ func TestNormalization(t *testing.T) {
 	}
 }
 
+func TestInvalidSignature(t *testing.T) {
+	msg := []byte("hello")
+	publicKey := "03831f7d72b912e589ec5dec0321342f21d036a1983601926654e4d1c2278ab278"
+	badSignature := "96f96b7eb69615acd55c4b9fede157ce054c1520789cbc519c67c8b43893337c37202734c76c8beb8b200103860dd5edede4cc98f4b47ba81e92e151e516572f"
+
+	require := require.New(t)
+	pk, err := hex.DecodeString(publicKey)
+	require.NoError(err)
+	sig, err := hex.DecodeString(badSignature)
+	require.NoError(err)
+	require.False(Verify(msg, PublicKey(pk), Signature(sig)))
+}
+
+func TestSignatureLargeS(t *testing.T) {
+	msg := []byte("hello")
+	publicKey := "03ca7eedb087dd30ba97c468f1c3ac06e0571dd055d0cdaf4147d11df0337c11f9"
+	badSignature := "cd0fb02caaac3896f9a1257f077344b3710626c59913ae0100fcc2f8005b10c19d0c237bc8929f3a07993d2c42037bcee6adf33feb3523c17c9ee29b651c7ef7"
+
+	require := require.New(t)
+	pk, err := hex.DecodeString(publicKey)
+	require.NoError(err)
+	sig, err := hex.DecodeString(badSignature)
+	require.NoError(err)
+	require.False(Verify(msg, PublicKey(pk), Signature(sig)))
+}
+
 func TestASN1Parsing(t *testing.T) {
 	// PublicKey/Signature source: https://kjur.github.io/jsrsasign/sample/sample-ecdsa.html
 	ssig := "304502210099086f10c8fc0b32e83f6f0280997950b4f6fe376479334fab2ab12f652b767a02203c53f459a2c35ee274cff20e27461f919dd891475dcd59bab7e2e5db3bad05be"

--- a/crypto/secp256r1/secp256r1_test.go
+++ b/crypto/secp256r1/secp256r1_test.go
@@ -3,6 +3,7 @@ package secp256r1
 import (
 	"crypto/elliptic"
 	"encoding/hex"
+	"math/big"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -38,5 +39,33 @@ func TestASN1Parsing(t *testing.T) {
 
 	// Verify signature
 	msg := []byte("aaa")
+	require.True(IsNormalized(new(big.Int).SetBytes(s)))
 	require.True(Verify(msg, PublicKey(cpk), Signature(append(r, s...))))
+}
+
+func TestASN1ParsingUpperOrder(t *testing.T) {
+	// PublicKey/Signature source: https://kjur.github.io/jsrsasign/sample/sample-ecdsa.html
+	ssig := "3046022100c8e58be6d0f1a14543441f13e091befe44d6f50ae3674e52ea4a83878f52a0a60221009b4d1aeb55aec89ae2caa868c0326df2e35546d163c1ddf0e9afd65d8b3c8388"
+	hpk := "04306b5d823340e69712cd1feff3b31ae48f60e6f8d62d9e4248d630969b1e7c85c7425fed4efd200c102ac1d93e5bbe37b8c027fa63bd58be298734d33bda53c3"
+
+	// Parse uncompressed public key
+	require := require.New(t)
+	rpk, err := hex.DecodeString(hpk)
+	require.NoError(err)
+	x, y := elliptic.Unmarshal(elliptic.P256(), rpk)
+	cpk := elliptic.MarshalCompressed(elliptic.P256(), x, y)
+	require.Len(cpk, PublicKeyLen)
+
+	// Parse signature
+	sig, err := hex.DecodeString(ssig)
+	require.NoError(err)
+	r, s, err := ParseASN1Signature(sig)
+	require.NoError(err)
+	require.Len(r, rsLen)
+	require.Len(s, rsLen)
+
+	// Verify signature
+	msg := []byte("aaa")
+	require.False(IsNormalized(new(big.Int).SetBytes(s)))
+	require.False(Verify(msg, PublicKey(cpk), Signature(append(r, s...))))
 }

--- a/crypto/secp256r1/secp256r1_test.go
+++ b/crypto/secp256r1/secp256r1_test.go
@@ -76,6 +76,39 @@ func TestInvalidSignature(t *testing.T) {
 	require.False(Verify(msg, PublicKey(pk), Signature(sig)))
 }
 
+func TestEmptySignature(t *testing.T) {
+	msg := []byte("hello")
+	publicKey := "03831f7d72b912e589ec5dec0321342f21d036a1983601926654e4d1c2278ab278"
+
+	require := require.New(t)
+	pk, err := hex.DecodeString(publicKey)
+	require.NoError(err)
+	require.False(Verify(msg, PublicKey(pk), EmptySignature))
+}
+
+func TestBadPublicKey(t *testing.T) {
+	msg := []byte("hello")
+	publicKey := "03831f7d72b912e589ec5dec0321342f21d036a1983601926654e4d1c2278ab288"
+	badSignature := "96f96b7eb69615acd55c4b9fede157ce054c1520789cbc519c67c8b43893337c37202734c76c8beb8b200103860dd5edede4cc98f4b47ba81e92e151e516573f"
+
+	require := require.New(t)
+	pk, err := hex.DecodeString(publicKey)
+	require.NoError(err)
+	sig, err := hex.DecodeString(badSignature)
+	require.NoError(err)
+	require.False(Verify(msg, PublicKey(pk), Signature(sig)))
+}
+
+func TestEmptyPublicKey(t *testing.T) {
+	msg := []byte("hello")
+	badSignature := "96f96b7eb69615acd55c4b9fede157ce054c1520789cbc519c67c8b43893337c37202734c76c8beb8b200103860dd5edede4cc98f4b47ba81e92e151e516573f"
+
+	require := require.New(t)
+	sig, err := hex.DecodeString(badSignature)
+	require.NoError(err)
+	require.False(Verify(msg, EmptyPublicKey, Signature(sig)))
+}
+
 func TestSignatureLargeS(t *testing.T) {
 	msg := []byte("hello")
 	publicKey := "03ca7eedb087dd30ba97c468f1c3ac06e0571dd055d0cdaf4147d11df0337c11f9"

--- a/examples/morpheusvm/auth/ed25519.go
+++ b/examples/morpheusvm/auth/ed25519.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm/warp"
 	"github.com/ava-labs/hypersdk/chain"
 	"github.com/ava-labs/hypersdk/codec"
+	"github.com/ava-labs/hypersdk/crypto"
 	"github.com/ava-labs/hypersdk/crypto/ed25519"
 	"github.com/ava-labs/hypersdk/examples/morpheusvm/storage"
 	"github.com/ava-labs/hypersdk/state"
@@ -47,7 +48,7 @@ func (d *ED25519) StateKeys() []string {
 
 func (d *ED25519) AsyncVerify(msg []byte) error {
 	if !ed25519.Verify(msg, d.Signer, d.Signature) {
-		return ed25519.ErrInvalidSignature
+		return crypto.ErrInvalidSignature
 	}
 	return nil
 }

--- a/examples/morpheusvm/go.mod
+++ b/examples/morpheusvm/go.mod
@@ -48,7 +48,6 @@ require (
 	github.com/go-stack/stack v1.8.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.3.0 // indirect
-	github.com/golang/mock v1.6.0 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/golang/snappy v0.0.5-0.20220116011046-fa5810519dcb // indirect
 	github.com/google/btree v1.1.2 // indirect

--- a/examples/morpheusvm/go.sum
+++ b/examples/morpheusvm/go.sum
@@ -244,7 +244,6 @@ github.com/golang/mock v1.4.1/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt
 github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
 github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
-github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -908,7 +907,6 @@ golang.org/x/tools v0.0.0-20210105154028-b0ab187a4818/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210108195828-e2f9c7f1fc8e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
-golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.3/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/examples/tokenvm/auth/ed25519.go
+++ b/examples/tokenvm/auth/ed25519.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm/warp"
 	"github.com/ava-labs/hypersdk/chain"
 	"github.com/ava-labs/hypersdk/codec"
+	"github.com/ava-labs/hypersdk/crypto"
 	"github.com/ava-labs/hypersdk/crypto/ed25519"
 	"github.com/ava-labs/hypersdk/examples/tokenvm/storage"
 	"github.com/ava-labs/hypersdk/state"
@@ -49,7 +50,7 @@ func (d *ED25519) StateKeys() []string {
 
 func (d *ED25519) AsyncVerify(msg []byte) error {
 	if !ed25519.Verify(msg, d.Signer, d.Signature) {
-		return ed25519.ErrInvalidSignature
+		return crypto.ErrInvalidSignature
 	}
 	return nil
 }

--- a/examples/tokenvm/go.mod
+++ b/examples/tokenvm/go.mod
@@ -52,7 +52,6 @@ require (
 	github.com/go-stack/stack v1.8.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.3.0 // indirect
-	github.com/golang/mock v1.6.0 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/golang/snappy v0.0.5-0.20220116011046-fa5810519dcb // indirect
 	github.com/google/btree v1.1.2 // indirect

--- a/examples/tokenvm/go.sum
+++ b/examples/tokenvm/go.sum
@@ -246,7 +246,6 @@ github.com/golang/mock v1.4.1/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt
 github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
 github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
-github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -946,7 +945,6 @@ golang.org/x/tools v0.0.0-20210105154028-b0ab187a4818/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210108195828-e2f9c7f1fc8e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
-golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.3/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,9 @@ require (
 	go.opentelemetry.io/otel/exporters/zipkin v1.11.2
 	go.opentelemetry.io/otel/sdk v1.11.2
 	go.opentelemetry.io/otel/trace v1.11.2
+	go.uber.org/mock v0.2.0
 	go.uber.org/zap v1.24.0
+	golang.org/x/crypto v0.14.0
 	golang.org/x/exp v0.0.0-20230425010034-47ecfdc1ba53
 	golang.org/x/sync v0.2.0
 	gopkg.in/yaml.v2 v2.4.0
@@ -127,9 +129,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.11.2 // indirect
 	go.opentelemetry.io/proto/otlp v0.19.0 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
-	go.uber.org/mock v0.2.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	golang.org/x/crypto v0.14.0 // indirect
 	golang.org/x/mod v0.10.0 // indirect
 	golang.org/x/net v0.17.0 // indirect
 	golang.org/x/sys v0.13.0 // indirect

--- a/scripts/mock.gen.sh
+++ b/scripts/mock.gen.sh
@@ -19,8 +19,8 @@ source "$HYPERSDK_PATH"/scripts/constants.sh
 if ! command -v mockgen &> /dev/null
 then
   echo "mockgen not found, installing..."
-  # https://github.com/golang/mock
-  go install -v github.com/golang/mock/mockgen@v1.6.0
+  # https://github.com/uber-go/mock
+  go install -v go.uber.org/mock/mockgen@v0.2.0
 fi
 
 if ! command -v go-license &> /dev/null

--- a/state/mock_immutable.go
+++ b/state/mock_immutable.go
@@ -11,7 +11,7 @@ import (
 	context "context"
 	reflect "reflect"
 
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockImmutable is a mock of Immutable interface.

--- a/state/mock_mutable.go
+++ b/state/mock_mutable.go
@@ -11,7 +11,7 @@ import (
 	context "context"
 	reflect "reflect"
 
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockMutable is a mock of Mutable interface.

--- a/state/mock_view.go
+++ b/state/mock_view.go
@@ -13,7 +13,7 @@ import (
 
 	ids "github.com/ava-labs/avalanchego/ids"
 	merkledb "github.com/ava-labs/avalanchego/x/merkledb"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockView is a mock of View interface.

--- a/vm/mock_controller.go
+++ b/vm/mock_controller.go
@@ -17,7 +17,7 @@ import (
 	builder "github.com/ava-labs/hypersdk/builder"
 	chain "github.com/ava-labs/hypersdk/chain"
 	gossiper "github.com/ava-labs/hypersdk/gossiper"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockController is a mock of Controller interface.

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/version"
-	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 
 	hcache "github.com/ava-labs/hypersdk/cache"
 	"github.com/ava-labs/hypersdk/chain"


### PR DESCRIPTION
Related: #267 

`secp256r1` is widely used in consumer hardware and in the newly released passkey standard. This PR adds support for generating/verifying such signatures.