### PR TITLE
[rpc] optionally storing `block.Results` on disk, start stream from a specified block

### DIFF
--- a/chain/block.go
+++ b/chain/block.go
@@ -730,6 +730,13 @@ func (b *StatelessBlock) Accept(ctx context.Context) error {
 		}
 	}
 
+	// optionally store [block.Results] to disk
+	if b.vm.GetStoreBlockResultsOnDisk() {
+		if err := b.vm.StoreBlockResultsOnDisk(b); err != nil {
+			return fmt.Errorf("%w: unable to store block results on disk", err)
+		}
+	}
+
 	// Commit view if we don't return before here (would happen if we are still
 	// syncing)
 	if err := b.view.CommitToDB(ctx); err != nil {

--- a/chain/dependencies.go
+++ b/chain/dependencies.go
@@ -59,6 +59,8 @@ type VM interface {
 	GetTargetBuildDuration() time.Duration
 	GetTransactionExecutionCores() int
 
+	GetStoreBlockResultsOnDisk() bool
+	StoreBlockResultsOnDisk(*StatelessBlock) error
 	Verified(context.Context, *StatelessBlock)
 	Rejected(context.Context, *StatelessBlock)
 	Accepted(context.Context, *StatelessBlock)

--- a/cli/chain.go
+++ b/cli/chain.go
@@ -190,7 +190,7 @@ func (h *Handler) PrintChainInfo() error {
 	return nil
 }
 
-func (h *Handler) WatchChain(hideTxs bool, getParser func(string, uint32, ids.ID) (chain.Parser, error), handleTx func(*chain.Transaction, *chain.Result)) error {
+func (h *Handler) WatchChain(hideTxs bool, pastBlocks bool, startBlock uint64, getParser func(string, uint32, ids.ID) (chain.Parser, error), handleTx func(*chain.Transaction, *chain.Result)) error {
 	ctx := context.Background()
 	chainID, uris, err := h.PromptChain("select chainID", nil)
 	if err != nil {
@@ -214,8 +214,14 @@ func (h *Handler) WatchChain(hideTxs bool, getParser func(string, uint32, ids.ID
 		return err
 	}
 	defer scli.Close()
-	if err := scli.RegisterBlocks(); err != nil {
-		return err
+	if pastBlocks {
+		if err := scli.RegisterBlocksFrom(startBlock); err != nil {
+			return err
+		}
+	} else {
+		if err := scli.RegisterBlocks(); err != nil {
+			return err
+		}
 	}
 	utils.Outf("{{green}}watching for new blocks on %s 👀{{/}}\n", chainID)
 	var (

--- a/cli/prompt.go
+++ b/cli/prompt.go
@@ -156,6 +156,30 @@ func (*Handler) PromptInt(
 	return strconv.Atoi(rawAmount)
 }
 
+func (*Handler) PromptUint64(
+	label string,
+) (uint64, error) {
+	promptText := promptui.Prompt{
+		Label: label,
+		Validate: func(input string) error {
+			if len(input) == 0 {
+				return ErrInputEmpty
+			}
+			_, err := strconv.ParseUint(input, 10, 64)
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+	rawAmount, err := promptText.Run()
+	if err != nil {
+		return 0, err
+	}
+	rawAmount = strings.TrimSpace(rawAmount)
+	return strconv.ParseUint(rawAmount, 10, 64)
+
+}
 func (*Handler) PromptChoice(label string, max int) (int, error) {
 	if max == 1 {
 		utils.Outf("{{yellow}}%s:{{/}} 0 [auto-selected]\n", label)

--- a/config/config.go
+++ b/config/config.go
@@ -24,6 +24,7 @@ func (c *Config) GetMempoolSize() int                       { return 2_048 }
 func (c *Config) GetMempoolSponsorSize() int                { return 32 }
 func (c *Config) GetMempoolExemptSponsors() []codec.Address { return nil }
 func (c *Config) GetStreamingBacklogSize() int              { return 1024 }
+func (c *Config) GetStoreBlockResultsOnDisk() bool			{ return true }
 func (c *Config) GetStateEvictionBatchSize() int            { return 4 * units.MiB }
 func (c *Config) GetIntermediateNodeCacheSize() int         { return 4 * units.GiB }
 func (c *Config) GetValueNodeCacheSize() int                { return 2 * units.GiB }

--- a/examples/morpheusvm/cmd/morpheus-cli/cmd/chain.go
+++ b/examples/morpheusvm/cmd/morpheus-cli/cmd/chain.go
@@ -64,7 +64,18 @@ var chainInfoCmd = &cobra.Command{
 var watchChainCmd = &cobra.Command{
 	Use: "watch",
 	RunE: func(_ *cobra.Command, args []string) error {
-		return handler.Root().WatchChain(hideTxs, func(uri string, networkID uint32, chainID ids.ID) (chain.Parser, error) {
+		pastBlocks, err := handler.Root().PromptBool("stream from a past block")
+		if err != nil {
+			return err
+		}
+		var startBlock uint64
+		if pastBlocks {
+			startBlock, err = handler.Root().PromptUint64("start block number")
+			if err != nil {
+				return err
+			}
+		}
+		return handler.Root().WatchChain(hideTxs, pastBlocks, startBlock, func(uri string, networkID uint32, chainID ids.ID) (chain.Parser, error) {
 			cli := brpc.NewJSONRPCClient(uri, networkID, chainID)
 			return cli.Parser(context.TODO())
 		}, handleTx)

--- a/examples/morpheusvm/config/config.go
+++ b/examples/morpheusvm/config/config.go
@@ -45,8 +45,8 @@ type Config struct {
 	ContinuousProfilerDir string `json:"continuousProfilerDir"` // "*" is replaced with rand int
 
 	// Streaming settings
-	StreamingBacklogSize int `json:"streamingBacklogSize"`
-
+	StreamingBacklogSize    int  `json:"streamingBacklogSize"`
+	StoreBlockResultsOnDisk bool `json:"storeBlockResultsOnDisk"`
 	// Mempool
 	MempoolSize           int      `json:"mempoolSize"`
 	MempoolSponsorSize    int      `json:"mempoolSponsorSize"`
@@ -98,6 +98,7 @@ func (c *Config) setDefault() {
 	c.MempoolSponsorSize = c.Config.GetMempoolSponsorSize()
 	c.StateSyncServerDelay = c.Config.GetStateSyncServerDelay()
 	c.StreamingBacklogSize = c.Config.GetStreamingBacklogSize()
+	c.StoreBlockResultsOnDisk = c.Config.GetStoreBlockResultsOnDisk()
 	c.VerifySignatures = c.Config.GetVerifySignatures()
 	c.StoreTransactions = defaultStoreTransactions
 }
@@ -121,6 +122,7 @@ func (c *Config) GetTraceConfig() *trace.Config {
 }
 func (c *Config) GetStateSyncServerDelay() time.Duration { return c.StateSyncServerDelay }
 func (c *Config) GetStreamingBacklogSize() int           { return c.StreamingBacklogSize }
+func (c *Config) GetStoreBlockResultsOnDisk() bool       { return c.StoreBlockResultsOnDisk }
 func (c *Config) GetContinuousProfilerConfig() *profiler.Config {
 	if len(c.ContinuousProfilerDir) == 0 {
 		return &profiler.Config{Enabled: false}

--- a/examples/morpheusvm/scripts/run.sh
+++ b/examples/morpheusvm/scripts/run.sh
@@ -26,6 +26,7 @@ STATESYNC_DELAY=${STATESYNC_DELAY:-0}
 MIN_BLOCK_GAP=${MIN_BLOCK_GAP:-100}
 STORE_TXS=${STORE_TXS:-false}
 UNLIMITED_USAGE=${UNLIMITED_USAGE:-false}
+STORE_BLOCK_RESULTS_ON_DISK=${STORE_BLOCK_RESULTS_ON_DISK:-true}
 ADDRESS=${ADDRESS:-morpheus1qrzvk4zlwj9zsacqgtufx7zvapd3quufqpxk5rsdd4633m4wz2fdjk97rwu}
 if [[ ${MODE} != "run" ]]; then
   LOGLEVEL=debug
@@ -54,6 +55,7 @@ echo MIN_BLOCK_GAP \(ms\): ${MIN_BLOCK_GAP}
 echo STORE_TXS: ${STORE_TXS}
 echo WINDOW_TARGET_UNITS: ${WINDOW_TARGET_UNITS}
 echo MAX_BLOCK_UNITS: ${MAX_BLOCK_UNITS}
+echo STORE_BLOCK_RESULTS_ON_DISK: ${STORE_BLOCK_RESULTS_ON_DISK}
 echo ADDRESS: ${ADDRESS}
 
 ############################
@@ -159,7 +161,8 @@ cat <<EOF > ${TMPDIR}/morpheusvm.config
   "streamingBacklogSize": 10000000,
   "logLevel": "${LOGLEVEL}",
   "continuousProfilerDir":"${TMPDIR}/morpheusvm-e2e-profiles/*",
-  "stateSyncServerDelay": ${STATESYNC_DELAY}
+  "stateSyncServerDelay": ${STATESYNC_DELAY},
+  "storeBlockResultsOnDisk": ${STORE_BLOCK_RESULTS_ON_DISK}
 }
 EOF
 mkdir -p ${TMPDIR}/morpheusvm-e2e-profiles

--- a/examples/tokenvm/cmd/token-cli/cmd/chain.go
+++ b/examples/tokenvm/cmd/token-cli/cmd/chain.go
@@ -66,7 +66,18 @@ var watchChainCmd = &cobra.Command{
 	Use: "watch",
 	RunE: func(_ *cobra.Command, args []string) error {
 		var cli *trpc.JSONRPCClient
-		return handler.Root().WatchChain(hideTxs, func(uri string, networkID uint32, chainID ids.ID) (chain.Parser, error) {
+		pastBlocks, err := handler.Root().PromptBool("stream from a past block")
+		if err != nil {
+			return err
+		}
+		var startBlock uint64
+		if pastBlocks {
+			startBlock, err = handler.Root().PromptUint64("start block number")
+			if err != nil {
+				return err
+			}
+		}
+		return handler.Root().WatchChain(hideTxs, pastBlocks, startBlock, func(uri string, networkID uint32, chainID ids.ID) (chain.Parser, error) {
 			cli = trpc.NewJSONRPCClient(uri, networkID, chainID)
 			return cli.Parser(context.TODO())
 		}, func(tx *chain.Transaction, result *chain.Result) {

--- a/examples/tokenvm/config/config.go
+++ b/examples/tokenvm/config/config.go
@@ -54,7 +54,8 @@ type Config struct {
 	ContinuousProfilerDir string `json:"continuousProfilerDir"` // "*" is replaced with rand int
 
 	// Streaming settings
-	StreamingBacklogSize int `json:"streamingBacklogSize"`
+	StreamingBacklogSize    int  `json:"streamingBacklogSize"`
+	StoreBlockResultsOnDisk bool `json:"storeBlockResultsOnDisk"`
 
 	// Mempool
 	MempoolSize           int      `json:"mempoolSize"`
@@ -119,6 +120,7 @@ func (c *Config) setDefault() {
 	c.MempoolSponsorSize = c.Config.GetMempoolSponsorSize()
 	c.StateSyncServerDelay = c.Config.GetStateSyncServerDelay()
 	c.StreamingBacklogSize = c.Config.GetStreamingBacklogSize()
+	c.StoreBlockResultsOnDisk = c.Config.GetStoreBlockResultsOnDisk()
 	c.VerifySignatures = c.Config.GetVerifySignatures()
 	c.StoreTransactions = defaultStoreTransactions
 	c.MaxOrdersPerPair = defaultMaxOrdersPerPair
@@ -143,6 +145,7 @@ func (c *Config) GetTraceConfig() *trace.Config {
 }
 func (c *Config) GetStateSyncServerDelay() time.Duration { return c.StateSyncServerDelay }
 func (c *Config) GetStreamingBacklogSize() int           { return c.StreamingBacklogSize }
+func (c *Config) GetStoreBlockResultsOnDisk() bool       { return c.StoreBlockResultsOnDisk }
 func (c *Config) GetContinuousProfilerConfig() *profiler.Config {
 	if len(c.ContinuousProfilerDir) == 0 {
 		return &profiler.Config{Enabled: false}

--- a/examples/tokenvm/scripts/run.sh
+++ b/examples/tokenvm/scripts/run.sh
@@ -26,6 +26,7 @@ STATESYNC_DELAY=${STATESYNC_DELAY:-0}
 MIN_BLOCK_GAP=${MIN_BLOCK_GAP:-100}
 STORE_TXS=${STORE_TXS:-false}
 UNLIMITED_USAGE=${UNLIMITED_USAGE:-false}
+STORE_BLOCK_RESULTS_ON_DISK=${STORE_BLOCK_RESULTS_ON_DISK:-true}
 ADDRESS=${ADDRESS:-token1qrzvk4zlwj9zsacqgtufx7zvapd3quufqpxk5rsdd4633m4wz2fdj73w34s}
 if [[ ${MODE} != "run" && ${MODE} != "run-single" ]]; then
   LOGLEVEL=debug
@@ -53,6 +54,7 @@ echo MIN_BLOCK_GAP \(ms\): ${MIN_BLOCK_GAP}
 echo STORE_TXS: ${STORE_TXS}
 echo WINDOW_TARGET_UNITS: ${WINDOW_TARGET_UNITS}
 echo MAX_BLOCK_UNITS: ${MAX_BLOCK_UNITS}
+echo STORE_BLOCK_RESULTS_ON_DISK: ${STORE_BLOCK_RESULTS_ON_DISK}
 echo ADDRESS: ${ADDRESS}
 
 ############################
@@ -164,7 +166,8 @@ cat <<EOF > ${TMPDIR}/tokenvm.config
   "trackedPairs":["*"],
   "logLevel": "${LOGLEVEL}",
   "continuousProfilerDir":"${TMPDIR}/tokenvm-e2e-profiles/*",
-  "stateSyncServerDelay": ${STATESYNC_DELAY}
+  "stateSyncServerDelay": ${STATESYNC_DELAY},
+  "storeBlockResultsOnDisk": ${STORE_BLOCK_RESULTS_ON_DISK}
 }
 EOF
 mkdir -p ${TMPDIR}/tokenvm-e2e-profiles

--- a/rpc/dependencies.go
+++ b/rpc/dependencies.go
@@ -35,4 +35,8 @@ type VM interface {
 	) (map[ids.NodeID]*validators.GetValidatorOutput, map[string]struct{})
 	GatherSignatures(context.Context, ids.ID, []byte)
 	GetVerifySignatures() bool
+	HasDiskBlock(height uint64) (bool, error)
+	GetDiskBlock(ctx context.Context, height uint64) (*chain.StatelessBlock, error)
+	GetDiskBlockResults(ctx context.Context, height uint64) ([]*chain.Result, error)
+	GetDiskFeeManager(ctx context.Context, height uint64) ([]byte, error)
 }

--- a/rpc/websocket_client.go
+++ b/rpc/websocket_client.go
@@ -5,6 +5,7 @@ package rpc
 
 import (
 	"context"
+	"encoding/binary"
 	"net/http"
 	"strings"
 	"sync"
@@ -135,6 +136,13 @@ func (c *WebSocketClient) RegisterBlocks() error {
 		return ErrClosed
 	}
 	return c.mb.Send([]byte{BlockMode})
+}
+
+func (c *WebSocketClient) RegisterBlocksFrom(blockNumber uint64) error {
+	if c.closed {
+		return ErrClosed
+	}
+	return c.mb.Send(binary.BigEndian.AppendUint64([]byte{BlockMode}, blockNumber))
 }
 
 // Listen listens for block messages from the streaming server.

--- a/rpc/websocket_packer.go
+++ b/rpc/websocket_packer.go
@@ -31,6 +31,19 @@ func PackBlockMessage(b *chain.StatelessBlock) ([]byte, error) {
 	return p.Bytes(), p.Err()
 }
 
+func PackBlockMessageForBackwardStream(b *chain.StatelessBlock, results []*chain.Result, feeBytes []byte) ([]byte, error) {
+	size := codec.BytesLen(b.Bytes()) + consts.IntLen + codec.CummSize(results) + chain.DimensionsLen
+	p := codec.NewWriter(size, consts.MaxInt)
+	p.PackBytes(b.Bytes())
+	mresults, err := chain.MarshalResults(results)
+	if err != nil {
+		return nil, err
+	}
+	p.PackBytes(mresults)
+	p.PackFixedBytes(feeBytes)
+	return p.Bytes(), p.Err()
+}
+
 func UnpackBlockMessage(
 	msg []byte,
 	parser chain.Parser,

--- a/rpc/websocket_server.go
+++ b/rpc/websocket_server.go
@@ -5,6 +5,7 @@ package rpc
 
 import (
 	"context"
+	"encoding/binary"
 	"sync"
 
 	"github.com/ava-labs/avalanchego/ids"
@@ -153,6 +154,47 @@ func (w *WebSocketServer) MessageCallback(vm VM) pubsub.Callback {
 		// implementations
 		switch msgBytes[0] {
 		case BlockMode:
+			if len(msgBytes) > 1 {
+				currentBlockHeight := vm.LastAcceptedBlock().Height()
+				blockNumber := binary.BigEndian.Uint64(msgBytes[1:])
+				if currentBlockHeight <= blockNumber {
+					log.Error("Invalid block height", zap.Uint64("current block height", currentBlockHeight), zap.Uint64("given block height", blockNumber))
+					return
+				}
+				has, err := vm.HasDiskBlock(blockNumber)
+				if err != nil || !has {
+					log.Error("Could not find block on disk")
+					return
+				}
+				for i := blockNumber; i < currentBlockHeight; i++ {
+					blk, err := vm.GetDiskBlock(ctx, i)
+					if err != nil {
+						log.Error("Something went wrong, couldnot find block on disk")
+						return
+					}
+					blkResults, err := vm.GetDiskBlockResults(ctx, i)
+					if err != nil {
+						log.Error("Something went wrong, couldnot find block results on disk")
+						return
+					}
+					feeBytes, err := vm.GetDiskFeeManager(ctx, i)
+					if err != nil {
+						log.Error("Something went wrong, couldnot find block results on disk")
+						return
+					}
+					bytes, err := PackBlockMessageForBackwardStream(blk, blkResults, feeBytes)
+					if err != nil {
+						return
+					}
+					if !c.Send(append([]byte{BlockMode}, bytes...)) {
+						log.Verbo("dropping message to subscribed connection due to too many pending messages")
+					}
+					if i == currentBlockHeight-1 { // ensure to stream all blocks
+						currentBlockHeight = vm.LastAcceptedBlock().Height()
+					}
+				}
+			}
+
 			w.blockListeners.Add(c)
 			log.Debug("added block listener")
 		case TxMode:

--- a/vm/dependencies.go
+++ b/vm/dependencies.go
@@ -35,6 +35,7 @@ type Config interface {
 	GetMempoolExemptSponsors() []codec.Address
 	GetVerifySignatures() bool
 	GetStreamingBacklogSize() int
+	GetStoreBlockResultsOnDisk() bool
 	GetStateHistoryLength() int        // how many roots back of data to keep to serve state queries
 	GetStateEvictionBatchSize() int    // how many bytes to evict at once
 	GetIntermediateNodeCacheSize() int // how many bytes to keep in intermediate cache

--- a/vm/resolutions.go
+++ b/vm/resolutions.go
@@ -417,6 +417,10 @@ func (vm *VM) GetVerifySignatures() bool {
 	return vm.config.GetVerifySignatures()
 }
 
+func (vm *VM) GetStoreBlockResultsOnDisk() bool {
+	return vm.config.GetStoreBlockResultsOnDisk()
+}
+
 func (vm *VM) RecordTxsGossiped(c int) {
 	vm.metrics.txsGossiped.Add(float64(c))
 }

--- a/vm/storage.go
+++ b/vm/storage.go
@@ -40,6 +40,7 @@ const (
 	blockHeightIDPrefix = 0x2 // Height -> ID (don't always need full block from disk)
 	warpSignaturePrefix = 0x3
 	warpFetchPrefix     = 0x4
+	blockResultsPrefix  = 0x5
 )
 
 var (
@@ -66,6 +67,13 @@ func PrefixBlockIDHeightKey(id ids.ID) []byte {
 func PrefixBlockHeightIDKey(height uint64) []byte {
 	k := make([]byte, 1+consts.Uint64Len)
 	k[0] = blockHeightIDPrefix
+	binary.BigEndian.PutUint64(k[1:], height)
+	return k
+}
+
+func PrefixBlockResultsKey(height uint64) []byte {
+	k := make([]byte, 1+consts.Uint64Len)
+	k[0] = blockResultsPrefix
 	binary.BigEndian.PutUint64(k[1:], height)
 	return k
 }
@@ -167,6 +175,28 @@ func (vm *VM) UpdateLastAccepted(blk *chain.StatelessBlock) error {
 	return nil
 }
 
+func (vm *VM) StoreBlockResultsOnDisk(blk *chain.StatelessBlock) error {
+	blockResultBytes, err := chain.MarshalResults(blk.Results())
+	if err != nil {
+		return err
+	}
+	batch := vm.vmDB.NewBatch()
+	if err := batch.Put(PrefixBlockResultsKey(blk.Height()), blockResultBytes); err != nil {
+		return err
+	}
+	expiryHeight := blk.Height() - uint64(vm.config.GetAcceptedBlockWindow())
+	if expiryHeight > 0 && expiryHeight < blk.Height() {
+		if err := batch.Delete(PrefixBlockResultsKey(blk.Height())); err != nil {
+			return err
+		}
+	}
+	if err := batch.Write(); err != nil {
+		return fmt.Errorf("%w: unable to update block.Results", zap.Uint64("height", expiryHeight))
+	}
+	vm.Logger().Info("written block.Results to disk", zap.Uint64("block.height", blk.Height()))
+	return nil
+}
+
 func (vm *VM) GetDiskBlock(ctx context.Context, height uint64) (*chain.StatelessBlock, error) {
 	b, err := vm.vmDB.Get(PrefixBlockKey(height))
 	if err != nil {
@@ -177,6 +207,14 @@ func (vm *VM) GetDiskBlock(ctx context.Context, height uint64) (*chain.Stateless
 
 func (vm *VM) HasDiskBlock(height uint64) (bool, error) {
 	return vm.vmDB.Has(PrefixBlockKey(height))
+}
+
+func (vm *VM) GetDiskBlockResults(ctx context.Context, height uint64) ([]*chain.Result, error) {
+	r, err := vm.vmDB.Get(PrefixBlockResultsKey(height))
+	if err != nil {
+		return nil, err
+	}
+	return chain.UnmarshalResults(r)
 }
 
 func (vm *VM) GetBlockHeightID(height uint64) (ids.ID, error) {


### PR DESCRIPTION
This PR covers #556, #555, #562

Currently `block.Bytes()`  are stored to disk. now allowing to optionally store `block.Results`  to disk.

`block.Results` & `block.FeeManager` are now stored in `VM.vmDB`.

- [x] optionally store `block.Results` & `block.FeeManager` during `block.Accept` before committing to disk or updating the last accepted block.
- [x] limit `block.Results` stored on disk to same number of `blocks` stored on disk 
- [x] remove `block.Results` for expired blocks.
- [x] getter for fetching `block.Results` & `block.FeeManager` from disk.
- [x] Allow caller to specify a start block to stream if the block is stored on disk by node
- [x] [cli] Added arguments in `chain watch` to start stream at an earlier block height
- [x] update `scripts/run.sh` in `morpheusvm`  and `tokenvm`.

