### PR TITLE
[crypto/ed25519] Preallocate batch size for verification

### DIFF
--- a/crypto/ed25519/ed25519.go
+++ b/crypto/ed25519/ed25519.go
@@ -78,9 +78,8 @@ type Batch struct {
 	bv ed25519consensus.BatchVerifier
 }
 
-func NewBatch() *Batch {
-	// TODO: add support for pre-allocating batch (#652)
-	return &Batch{bv: ed25519consensus.NewBatchVerifier()}
+func NewBatch(size int) *Batch {
+	return &Batch{bv: ed25519consensus.NewPreallocatedBatchVerifier(size)}
 }
 
 func (b *Batch) Add(msg []byte, p PublicKey, s Signature) {

--- a/crypto/ed25519/ed25519_test.go
+++ b/crypto/ed25519/ed25519_test.go
@@ -138,7 +138,7 @@ func TestBatchAddVerifyValid(t *testing.T) {
 		sig := Sign(msg, priv)
 		sigs[i] = sig
 	}
-	bv := NewBatch()
+	bv := NewBatch(numItems)
 	for i := 0; i < numItems; i++ {
 		bv.Add(msgs[i], pubs[i], sigs[i])
 	}
@@ -172,7 +172,7 @@ func TestBatchAddVerifyInvalid(t *testing.T) {
 		}
 		sigs[i] = sig
 	}
-	bv := NewBatch()
+	bv := NewBatch(numItems)
 	for i := 0; i < numItems; i++ {
 		bv.Add(msgs[i], pubs[i], sigs[i])
 	}
@@ -292,7 +292,7 @@ func BenchmarkConsensusBatchAddVerify(b *testing.B) {
 			b.StartTimer()
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
-				bv := ed25519consensus.NewBatchVerifier()
+				bv := ed25519consensus.NewPreallocatedBatchVerifier(numItems)
 				for j := 0; j < numItems; j++ {
 					bv.Add(pubs[j], msgs[j], sigs[j])
 				}
@@ -326,7 +326,7 @@ func BenchmarkConsensusBatchVerify(b *testing.B) {
 				sig := ed25519.Sign(priv, msg)
 				sigs[i] = sig
 			}
-			bv := ed25519consensus.NewBatchVerifier()
+			bv := ed25519consensus.NewPreallocatedBatchVerifier(numItems)
 			for i := 0; i < numItems; i++ {
 				bv.Add(pubs[i], msgs[i], sigs[i])
 			}

--- a/examples/morpheusvm/auth/ed25519.go
+++ b/examples/morpheusvm/auth/ed25519.go
@@ -127,7 +127,7 @@ type ED25519Batch struct {
 func (b *ED25519Batch) Add(msg []byte, rauth chain.Auth) func() error {
 	auth := rauth.(*ED25519)
 	if b.batch == nil {
-		b.batch = ed25519.NewBatch()
+		b.batch = ed25519.NewBatch(b.batchSize)
 	}
 	b.batch.Add(msg, auth.Signer, auth.Signature)
 	b.counter++
@@ -137,7 +137,7 @@ func (b *ED25519Batch) Add(msg []byte, rauth chain.Auth) func() error {
 		b.counter = 0
 		if b.totalCounter < b.total {
 			// don't create a new batch if we are done
-			b.batch = ed25519.NewBatch()
+			b.batch = ed25519.NewBatch(b.batchSize)
 		}
 		return last.VerifyAsync()
 	}

--- a/examples/morpheusvm/go.mod
+++ b/examples/morpheusvm/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/hashicorp/go-bexpr v0.1.10 // indirect
 	github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
-	github.com/hdevalence/ed25519consensus v0.1.0 // indirect
+	github.com/hdevalence/ed25519consensus v0.2.0 // indirect
 	github.com/holiman/bloomfilter/v2 v2.0.3 // indirect
 	github.com/holiman/uint256 v1.2.2-0.20230321075855-87b91420868c // indirect
 	github.com/huin/goupnp v1.0.3 // indirect

--- a/examples/morpheusvm/go.sum
+++ b/examples/morpheusvm/go.sum
@@ -337,8 +337,8 @@ github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d h1:dg1dEPuW
 github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/hdevalence/ed25519consensus v0.1.0 h1:jtBwzzcHuTmFrQN6xQZn6CQEO/V9f7HsjsjeEZ6auqU=
-github.com/hdevalence/ed25519consensus v0.1.0/go.mod h1:w3BHWjwJbFU29IRHL1Iqkw3sus+7FctEyM4RqDxYNzo=
+github.com/hdevalence/ed25519consensus v0.2.0 h1:37ICyZqdyj0lAZ8P4D1d1id3HqbbG1N3iBb1Tb4rdcU=
+github.com/hdevalence/ed25519consensus v0.2.0/go.mod h1:w3BHWjwJbFU29IRHL1Iqkw3sus+7FctEyM4RqDxYNzo=
 github.com/holiman/bloomfilter/v2 v2.0.3 h1:73e0e/V0tCydx14a0SCYS/EWCxgwLZ18CZcZKVu0fao=
 github.com/holiman/bloomfilter/v2 v2.0.3/go.mod h1:zpoh+gs7qcpqrHr3dB55AMiJwo0iURXE7ZOP9L9hSkA=
 github.com/holiman/uint256 v1.2.2-0.20230321075855-87b91420868c h1:DZfsyhDK1hnSS5lH8l+JggqzEleHteTYfutAiVlSUM8=

--- a/examples/tokenvm/auth/ed25519.go
+++ b/examples/tokenvm/auth/ed25519.go
@@ -126,7 +126,7 @@ type ED25519Batch struct {
 func (b *ED25519Batch) Add(msg []byte, rauth chain.Auth) func() error {
 	auth := rauth.(*ED25519)
 	if b.batch == nil {
-		b.batch = ed25519.NewBatch()
+		b.batch = ed25519.NewBatch(b.batchSize)
 	}
 	b.batch.Add(msg, auth.Signer, auth.Signature)
 	b.counter++
@@ -136,7 +136,7 @@ func (b *ED25519Batch) Add(msg []byte, rauth chain.Auth) func() error {
 		b.counter = 0
 		if b.totalCounter < b.total {
 			// don't create a new batch if we are done
-			b.batch = ed25519.NewBatch()
+			b.batch = ed25519.NewBatch(b.batchSize)
 		}
 		return last.VerifyAsync()
 	}

--- a/examples/tokenvm/go.mod
+++ b/examples/tokenvm/go.mod
@@ -69,7 +69,7 @@ require (
 	github.com/hashicorp/go-bexpr v0.1.10 // indirect
 	github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
-	github.com/hdevalence/ed25519consensus v0.1.0 // indirect
+	github.com/hdevalence/ed25519consensus v0.2.0 // indirect
 	github.com/holiman/bloomfilter/v2 v2.0.3 // indirect
 	github.com/holiman/uint256 v1.2.2-0.20230321075855-87b91420868c // indirect
 	github.com/huin/goupnp v1.0.3 // indirect

--- a/examples/tokenvm/go.sum
+++ b/examples/tokenvm/go.sum
@@ -339,8 +339,8 @@ github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d h1:dg1dEPuW
 github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/hdevalence/ed25519consensus v0.1.0 h1:jtBwzzcHuTmFrQN6xQZn6CQEO/V9f7HsjsjeEZ6auqU=
-github.com/hdevalence/ed25519consensus v0.1.0/go.mod h1:w3BHWjwJbFU29IRHL1Iqkw3sus+7FctEyM4RqDxYNzo=
+github.com/hdevalence/ed25519consensus v0.2.0 h1:37ICyZqdyj0lAZ8P4D1d1id3HqbbG1N3iBb1Tb4rdcU=
+github.com/hdevalence/ed25519consensus v0.2.0/go.mod h1:w3BHWjwJbFU29IRHL1Iqkw3sus+7FctEyM4RqDxYNzo=
 github.com/holiman/bloomfilter/v2 v2.0.3 h1:73e0e/V0tCydx14a0SCYS/EWCxgwLZ18CZcZKVu0fao=
 github.com/holiman/bloomfilter/v2 v2.0.3/go.mod h1:zpoh+gs7qcpqrHr3dB55AMiJwo0iURXE7ZOP9L9hSkA=
 github.com/holiman/uint256 v1.2.2-0.20230321075855-87b91420868c h1:DZfsyhDK1hnSS5lH8l+JggqzEleHteTYfutAiVlSUM8=

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/rpc v1.2.0
 	github.com/gorilla/websocket v1.5.0
-	github.com/hdevalence/ed25519consensus v0.1.0
+	github.com/hdevalence/ed25519consensus v0.2.0
 	github.com/manifoldco/promptui v0.9.0
 	github.com/near/borsh-go v0.3.1
 	github.com/neilotoole/errgroup v0.1.6

--- a/go.sum
+++ b/go.sum
@@ -260,8 +260,8 @@ github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/hdevalence/ed25519consensus v0.1.0 h1:jtBwzzcHuTmFrQN6xQZn6CQEO/V9f7HsjsjeEZ6auqU=
-github.com/hdevalence/ed25519consensus v0.1.0/go.mod h1:w3BHWjwJbFU29IRHL1Iqkw3sus+7FctEyM4RqDxYNzo=
+github.com/hdevalence/ed25519consensus v0.2.0 h1:37ICyZqdyj0lAZ8P4D1d1id3HqbbG1N3iBb1Tb4rdcU=
+github.com/hdevalence/ed25519consensus v0.2.0/go.mod h1:w3BHWjwJbFU29IRHL1Iqkw3sus+7FctEyM4RqDxYNzo=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/hydrogen18/memlistener v0.0.0-20200120041712-dcc25e7acd91/go.mod h1:qEIFzExnS6016fRpRfxrExeVn2gbClQA99gQhnIcdhE=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=


### PR DESCRIPTION
Related: #645

https://github.com/hdevalence/ed25519consensus/pull/16

### Previous
```
BenchmarkConsensusBatchAddVerify/1-12   	   20367	     58998 ns/op	    5648 B/op	       9 allocs/op
BenchmarkConsensusBatchAddVerify/4-12   	    9326	    130121 ns/op	   17232 B/op	      17 allocs/op
BenchmarkConsensusBatchAddVerify/16-12  	    2929	    420688 ns/op	   69264 B/op	      43 allocs/op
BenchmarkConsensusBatchAddVerify/64-12  	     775	   1545830 ns/op	  253649 B/op	     141 allocs/op
BenchmarkConsensusBatchAddVerify/128-12 	     394	   3058001 ns/op	  496850 B/op	     270 allocs/op
BenchmarkConsensusBatchAddVerify/512-12 	      97	  12106657 ns/op	 1927155 B/op	    1040 allocs/op
BenchmarkConsensusBatchAddVerify/1024-12         	      50	  24355565 ns/op	 3812816 B/op	    2065 allocs/op
BenchmarkConsensusBatchAddVerify/4096-12         	      10	 100681646 ns/op	15424976 B/op	    8213 allocs/op
BenchmarkConsensusBatchAddVerify/16384-12        	       3	 448992083 ns/op	63077872 B/op	   32795 allocs/op
BenchmarkConsensusBatchVerify/1-12               	   20228	     59853 ns/op	    5552 B/op	       7 allocs/op
BenchmarkConsensusBatchVerify/4-12               	    9436	    130756 ns/op	   16704 B/op	      10 allocs/op
BenchmarkConsensusBatchVerify/16-12              	    2968	    412512 ns/op	   67008 B/op	      22 allocs/op
BenchmarkConsensusBatchVerify/64-12              	     782	   1531430 ns/op	  243969 B/op	      70 allocs/op
BenchmarkConsensusBatchVerify/128-12             	     392	   3096470 ns/op	  476929 B/op	     134 allocs/op
BenchmarkConsensusBatchVerify/512-12             	      99	  12071803 ns/op	 1845765 B/op	     518 allocs/op
BenchmarkConsensusBatchVerify/1024-12            	      50	  24384858 ns/op	 3657735 B/op	    1030 allocs/op
BenchmarkConsensusBatchVerify/4096-12            	      12	  99508948 ns/op	14532608 B/op	    4102 allocs/op
BenchmarkConsensusBatchVerify/16384-12           	       3	 449900194 ns/op	57982976 B/op	   16390 allocs/op
```

### PR (99% reduction in allocs)
```
BenchmarkConsensusBatchAddVerify/1-12   	   20077	     60035 ns/op	    5728 B/op	       8 allocs/op
BenchmarkConsensusBatchAddVerify/4-12   	    9250	    131768 ns/op	   17312 B/op	       8 allocs/op
BenchmarkConsensusBatchAddVerify/16-12  	    2857	    417964 ns/op	   69216 B/op	       8 allocs/op
BenchmarkConsensusBatchAddVerify/64-12  	     759	   1599658 ns/op	  252832 B/op	       8 allocs/op
BenchmarkConsensusBatchAddVerify/128-12 	     380	   3107973 ns/op	  494626 B/op	       8 allocs/op
BenchmarkConsensusBatchAddVerify/512-12 	      99	  12248031 ns/op	 1919529 B/op	       8 allocs/op
BenchmarkConsensusBatchAddVerify/1024-12         	      49	  24498628 ns/op	 3797029 B/op	       8 allocs/op
BenchmarkConsensusBatchAddVerify/4096-12         	      10	 101433183 ns/op	15065129 B/op	       8 allocs/op
BenchmarkConsensusBatchAddVerify/16384-12        	       3	 452705625 ns/op	60096544 B/op	       8 allocs/op
BenchmarkConsensusBatchVerify/1-12               	   19965	     60094 ns/op	    5552 B/op	       7 allocs/op
BenchmarkConsensusBatchVerify/4-12               	    8989	    131767 ns/op	   16608 B/op	       7 allocs/op
BenchmarkConsensusBatchVerify/16-12              	    2839	    418850 ns/op	   66528 B/op	       7 allocs/op
BenchmarkConsensusBatchVerify/64-12              	     763	   1565576 ns/op	  241953 B/op	       7 allocs/op
BenchmarkConsensusBatchVerify/128-12             	     388	   3068891 ns/op	  472865 B/op	       7 allocs/op
BenchmarkConsensusBatchVerify/512-12             	      98	  12609815 ns/op	 1829415 B/op	       7 allocs/op
BenchmarkConsensusBatchVerify/1024-12            	      46	  24334647 ns/op	 3624998 B/op	       7 allocs/op
BenchmarkConsensusBatchVerify/4096-12            	      12	  99872802 ns/op	14401584 B/op	       7 allocs/op
BenchmarkConsensusBatchVerify/16384-12           	       3	 450050639 ns/op	57458720 B/op	       7 allocs/op
```