### PR TITLE
[cli] Change failed tx emoji

### DIFF
--- a/cli/prompt.go
+++ b/cli/prompt.go
@@ -319,7 +319,7 @@ func (h *Handler) PromptChain(label string, excluded set.Set[ids.ID]) (ids.ID, [
 }
 
 func (*Handler) PrintStatus(txID ids.ID, success bool) {
-	status := "⚠️"
+	status := "❌"
 	if success {
 		status = "✅"
 	}

--- a/examples/morpheusvm/cmd/morpheus-cli/cmd/resolutions.go
+++ b/examples/morpheusvm/cmd/morpheus-cli/cmd/resolutions.go
@@ -60,7 +60,7 @@ func sendAndWait(
 func handleTx(tx *chain.Transaction, result *chain.Result) {
 	summaryStr := string(result.Output)
 	actor := tx.Auth.Actor()
-	status := "⚠️"
+	status := "❌"
 	if result.Success {
 		status = "✅"
 		switch action := tx.Action.(type) { //nolint:gocritic

--- a/examples/tokenvm/cmd/token-cli/cmd/resolutions.go
+++ b/examples/tokenvm/cmd/token-cli/cmd/resolutions.go
@@ -61,7 +61,7 @@ func sendAndWait(
 func handleTx(c *trpc.JSONRPCClient, tx *chain.Transaction, result *chain.Result) {
 	summaryStr := string(result.Output)
 	actor := tx.Auth.Actor()
-	status := "⚠️"
+	status := "❌"
 	if result.Success {
 		status = "✅"
 		switch action := tx.Action.(type) {


### PR DESCRIPTION
### Problem
The currently used emoji for failed transactions (⚠️) is not rendered correctly in VS Code
<img width="812" alt="Screenshot 2023-12-11 at 9 58 40 PM" src="https://github.com/ava-labs/hypersdk/assets/10773395/9cc16eb8-e5ef-4b4a-b5be-b8a9e75c3c02">

This is actually an issue of the default font of VS Code on MacOS
https://github.com/microsoft/vscode/issues/118905

### Solution
Change emoji to a more basic one that can be rendered by VS Code also
<img width="818" alt="Screenshot 2023-12-11 at 10 18 26 PM" src="https://github.com/ava-labs/hypersdk/assets/10773395/a1b334f1-aab6-47f0-b020-13a57a1144c9">
