### PR TITLE
[storage] Add serializeData helper function

### DIFF
--- a/examples/tokenvm/storage/storage_test.go
+++ b/examples/tokenvm/storage/storage_test.go
@@ -1,0 +1,101 @@
+// Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package storage
+
+import (
+	_ "embed"
+	"encoding/binary"
+	"testing"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/hypersdk/codec"
+	"github.com/ava-labs/hypersdk/consts"
+)
+
+func serializeOriginal(
+	asset ids.ID,
+	symbol []byte,
+	decimals uint8,
+	metadata []byte,
+	supply uint64,
+	owner codec.Address,
+	warp bool,
+) []byte {
+	symbolLen := len(symbol)
+	metadataLen := len(metadata)
+	v := make([]byte, consts.Uint16Len+symbolLen+consts.Uint8Len+consts.Uint16Len+metadataLen+consts.Uint64Len+codec.AddressLen+1)
+	binary.BigEndian.PutUint16(v, uint16(symbolLen))
+	copy(v[consts.Uint16Len:], symbol)
+	v[consts.Uint16Len+symbolLen] = decimals
+	binary.BigEndian.PutUint16(v[consts.Uint16Len+symbolLen+consts.Uint8Len:], uint16(metadataLen))
+	copy(v[consts.Uint16Len+symbolLen+consts.Uint8Len+consts.Uint16Len:], metadata)
+	binary.BigEndian.PutUint64(v[consts.Uint16Len+symbolLen+consts.Uint8Len+consts.Uint16Len+metadataLen:], supply)
+	copy(v[consts.Uint16Len+symbolLen+consts.Uint8Len+consts.Uint16Len+metadataLen+consts.Uint64Len:], owner[:])
+	b := byte(0x0)
+	if warp {
+		b = 0x1
+	}
+	v[consts.Uint16Len+symbolLen+consts.Uint8Len+consts.Uint16Len+metadataLen+consts.Uint64Len+codec.AddressLen] = b
+
+	return v
+}
+
+func serializeWithHelper(
+	asset ids.ID,
+	symbol []byte,
+	decimals uint8,
+	metadata []byte,
+	supply uint64,
+	owner codec.Address,
+	warp bool,
+) ([]byte, error) {
+	// Calculate warp flag
+	var warpFlag byte
+	if warp {
+		warpFlag = 0x1
+	} else {
+		warpFlag = 0x0
+	}
+
+	v, err := serializeData(uint16(len(symbol)), symbol, decimals, uint16(len(metadata)), metadata, supply, owner[:], warpFlag)
+	if err != nil {
+		return nil, err
+	}
+
+	return v, nil
+}
+
+// go test -v -benchmem -run=^$ -bench ^BenchmarkSerializeOriginal$ github.com/ava-labs/hypersdk/examples/tokenvm/storage -memprofile benchvset.mem -cpuprofile benchvset.cpu
+func BenchmarkSerializeOriginal(b *testing.B) {
+	asset := ids.GenerateTestID()
+	symbol := []byte("AVAX")
+	decimals := uint8(16)
+	metadata := []byte("Avalanche")
+	supply := uint64(72000000000000000)
+	owner := codec.Address{}
+	warp := false
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		serializeOriginal(asset, symbol, decimals, metadata, supply, owner, warp)
+	}
+}
+
+// go test -v -benchmem -run=^$ -bench ^BenchmarkSerializeWithHelper$ github.com/ava-labs/hypersdk/examples/tokenvm/storage -memprofile benchvset.mem -cpuprofile benchvset.cpu
+func BenchmarkSerializeWithHelper(b *testing.B) {
+	asset := ids.GenerateTestID()
+	symbol := []byte("AVAX")
+	decimals := uint8(16)
+	metadata := []byte("Avalanche")
+	supply := uint64(72000000000000000)
+	owner := codec.Address{}
+	warp := false
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		serializeWithHelper(asset, symbol, decimals, metadata, supply, owner, warp)
+	}
+}


### PR DESCRIPTION
### Problem

I've found the Set functions in the storage.go somewhat hard to understand:

```go
func SetAsset(
	ctx context.Context,
	mu state.Mutable,
	asset ids.ID,
	symbol []byte,
	decimals uint8,
	metadata []byte,
	supply uint64,
	owner codec.Address,
	warp bool,
) error {
	k := AssetKey(asset)
	symbolLen := len(symbol)
	metadataLen := len(metadata)
	v := make([]byte, consts.Uint16Len+symbolLen+consts.Uint8Len+consts.Uint16Len+metadataLen+consts.Uint64Len+codec.AddressLen+1)
	binary.BigEndian.PutUint16(v, uint16(symbolLen))
	copy(v[consts.Uint16Len:], symbol)
	v[consts.Uint16Len+symbolLen] = decimals
	binary.BigEndian.PutUint16(v[consts.Uint16Len+symbolLen+consts.Uint8Len:], uint16(metadataLen))
	copy(v[consts.Uint16Len+symbolLen+consts.Uint8Len+consts.Uint16Len:], metadata)
	binary.BigEndian.PutUint64(v[consts.Uint16Len+symbolLen+consts.Uint8Len+consts.Uint16Len+metadataLen:], supply)
	copy(v[consts.Uint16Len+symbolLen+consts.Uint8Len+consts.Uint16Len+metadataLen+consts.Uint64Len:], owner[:])
	b := byte(0x0)
	if warp {
		b = 0x1
	}
	v[consts.Uint16Len+symbolLen+consts.Uint8Len+consts.Uint16Len+metadataLen+consts.Uint64Len+codec.AddressLen] = b
	return mu.Insert(ctx, k, v)
}
```

Therefore I was thinking about if there is a way to make them more readable and easier to maintain.

### Possible solution

Introduce a new helper function:

```go
func serializeData(data ...interface{}) ([]byte, error) {
	totalLen := 0
	for _, d := range data {
		switch value := d.(type) {
		case byte: // includes uint8
			totalLen += consts.ByteLen
		case uint16:
			totalLen += consts.Uint16Len
		case uint64:
			totalLen += consts.Uint64Len
		case []byte:
			totalLen += len(value)
		default:
			return nil, fmt.Errorf("unsupported type: %T", value)
		}
	}

	v := make([]byte, totalLen)
	offset := 0
	for _, d := range data {
		switch value := d.(type) {
		case byte: // includes uint8
			v[offset] = value
			offset += consts.ByteLen
		case uint16:
			binary.BigEndian.PutUint16(v[offset:], value)
			offset += consts.Uint16Len
		case uint64:
			binary.BigEndian.PutUint64(v[offset:], value)
			offset += consts.Uint64Len
		case []byte:
			copy(v[offset:], value)
			offset += len(value)
		default:
			return nil, fmt.Errorf("unsupported type: %T", value)
		}
	}

	return v, nil
}
```

This would simplify the SetAsset and SetOrder functions:

```go

func SetAsset(
	ctx context.Context,
	mu state.Mutable,
	asset ids.ID,
	symbol []byte,
	decimals uint8,
	metadata []byte,
	supply uint64,
	owner codec.Address,
	warp bool,
) error {
	k := AssetKey(asset)

	// Calculate warp flag
	var warpFlag byte
	if warp {
		warpFlag = 0x1
	} else {
		warpFlag = 0x0
	}

	v, err := serializeData(uint16(len(symbol)), symbol, decimals, uint16(len(metadata)), metadata, supply, owner[:], warpFlag)
	if err != nil {
		return err
	}

	return mu.Insert(ctx, k, v)
}

func SetOrder(
	ctx context.Context,
	mu state.Mutable,
	txID ids.ID,
	in ids.ID,
	inTick uint64,
	out ids.ID,
	outTick uint64,
	supply uint64,
	owner codec.Address,
) error {
	k := OrderKey(txID)

	v, err := serializeData(in[:], inTick, out[:], outTick, supply, owner[:])
	if err != nil {
		return err
	}

	return mu.Insert(ctx, k, v)
}
```

I've tested this with the integration test of the TokenVM and the test passed.

### Open questions:
- Writing to state is an crucial operation for performance. Are we gaining readability at the price of perfomance here?

- Where should the serializeData helper function live? 
HyperSDK: Provide this as part of the HyperSDK => uniform across all HyperVMs, but loosing the ability to add further types
TokenVM: Use it in the reference implementation as a suggestion

