### PR TITLE
[fee manager] add unit tests

### DIFF
--- a/chain/fee_manager.go
+++ b/chain/fee_manager.go
@@ -231,7 +231,6 @@ func computeNextPriceWindow(
 		window.Update(&newRollupWindow, start, previousConsumed)
 	}
 	total := window.Sum(newRollupWindow)
-
 	nextPrice := previousPrice
 	if total > target {
 		// If the parent block used more units than its target, the baseFee should increase.

--- a/chain/fee_manager.go
+++ b/chain/fee_manager.go
@@ -231,6 +231,7 @@ func computeNextPriceWindow(
 		window.Update(&newRollupWindow, start, previousConsumed)
 	}
 	total := window.Sum(newRollupWindow)
+	
 	nextPrice := previousPrice
 	if total > target {
 		// If the parent block used more units than its target, the baseFee should increase.

--- a/chain/fee_manager_test.go
+++ b/chain/fee_manager_test.go
@@ -1,0 +1,85 @@
+// Copyright (C) 2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package chain
+
+import (
+	//"context"
+	//"fmt"
+	"time"
+	"testing"
+
+	"github.com/ava-labs/avalanchego/ids"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetUnitPrice(t *testing.T) {
+	require := require.New(t)
+
+	var d Dimensions
+	feeManager := NewFeeManager(nil)
+	for i := Dimension(0); i < FeeDimensions; i++ {
+		// Set unit prices for different dimensions
+		feeManager.SetUnitPrice(i, uint64(i))
+		d[i] = uint64(i)
+	}
+
+	unitPrices := feeManager.UnitPrices()
+	for i := Dimension(0); i < FeeDimensions; i++ {
+		require.Equal(unitPrices[i], feeManager.UnitPrice(i))
+	}
+
+	_, err := feeManager.MaxFee(d)
+	require.NoError(err)
+}
+
+func TestSetLastConsumed(t *testing.T) {
+	require := require.New(t)
+	feeManager := NewFeeManager(nil)
+	for i := Dimension(0); i < FeeDimensions; i++ {
+		feeManager.SetLastConsumed(i, uint64(i))
+	}
+
+	unitsConsumed := feeManager.UnitsConsumed()
+	for i := Dimension(0); i < FeeDimensions; i++ {
+		require.Equal(unitsConsumed[i], feeManager.LastConsumed(i))
+	}
+}
+
+func TestConsume(t *testing.T) {
+	require := require.New(t)
+	feeManager := NewFeeManager(nil)
+
+	consumed := Dimensions{100, 100, 100, 100, 100}
+	maxUnits := Dimensions{1_800_000, 2_000, 2_000, 2_000, 2_000}
+
+	ok, dimension := feeManager.Consume(consumed, maxUnits)
+	require.True(ok)
+	require.Equal(dimension, Dimension(0))
+}
+
+func TestComputeNext(t *testing.T) {
+	/*require := require.New(t)
+	//var vm VM
+	var r Rules
+	parent := &StatelessBlock{
+		StatefulBlock: &StatefulBlock{
+			Prnt: ids.GenerateTestID(),
+			Tmstmp: time.Date(2024, time.January, 1, 0, 0, 0, 0, time.UTC).UnixMilli(),
+			Hght: 10000,
+		},
+	}
+
+	parentTime := time.Date(2024, time.January, 1, 0, 0, 0, 0, time.UTC).UnixMilli()
+	nextTime := time.Now().UnixMilli()
+	//parentID := parent.ID()
+	//r := parent.vm.Rules(nextTime)
+
+	parentFeeManager := NewFeeManager(nil)
+	_, err := parentFeeManager.ComputeNext(parentTime, nextTime, r)
+	require.NoError(err)*/
+
+	parent := NewGenesisBlock(ids.GenerateTestID())
+	
+}

--- a/chain/fee_manager_test.go
+++ b/chain/fee_manager_test.go
@@ -4,7 +4,6 @@
 package chain
 
 import (
-	//"fmt"
 	"time"
 	"testing"
 
@@ -22,121 +21,174 @@ func TestUnitPrice(t *testing.T) {
 	// Mock VM
 	rules := NewMockRules(ctrl)
 	rules.EXPECT().GetMinUnitPrice().Return(Dimensions{100, 100, 100, 100, 100})
-	rules.EXPECT().GetMaxBlockUnits().Return(Dimensions{1_800_000, 2_000, 2_000, 2_000, 2_000})
 
-	// Similar to vm.go L326
+	// We set unit prices by the min unit price assigned at Genesis
+	// This is similar to a usage described in:
+	// https://github.com/ava-labs/hypersdk/blob/main/vm/vm.go#L326 
 	minUnitPrice := rules.GetMinUnitPrice()
 
 	var d Dimensions
 	feeManager := NewFeeManager(nil)
 	for i := Dimension(0); i < FeeDimensions; i++ {
-		// Set unit prices for different dimensions
+		// Set unit prices for different dimensions 
 		feeManager.SetUnitPrice(i, minUnitPrice[i])
+		// Set last consumed
+		feeManager.SetLastConsumed(i, minUnitPrice[i])
 		d[i] = uint64(i)
 	}
 
 	// Check unit prices
 	unitPrices := feeManager.UnitPrices()
+	unitsConsumed := feeManager.UnitsConsumed()
 	for i := Dimension(0); i < FeeDimensions; i++ {
 		require.Equal(unitPrices[i], feeManager.UnitPrice(i))
+		require.Equal(unitsConsumed[i], minUnitPrice[i])
 	}
-
-	// Similar to spam.go
-	maxUnits := rules.GetMaxBlockUnits()
-	_, err := MulSum(unitPrices, maxUnits)
-	require.NoError(err)
 }
 
 func TestConsume(t *testing.T) {
-	require := require.New(t)
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	feeManager := NewFeeManager(nil)
-	chunks := 100
-
-	// Mock VM
-	rules := NewMockRules(ctrl)
-
-	// Similar to genesis
-	rules.EXPECT().GetMaxBlockUnits().Return(Dimensions{1_800_000, 2_000, 2_000, 2_000, 2_000})
-	rules.EXPECT().GetBaseComputeUnits().Return(uint64(1))
-	rules.EXPECT().GetStorageKeyReadUnits().Return(uint64(5))
-	rules.EXPECT().GetStorageValueReadUnits().Return(uint64(2))
-	rules.EXPECT().GetStorageKeyAllocateUnits().Return(uint64(20))
-	rules.EXPECT().GetStorageValueAllocateUnits().Return(uint64(5))
-	rules.EXPECT().GetStorageKeyWriteUnits().Return(uint64(10))
-	rules.EXPECT().GetStorageValueWriteUnits().Return(uint64(3))
-
-	// Get usage for bandwith, compute, read, allocate, writes
-	bandwidthOp := math.NewUint64Operator(200)
-	bandwidthUnits, err := bandwidthOp.Value()
-	require.NoError(err)
-
-	computeUnitsOp := math.NewUint64Operator(rules.GetBaseComputeUnits())
-	computeUnitsOp.Add(50)
-	computeUnitsOp.Add(100)
-	computeUnits, err := computeUnitsOp.Value()
-	require.NoError(err)
-
-	readsOp := math.NewUint64Operator(0)
-	readsOp.Add(rules.GetStorageKeyReadUnits())
-	readsOp.MulAdd(uint64(chunks), rules.GetStorageValueReadUnits())
-	readUnits, err := readsOp.Value()
-	require.NoError(err)
-
-	allocatesOp := math.NewUint64Operator(0)
-	allocatesOp.Add(rules.GetStorageKeyAllocateUnits())
-	allocatesOp.MulAdd(uint64(chunks), rules.GetStorageValueAllocateUnits())
-	allocateUnits, err := allocatesOp.Value()
-	require.NoError(err)
-
-	writesOp := math.NewUint64Operator(0)
-	writesOp.Add(rules.GetStorageKeyWriteUnits())
-	writesOp.MulAdd(uint64(chunks), rules.GetStorageValueWriteUnits())
-	writeUnits, err := writesOp.Value()
-	require.NoError(err)
-
-	consumed := Dimensions{bandwidthUnits, computeUnits, readUnits, allocateUnits, writeUnits}
-
-	// Similar to processor.go
-	ok, dimension := feeManager.Consume(consumed, rules.GetMaxBlockUnits())
-	require.True(ok)
-	require.Equal(dimension, Dimension(0))
-
-	// The fee required 
-	_, err = feeManager.MaxFee(consumed)
-	require.NoError(err)
-
-	// Update last consumed
-	for i := Dimension(0); i < FeeDimensions; i++ {
-		feeManager.SetLastConsumed(i, consumed[i])
+	tests := []struct {
+		name				string
+		maxBlockUnits		Dimensions
+		chunks				uint64
+		expectedOk			bool
+		expectedDim			Dimension
+	}{
+		{
+			name: "all units are under max block units",
+			maxBlockUnits: Dimensions{1_800_000, 2_000, 2_000, 2_000, 2_000},
+			chunks: 100,
+			expectedOk: true,
+			expectedDim: Dimension(0),
+		},
+		{
+			name: "read unit is over max block units",
+			maxBlockUnits: Dimensions{2_000, 2_000, 2_000, 2_000, 2_000},
+			chunks: 1000,
+			expectedOk: false,
+			expectedDim: Dimension(2),
+		},		
 	}
 
-	unitsConsumed := feeManager.UnitsConsumed()
-	for i := Dimension(0); i < FeeDimensions; i++ {
-		require.Equal(unitsConsumed[i], feeManager.LastConsumed(i))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			feeManager := NewFeeManager(nil)
+
+			// Mock VM
+			rules := NewMockRules(ctrl)
+
+			// Borrowed config values from 
+			// https://github.com/ava-labs/hypersdk/blob/main/x/programs/cmd/simulator/vm/genesis/genesis.go 
+			rules.EXPECT().GetMaxBlockUnits().Return(tt.maxBlockUnits)
+			rules.EXPECT().GetBaseComputeUnits().Return(uint64(1))
+			rules.EXPECT().GetStorageKeyReadUnits().Return(uint64(5))
+			rules.EXPECT().GetStorageValueReadUnits().Return(uint64(2))
+			rules.EXPECT().GetStorageKeyAllocateUnits().Return(uint64(20))
+			rules.EXPECT().GetStorageValueAllocateUnits().Return(uint64(5))
+			rules.EXPECT().GetStorageKeyWriteUnits().Return(uint64(10))
+			rules.EXPECT().GetStorageValueWriteUnits().Return(uint64(3))
+
+			// Get usage for bandwith, compute, read, allocate, writes
+			bandwidthOp := math.NewUint64Operator(200)
+			bandwidthUnits, err := bandwidthOp.Value()
+			require.NoError(err)
+
+			computeUnitsOp := math.NewUint64Operator(rules.GetBaseComputeUnits())
+			computeUnitsOp.Add(50)
+			computeUnits, err := computeUnitsOp.Value()
+			require.NoError(err)
+
+			readsOp := math.NewUint64Operator(0)
+			readsOp.Add(rules.GetStorageKeyReadUnits())
+			readsOp.MulAdd(uint64(tt.chunks), rules.GetStorageValueReadUnits())
+			readUnits, err := readsOp.Value()
+			require.NoError(err)
+
+			allocatesOp := math.NewUint64Operator(0)
+			allocatesOp.Add(rules.GetStorageKeyAllocateUnits())
+			allocatesOp.MulAdd(uint64(tt.chunks), rules.GetStorageValueAllocateUnits())
+			allocateUnits, err := allocatesOp.Value()
+			require.NoError(err)
+
+			writesOp := math.NewUint64Operator(0)
+			writesOp.Add(rules.GetStorageKeyWriteUnits())
+			writesOp.MulAdd(uint64(tt.chunks), rules.GetStorageValueWriteUnits())
+			writeUnits, err := writesOp.Value()
+			require.NoError(err)
+
+			consumed := Dimensions{bandwidthUnits, computeUnits, readUnits, allocateUnits, writeUnits}
+			ok, dimension := feeManager.Consume(consumed, rules.GetMaxBlockUnits())
+			require.Equal(tt.expectedOk, ok)
+			require.Equal(tt.expectedDim, dimension)			
+		})
 	}
 }
 
 func TestComputeNext(t *testing.T) {
-	require := require.New(t)
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
+	tests := []struct {
+		name			string
+		parentTime		int64
+		nextTime		int64
+		targetUnits		Dimensions
+		lastConsumed	Dimensions
+		shouldErr		bool
+	}{
+		{
+			name: "parent consumed units within rollup window",
+			parentTime: time.Date(2024, time.January, 1, 1, 1, 0, 0, time.UTC).UnixMilli(),
+			nextTime: time.Date(2024, time.January, 1, 1, 1, 5, 0, time.UTC).UnixMilli(),
+			targetUnits: Dimensions{20_000_000, 1_000, 1_000, 1_000, 1_000},
+			lastConsumed: Dimensions{100, 100, 100, 100, 100},
+			shouldErr: false,
+		},
+		{
+			name: "parent block used more units than its target",
+			parentTime: time.Date(2024, time.January, 1, 1, 1, 0, 0, time.UTC).UnixMilli(),
+			nextTime: time.Date(2024, time.January, 1, 1, 1, 5, 0, time.UTC).UnixMilli(),
+			targetUnits: Dimensions{1, 1, 1, 1, 1},
+			lastConsumed: Dimensions{100, 100, 100, 100, 100},
+			shouldErr: false,
+		},
+		{
+			name: "roll is greater than rollupWindow",
+			parentTime: time.Date(2024, time.January, 1, 1, 1, 0, 0, time.UTC).UnixMilli(),
+			nextTime: time.Date(2024, time.January, 1, 1, 2, 0, 0, time.UTC).UnixMilli(),
+			targetUnits: Dimensions{20_000_000, 1_000, 1_000, 1_000, 1_000},
+			lastConsumed: Dimensions{100, 100, 100, 100, 100},
+			shouldErr: false,
+		},		
+	}
 
-	// Similar to genesis config
-	rules := NewMockRules(ctrl)
-	rules.EXPECT().GetWindowTargetUnits().Return(Dimensions{20_000_000, 1_000, 1_000, 1_000, 1_000})
-	rules.EXPECT().GetUnitPriceChangeDenominator().Return(Dimensions{48, 48, 48, 48, 48})
-	rules.EXPECT().GetMinUnitPrice().Return(Dimensions{100, 100, 100, 100, 100})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+		
+			// Similar to genesis config
+			rules := NewMockRules(ctrl)
+			rules.EXPECT().GetWindowTargetUnits().Return(tt.targetUnits)
+			rules.EXPECT().GetUnitPriceChangeDenominator().Return(Dimensions{48, 48, 48, 48, 48})
+			rules.EXPECT().GetMinUnitPrice().Return(Dimensions{100, 100, 100, 100, 100})
 
-	// Create our parent "block"
-	parentTime := time.Date(2024, time.January, 1, 0, 0, 0, 0, time.UTC).UnixMilli()
-	nextTime := time.Now().UnixMilli()
+			parentFeeManager := NewFeeManager(nil)
 
-	parentFeeManager := NewFeeManager(nil)
-	_, err := parentFeeManager.ComputeNext(parentTime, nextTime, rules)
-	require.NoError(err)
+			for i := Dimension(0); i < FeeDimensions; i++ {
+				parentFeeManager.SetLastConsumed(i, tt.lastConsumed[i])
+			}	
+
+			_, err := parentFeeManager.ComputeNext(tt.parentTime, tt.nextTime, rules)
+			if tt.shouldErr {
+				require.Error(err)
+			} else {
+				require.NoError(err)			
+			}
+		})
+	}
 }
 
 func TestAdd(t *testing.T) {
@@ -152,43 +204,144 @@ func TestAdd(t *testing.T) {
 	}
 }
 
-func TestDimensionGreater(t *testing.T) {
-	require := require.New(t)
-	d := Dimensions{2,3,4,5,6}
-	o := Dimensions{1,2,3,4,5}
-	result := d.Greater(o)
-	require.True(result)
-}
+func TestMaxFee(t *testing.T) {
+	tests := []struct {
+		name 				string
+		unitPrices			Dimensions
+		expected			uint64
+	}{
+		{
+			name: "all unit prices are the same value",
+			unitPrices: Dimensions{1, 1, 1, 1, 1},
+			expected: uint64(10),
+		},
+		{
+			name: "different unit prices",
+			unitPrices: Dimensions{20, 50, 25, 52, 31},
+			expected: uint64(380),
+		},		
+	}
 
-func TestInvalidDimensionGreater(t *testing.T) {
-	require := require.New(t)
-	d := Dimensions{1,2,3,4,5}
-	o := Dimensions{2,3,4,5,6}
-	result := d.Greater(o)
-	require.False(result)	
-}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			feeManager := NewFeeManager(nil)
+			var d Dimensions
+			for i := Dimension(0); i < FeeDimensions; i++ {
+				// Set unit prices for different dimensions
+				feeManager.SetUnitPrice(i, tt.unitPrices[i])
+				d[i] = uint64(i)
+			}
 
-func TestParseDimensions(t *testing.T) {
-	require := require.New(t)
-	input := []string{"0", "1", "2", "3", "4"}
-	output, err := ParseDimensions(input)
-	require.NoError(err)
-	expected := Dimensions{0,1,2,3,4}
-	for i := 0; i < FeeDimensions; i++ {
-		require.Equal(expected[i], output[i])
+			// The fee required 
+			feeRequired, err := feeManager.MaxFee(d)
+			require.NoError(err)
+			require.Equal(tt.expected, feeRequired)		
+		})		
 	}
 }
 
-func TestInvalidParseDimensions(t *testing.T) {
-	require := require.New(t)
-	input := []string{"0", "1", "2", "3", "4", "5"}
-	_, err := ParseDimensions(input)
-	require.EqualError(err, "wrong dimensions size")
+func TestMulSum(t *testing.T) {
+	tests := []struct {
+		name 				string
+		unitPrices			Dimensions
+		maxUnits			Dimensions
+		expected			uint64
+	}{
+		{
+			name: "all units are the same value",
+			unitPrices: Dimensions{1, 1, 1, 1, 1},
+			maxUnits: Dimensions{1, 1, 1, 1, 1},
+			expected: uint64(5),
+		},
+		{
+			name: "different unit values",
+			unitPrices: Dimensions{2, 3, 4, 5, 6},
+			maxUnits: Dimensions{20, 50, 25, 52, 31},
+			expected: uint64(736),
+		},		
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			
+			val, err := MulSum(tt.unitPrices, tt.maxUnits)
+			require.NoError(err)
+			require.Equal(tt.expected, val)
+		})		
+	}
 }
 
-func TestInvalidInputParseDimension(t *testing.T) {
-	require := require.New(t)
-	input := []string{"O", "1", "2", "3", "4"}
-	_, err := ParseDimensions(input)
-	require.Error(err)	
+func TestDimensionGreater(t *testing.T) {
+	tests := []struct {
+		name 			string
+		d				Dimensions
+		o				Dimensions
+		expected		bool
+	}{
+		{
+			name: "dimensions are greater",
+			d: Dimensions{2,3,4,5,6},
+			o: Dimensions{1,2,3,4,5},
+			expected: true,
+		},
+		{
+			name: "dimensions are less than",
+			d: Dimensions{1,2,3,4,5},
+			o: Dimensions{2,3,4,5,6},
+			expected: false,
+		},		
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			result := tt.d.Greater(tt.o)
+			require.Equal(tt.expected, result)
+		})
+	}
+}
+
+func TestParseDimensions(t *testing.T) {
+	tests := []struct {
+		name			string
+		input			[]string
+		expected		Dimensions
+		shouldErr		bool
+	}{
+		{
+			name: "valid parse dimensions",
+			input: []string{"0", "1", "2", "3", "4"},
+			expected: Dimensions{0,1,2,3,4},
+			shouldErr: false,
+		},
+		{
+			name: "invalid number of dimensions",
+			input: []string{"0", "1", "2", "3", "4", "5"},
+			expected: Dimensions{},
+			shouldErr: true,
+		},	
+		{
+			name: "bad input",
+			input: []string{"O", "!", "2", "3", "4"},
+			expected: Dimensions{},
+			shouldErr: true,
+		},				
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			output, err := ParseDimensions(tt.input)
+			if !tt.shouldErr {
+				require.NoError(err)
+				for i := 0; i < FeeDimensions; i++ {
+					require.Equal(tt.expected[i], output[i])
+				}				
+			} else {
+				require.Error(err)
+			}
+		})
+	}
 }

--- a/chain/fee_manager_test.go
+++ b/chain/fee_manager_test.go
@@ -20,12 +20,13 @@ func TestUnitPrice(t *testing.T) {
 
 	// Mock VM
 	rules := NewMockRules(ctrl)
-	rules.EXPECT().GetMinUnitPrice().Return(Dimensions{100, 100, 100, 100, 100})
+	rules.EXPECT().GetMinUnitPrice().Return(Dimensions{100, 20, 70, 80, 200})
 
 	// We set unit prices by the min unit price assigned at Genesis
 	// This is similar to a usage described in:
 	// https://github.com/ava-labs/hypersdk/blob/main/vm/vm.go#L326 
 	minUnitPrice := rules.GetMinUnitPrice()
+	lastConsumed := Dimensions{150, 30, 75, 90, 210}
 
 	var d Dimensions
 	feeManager := NewFeeManager(nil)
@@ -33,7 +34,7 @@ func TestUnitPrice(t *testing.T) {
 		// Set unit prices for different dimensions 
 		feeManager.SetUnitPrice(i, minUnitPrice[i])
 		// Set last consumed
-		feeManager.SetLastConsumed(i, minUnitPrice[i])
+		feeManager.SetLastConsumed(i, lastConsumed[i])
 		d[i] = uint64(i)
 	}
 
@@ -42,7 +43,7 @@ func TestUnitPrice(t *testing.T) {
 	unitsConsumed := feeManager.UnitsConsumed()
 	for i := Dimension(0); i < FeeDimensions; i++ {
 		require.Equal(unitPrices[i], feeManager.UnitPrice(i))
-		require.Equal(unitsConsumed[i], minUnitPrice[i])
+		require.Equal(lastConsumed[i], unitsConsumed[i])
 	}
 }
 

--- a/chain/fee_manager_test.go
+++ b/chain/fee_manager_test.go
@@ -92,7 +92,7 @@ func TestConsume(t *testing.T) {
 			rules.EXPECT().GetStorageKeyWriteUnits().Return(uint64(10))
 			rules.EXPECT().GetStorageValueWriteUnits().Return(uint64(3))
 
-			// Get usage for bandwith, compute, read, allocate, writes
+			// Get usage for bandwidth, compute, read, allocate, writes
 			bandwidthOp := math.NewUint64Operator(200)
 			bandwidthUnits, err := bandwidthOp.Value()
 			require.NoError(err)
@@ -104,19 +104,19 @@ func TestConsume(t *testing.T) {
 
 			readsOp := math.NewUint64Operator(0)
 			readsOp.Add(rules.GetStorageKeyReadUnits())
-			readsOp.MulAdd(uint64(tt.chunks), rules.GetStorageValueReadUnits())
+			readsOp.MulAdd(tt.chunks, rules.GetStorageValueReadUnits())
 			readUnits, err := readsOp.Value()
 			require.NoError(err)
 
 			allocatesOp := math.NewUint64Operator(0)
 			allocatesOp.Add(rules.GetStorageKeyAllocateUnits())
-			allocatesOp.MulAdd(uint64(tt.chunks), rules.GetStorageValueAllocateUnits())
+			allocatesOp.MulAdd(tt.chunks, rules.GetStorageValueAllocateUnits())
 			allocateUnits, err := allocatesOp.Value()
 			require.NoError(err)
 
 			writesOp := math.NewUint64Operator(0)
 			writesOp.Add(rules.GetStorageKeyWriteUnits())
-			writesOp.MulAdd(uint64(tt.chunks), rules.GetStorageValueWriteUnits())
+			writesOp.MulAdd(tt.chunks, rules.GetStorageValueWriteUnits())
 			writeUnits, err := writesOp.Value()
 			require.NoError(err)
 
@@ -193,7 +193,6 @@ func TestComputeNext(t *testing.T) {
 
 func TestAdd(t *testing.T) {
 	require := require.New(t)
-	// Similar to tokenvm/cmd/token-wallet/backend/backend.go
 	consumed := Dimensions{1,2,3,4,5}
 	nconsumed := Dimensions{}
 	tmpConsumed, err := Add(nconsumed, consumed)

--- a/chain/fee_manager_test.go
+++ b/chain/fee_manager_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/ava-labs/avalanchego/ids"
+	"go.uber.org/mock/gomock"
 
 	"github.com/stretchr/testify/require"
 )
@@ -60,7 +61,15 @@ func TestConsume(t *testing.T) {
 }
 
 func TestComputeNext(t *testing.T) {
-	/*require := require.New(t)
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	controller := NewMockController(ctrl)
+	rules := NewMockRules(ctrl)
+	
+
+	/*
 	//var vm VM
 	var r Rules
 	parent := &StatelessBlock{
@@ -81,5 +90,5 @@ func TestComputeNext(t *testing.T) {
 	require.NoError(err)*/
 
 	parent := NewGenesisBlock(ids.GenerateTestID())
-	
+
 }

--- a/chain/fee_manager_test.go
+++ b/chain/fee_manager_test.go
@@ -9,55 +9,110 @@ import (
 	"time"
 	"testing"
 
-	"github.com/ava-labs/avalanchego/ids"
+	//"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/hypersdk/math"
+
 	"go.uber.org/mock/gomock"
 
 	"github.com/stretchr/testify/require"
 )
 
-func TestSetUnitPrice(t *testing.T) {
+func TestUnitPrice(t *testing.T) {
 	require := require.New(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// Mock VM
+	rules := NewMockRules(ctrl)
+	rules.EXPECT().GetMinUnitPrice().Return(Dimensions{100, 100, 100, 100, 100})
+
+	// Similar to vm.go L326
+	minUnitPrice := rules.GetMinUnitPrice()
 
 	var d Dimensions
 	feeManager := NewFeeManager(nil)
 	for i := Dimension(0); i < FeeDimensions; i++ {
 		// Set unit prices for different dimensions
-		feeManager.SetUnitPrice(i, uint64(i))
+		feeManager.SetUnitPrice(i, minUnitPrice[i])
 		d[i] = uint64(i)
 	}
 
+	// Check unit prices
 	unitPrices := feeManager.UnitPrices()
 	for i := Dimension(0); i < FeeDimensions; i++ {
 		require.Equal(unitPrices[i], feeManager.UnitPrice(i))
-	}
-
-	_, err := feeManager.MaxFee(d)
-	require.NoError(err)
-}
-
-func TestSetLastConsumed(t *testing.T) {
-	require := require.New(t)
-	feeManager := NewFeeManager(nil)
-	for i := Dimension(0); i < FeeDimensions; i++ {
-		feeManager.SetLastConsumed(i, uint64(i))
-	}
-
-	unitsConsumed := feeManager.UnitsConsumed()
-	for i := Dimension(0); i < FeeDimensions; i++ {
-		require.Equal(unitsConsumed[i], feeManager.LastConsumed(i))
 	}
 }
 
 func TestConsume(t *testing.T) {
 	require := require.New(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
 	feeManager := NewFeeManager(nil)
 
-	consumed := Dimensions{100, 100, 100, 100, 100}
-	maxUnits := Dimensions{1_800_000, 2_000, 2_000, 2_000, 2_000}
+	// Mock VM
+	rules := NewMockRules(ctrl)
+	// Similar to genesis
+	rules.EXPECT().GetMaxBlockUnits().Return(Dimensions{1_800_000, 2_000, 2_000, 2_000, 2_000})
+	rules.EXPECT().GetBaseComputeUnits().Return(uint64(1))
+	rules.EXPECT().GetStorageKeyReadUnits().Return(uint64(5))
+	rules.EXPECT().GetStorageValueReadUnits().Return(uint64(2))
+	rules.EXPECT().GetStorageKeyAllocateUnits().Return(uint64(20))
+	rules.EXPECT().GetStorageValueAllocateUnits().Return(uint64(5))
+	rules.EXPECT().GetStorageKeyWriteUnits().Return(uint64(10))
+	rules.EXPECT().GetStorageValueWriteUnits().Return(uint64(3))
 
-	ok, dimension := feeManager.Consume(consumed, maxUnits)
+	chunks := 100
+
+	bandwidthOp := math.NewUint64Operator(200)
+	bandwidthUnits, err := bandwidthOp.Value()
+	require.NoError(err)
+
+	computeUnitsOp := math.NewUint64Operator(rules.GetBaseComputeUnits())
+	computeUnitsOp.Add(50)
+	computeUnitsOp.Add(100)
+	computeUnits, err := computeUnitsOp.Value()
+	require.NoError(err)
+
+	readsOp := math.NewUint64Operator(0)
+	readsOp.Add(rules.GetStorageKeyReadUnits())
+	readsOp.MulAdd(uint64(chunks), rules.GetStorageValueReadUnits())
+	readUnits, err := readsOp.Value()
+	require.NoError(err)
+
+	allocatesOp := math.NewUint64Operator(0)
+	allocatesOp.Add(rules.GetStorageKeyAllocateUnits())
+	allocatesOp.MulAdd(uint64(chunks), rules.GetStorageValueAllocateUnits())
+	allocateUnits, err := allocatesOp.Value()
+	require.NoError(err)
+
+	writesOp := math.NewUint64Operator(0)
+	writesOp.Add(rules.GetStorageKeyWriteUnits())
+	writesOp.MulAdd(uint64(chunks), rules.GetStorageValueWriteUnits())
+	writeUnits, err := writesOp.Value()
+	require.NoError(err)
+
+	consumed := Dimensions{bandwidthUnits, computeUnits, readUnits, allocateUnits, writeUnits}
+
+	// Similar to processor.go
+	ok, dimension := feeManager.Consume(consumed, rules.GetMaxBlockUnits())
 	require.True(ok)
 	require.Equal(dimension, Dimension(0))
+
+	// Fee required 
+	_, err = feeManager.MaxFee(consumed)
+	require.NoError(err)
+
+	// Update last consumed
+	for i := Dimension(0); i < FeeDimensions; i++ {
+		feeManager.SetLastConsumed(i, consumed[i])
+	}
+
+	unitsConsumed := feeManager.UnitsConsumed()
+	for i := Dimension(0); i < FeeDimensions; i++ {
+		require.Equal(unitsConsumed[i], feeManager.LastConsumed(i))
+	}	
 }
 
 func TestComputeNext(t *testing.T) {
@@ -65,30 +120,17 @@ func TestComputeNext(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	controller := NewMockController(ctrl)
+	// Similar to genesis config
 	rules := NewMockRules(ctrl)
-	
+	rules.EXPECT().GetWindowTargetUnits().Return(Dimensions{20_000_000, 1_000, 1_000, 1_000, 1_000})
+	rules.EXPECT().GetUnitPriceChangeDenominator().Return(Dimensions{48, 48, 48, 48, 48})
+	rules.EXPECT().GetMinUnitPrice().Return(Dimensions{100, 100, 100, 100, 100})
 
-	/*
-	//var vm VM
-	var r Rules
-	parent := &StatelessBlock{
-		StatefulBlock: &StatefulBlock{
-			Prnt: ids.GenerateTestID(),
-			Tmstmp: time.Date(2024, time.January, 1, 0, 0, 0, 0, time.UTC).UnixMilli(),
-			Hght: 10000,
-		},
-	}
-
+	// Create our parent "block"
 	parentTime := time.Date(2024, time.January, 1, 0, 0, 0, 0, time.UTC).UnixMilli()
 	nextTime := time.Now().UnixMilli()
-	//parentID := parent.ID()
-	//r := parent.vm.Rules(nextTime)
 
 	parentFeeManager := NewFeeManager(nil)
-	_, err := parentFeeManager.ComputeNext(parentTime, nextTime, r)
-	require.NoError(err)*/
-
-	parent := NewGenesisBlock(ids.GenerateTestID())
-
+	_, err := parentFeeManager.ComputeNext(parentTime, nextTime, rules)
+	require.NoError(err)
 }

--- a/chain/fm_test.sh
+++ b/chain/fm_test.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+go test -coverprofile=coverage.out
+go tool cover -html=coverage.out

--- a/chain/fm_test.sh
+++ b/chain/fm_test.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-go test -coverprofile=coverage.out
-go tool cover -html=coverage.out


### PR DESCRIPTION
Closes #674 

Unit tests for all FeeManager functions, currently at ~80% total coverage for the `fee_manager.go`

Some notes: I encountered into this issue `Caught SIGILL in blst_cgo_init, consult <blst>/bindings/go/README.md` when running `go test` within `chain` package. To fix it, I ran:

```sh
export CGO_CFLAGS="-O -D__BLST_PORTABLE__"
export CGO_CFLAGS_ALLOW="-O -D__BLST_PORTABLE__"
```

