### PR TITLE
`ci`: Add shellcheck step to lint job

### DIFF
--- a/.github/workflows/hypersdk-static-analysis.yml
+++ b/.github/workflows/hypersdk-static-analysis.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Run static analysis tests
         shell: bash
         run: scripts/tests.lint.sh
+      - name: Run shellcheck
+        shell: bash
+        run: scripts/tests.shellcheck.sh
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,2 @@
+# Always require quoting for consistency
+enable=quote-safe-variables

--- a/examples/morpheusvm/scripts/build.sh
+++ b/examples/morpheusvm/scripts/build.sh
@@ -18,12 +18,8 @@ MORPHEUSVM_PATH=$(
     cd .. && pwd
 )
 
-realpath() {
-    [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
-}
-
 if [[ $# -eq 1 ]]; then
-    BINARY_PATH=$(realpath $1)
+    BINARY_PATH="$(realpath "$1")"
 elif [[ $# -eq 0 ]]; then
     # Set default binary directory location
     name="pkEmJQuTUic3dxzg8EYnktwn4W7uCHofNcwiYo458vodAUbY7"
@@ -33,13 +29,13 @@ else
     exit 1
 fi
 
-cd $MORPHEUSVM_PATH
+cd "$MORPHEUSVM_PATH"
 
 echo "Building morpheusvm in $BINARY_PATH"
-mkdir -p $(dirname $BINARY_PATH)
-go build -o $BINARY_PATH ./cmd/morpheusvm
+mkdir -p "$(dirname "$BINARY_PATH")"
+go build -o "$BINARY_PATH" ./cmd/morpheusvm
 
 CLI_PATH=$MORPHEUSVM_PATH/build/morpheus-cli
 echo "Building morpheus-cli in $CLI_PATH"
-mkdir -p $(dirname $CLI_PATH)
-go build -o $CLI_PATH ./cmd/morpheus-cli
+mkdir -p "$(dirname "$CLI_PATH")"
+go build -o "$CLI_PATH" ./cmd/morpheus-cli

--- a/examples/morpheusvm/scripts/run.sh
+++ b/examples/morpheusvm/scripts/run.sh
@@ -44,23 +44,21 @@ if ${UNLIMITED_USAGE}; then
 fi
 
 echo "Running with:"
-echo AGO_LOGLEVEL: ${AGO_LOGLEVEL}
-echo LOGLEVEL: ${LOGLEVEL}
+echo AGO_LOGLEVEL: "${AGO_LOGLEVEL}"
+echo LOGLEVEL: "${LOGLEVEL}"
 echo VERSION: ${VERSION}
-echo MODE: ${MODE}
-echo LOG LEVEL: ${LOGLEVEL}
-echo STATESYNC_DELAY \(ns\): ${STATESYNC_DELAY}
-echo MIN_BLOCK_GAP \(ms\): ${MIN_BLOCK_GAP}
-echo STORE_TXS: ${STORE_TXS}
+echo MODE: "${MODE}"
+echo LOG LEVEL: "${LOGLEVEL}"
+echo STATESYNC_DELAY \(ns\): "${STATESYNC_DELAY}"
+echo MIN_BLOCK_GAP \(ms\): "${MIN_BLOCK_GAP}"
+echo STORE_TXS: "${STORE_TXS}"
 echo WINDOW_TARGET_UNITS: ${WINDOW_TARGET_UNITS}
 echo MAX_BLOCK_UNITS: ${MAX_BLOCK_UNITS}
-echo ADDRESS: ${ADDRESS}
+echo ADDRESS: "${ADDRESS}"
 
 ############################
 # build avalanchego
 # https://github.com/ava-labs/avalanchego/releases
-GOARCH=$(go env GOARCH)
-GOOS=$(go env GOOS)
 TMPDIR=/tmp/hypersdk
 
 echo "working directory: $TMPDIR"
@@ -88,7 +86,7 @@ if [ ! -f "$AVALANCHEGO_PATH" ]; then
   ./scripts/build.sh
   mv build/avalanchego ${TMPDIR}/avalanchego-${VERSION}
 
-  cd ${CWD}
+  cd "${CWD}"
 else
   echo "using previously built avalanchego"
 fi
@@ -131,12 +129,12 @@ if [[ -z "${GENESIS_PATH}" ]]; then
   ${TMPDIR}/morpheus-cli genesis generate ${TMPDIR}/allocations.json \
   --window-target-units ${WINDOW_TARGET_UNITS} \
   --max-block-units ${MAX_BLOCK_UNITS} \
-  --min-block-gap ${MIN_BLOCK_GAP} \
+  --min-block-gap "${MIN_BLOCK_GAP}" \
   --genesis-file ${TMPDIR}/morpheusvm.genesis
 else
   echo "copying custom genesis file"
   rm -f ${TMPDIR}/morpheusvm.genesis
-  cp ${GENESIS_PATH} ${TMPDIR}/morpheusvm.genesis
+  cp "${GENESIS_PATH}" ${TMPDIR}/morpheusvm.genesis
 fi
 
 ############################
@@ -221,7 +219,6 @@ $BIN server \
 --log-level=verbo \
 --port=":12352" \
 --grpc-gateway-port=":12353" &
-PID=${!}
 
 ############################
 # By default, it runs all e2e test cases!
@@ -249,7 +246,7 @@ echo "running e2e tests"
 ./tests/e2e/e2e.test \
 --ginkgo.v \
 --network-runner-log-level verbo \
---avalanchego-log-level ${AGO_LOGLEVEL} \
+--avalanchego-log-level "${AGO_LOGLEVEL}" \
 --network-runner-grpc-endpoint="0.0.0.0:12352" \
 --network-runner-grpc-gateway-endpoint="0.0.0.0:12353" \
 --avalanchego-path=${AVALANCHEGO_PATH} \
@@ -258,7 +255,7 @@ echo "running e2e tests"
 --vm-config-path=${TMPDIR}/morpheusvm.config \
 --subnet-config-path=${TMPDIR}/morpheusvm.subnet \
 --output-path=${TMPDIR}/avalanchego-${VERSION}/output.yaml \
---mode=${MODE}
+--mode="${MODE}"
 
 ############################
 if [[ ${MODE} == "run" ]]; then

--- a/examples/morpheusvm/scripts/run.sh
+++ b/examples/morpheusvm/scripts/run.sh
@@ -46,14 +46,14 @@ fi
 echo "Running with:"
 echo AGO_LOGLEVEL: "${AGO_LOGLEVEL}"
 echo LOGLEVEL: "${LOGLEVEL}"
-echo VERSION: ${VERSION}
+echo VERSION: "${VERSION}"
 echo MODE: "${MODE}"
 echo LOG LEVEL: "${LOGLEVEL}"
 echo STATESYNC_DELAY \(ns\): "${STATESYNC_DELAY}"
 echo MIN_BLOCK_GAP \(ms\): "${MIN_BLOCK_GAP}"
 echo STORE_TXS: "${STORE_TXS}"
-echo WINDOW_TARGET_UNITS: ${WINDOW_TARGET_UNITS}
-echo MAX_BLOCK_UNITS: ${MAX_BLOCK_UNITS}
+echo WINDOW_TARGET_UNITS: "${WINDOW_TARGET_UNITS}"
+echo MAX_BLOCK_UNITS: "${MAX_BLOCK_UNITS}"
 echo ADDRESS: "${ADDRESS}"
 
 ############################
@@ -71,20 +71,20 @@ if [ ! -f "$AVALANCHEGO_PATH" ]; then
   CWD=$(pwd)
 
   # Clear old folders
-  rm -rf ${TMPDIR}/avalanchego-${VERSION}
-  mkdir -p ${TMPDIR}/avalanchego-${VERSION}
-  rm -rf ${TMPDIR}/avalanchego-src
-  mkdir -p ${TMPDIR}/avalanchego-src
+  rm -rf "${TMPDIR}"/avalanchego-"${VERSION}"
+  mkdir -p "${TMPDIR}"/avalanchego-"${VERSION}"
+  rm -rf "${TMPDIR}"/avalanchego-src
+  mkdir -p "${TMPDIR}"/avalanchego-src
 
   # Download src
-  cd ${TMPDIR}/avalanchego-src
+  cd "${TMPDIR}"/avalanchego-src
   git clone https://github.com/ava-labs/avalanchego.git
   cd avalanchego
-  git checkout ${VERSION}
+  git checkout "${VERSION}"
 
   # Build avalanchego
   ./scripts/build.sh
-  mv build/avalanchego ${TMPDIR}/avalanchego-${VERSION}
+  mv build/avalanchego "${TMPDIR}"/avalanchego-"${VERSION}"
 
   cd "${CWD}"
 else
@@ -97,18 +97,18 @@ fi
 echo "building morpheusvm"
 
 # delete previous (if exists)
-rm -f ${TMPDIR}/avalanchego-${VERSION}/plugins/qCNyZHrs3rZX458wPJXPJJypPf6w423A84jnfbdP2TPEmEE9u
+rm -f "${TMPDIR}"/avalanchego-"${VERSION}"/plugins/qCNyZHrs3rZX458wPJXPJJypPf6w423A84jnfbdP2TPEmEE9u
 
 # rebuild with latest code
 go build \
--o ${TMPDIR}/avalanchego-${VERSION}/plugins/qCNyZHrs3rZX458wPJXPJJypPf6w423A84jnfbdP2TPEmEE9u \
+-o "${TMPDIR}"/avalanchego-"${VERSION}"/plugins/qCNyZHrs3rZX458wPJXPJJypPf6w423A84jnfbdP2TPEmEE9u \
 ./cmd/morpheusvm
 
 echo "building morpheus-cli"
-go build -v -o ${TMPDIR}/morpheus-cli ./cmd/morpheus-cli
+go build -v -o "${TMPDIR}"/morpheus-cli ./cmd/morpheus-cli
 
 # log everything in the avalanchego directory
-find ${TMPDIR}/avalanchego-${VERSION}
+find "${TMPDIR}"/avalanchego-"${VERSION}"
 
 ############################
 
@@ -116,7 +116,7 @@ find ${TMPDIR}/avalanchego-${VERSION}
 
 # Always create allocations (linter doesn't like tab)
 echo "creating allocations file"
-cat <<EOF > ${TMPDIR}/allocations.json
+cat <<EOF > "${TMPDIR}"/allocations.json
 [
   {"address":"${ADDRESS}", "balance":10000000000000000000}
 ]
@@ -125,16 +125,16 @@ EOF
 GENESIS_PATH=$2
 if [[ -z "${GENESIS_PATH}" ]]; then
   echo "creating VM genesis file with allocations"
-  rm -f ${TMPDIR}/morpheusvm.genesis
-  ${TMPDIR}/morpheus-cli genesis generate ${TMPDIR}/allocations.json \
-  --window-target-units ${WINDOW_TARGET_UNITS} \
-  --max-block-units ${MAX_BLOCK_UNITS} \
+  rm -f "${TMPDIR}"/morpheusvm.genesis
+  "${TMPDIR}"/morpheus-cli genesis generate "${TMPDIR}"/allocations.json \
+  --window-target-units "${WINDOW_TARGET_UNITS}" \
+  --max-block-units "${MAX_BLOCK_UNITS}" \
   --min-block-gap "${MIN_BLOCK_GAP}" \
-  --genesis-file ${TMPDIR}/morpheusvm.genesis
+  --genesis-file "${TMPDIR}"/morpheusvm.genesis
 else
   echo "copying custom genesis file"
-  rm -f ${TMPDIR}/morpheusvm.genesis
-  cp "${GENESIS_PATH}" ${TMPDIR}/morpheusvm.genesis
+  rm -f "${TMPDIR}"/morpheusvm.genesis
+  cp "${GENESIS_PATH}" "${TMPDIR}"/morpheusvm.genesis
 fi
 
 ############################
@@ -142,9 +142,9 @@ fi
 ############################
 
 echo "creating vm config"
-rm -f ${TMPDIR}/morpheusvm.config
-rm -rf ${TMPDIR}/morpheusvm-e2e-profiles
-cat <<EOF > ${TMPDIR}/morpheusvm.config
+rm -f "${TMPDIR}"/morpheusvm.config
+rm -rf "${TMPDIR}"/morpheusvm-e2e-profiles
+cat <<EOF > "${TMPDIR}"/morpheusvm.config
 {
   "mempoolSize": 10000000,
   "mempoolSponsorSize": 10000000,
@@ -160,15 +160,15 @@ cat <<EOF > ${TMPDIR}/morpheusvm.config
   "stateSyncServerDelay": ${STATESYNC_DELAY}
 }
 EOF
-mkdir -p ${TMPDIR}/morpheusvm-e2e-profiles
+mkdir -p "${TMPDIR}"/morpheusvm-e2e-profiles
 
 ############################
 
 ############################
 
 echo "creating subnet config"
-rm -f ${TMPDIR}/morpheusvm.subnet
-cat <<EOF > ${TMPDIR}/morpheusvm.subnet
+rm -f "${TMPDIR}"/morpheusvm.subnet
+cat <<EOF > "${TMPDIR}"/morpheusvm.subnet
 {
   "proposerMinBlockDelay": 0,
   "proposerNumHistoricalBlocks": 50000
@@ -199,7 +199,7 @@ ACK_GINKGO_RC=true ginkgo build ./tests/e2e
 ANR_REPO_PATH=github.com/ava-labs/avalanche-network-runner
 ANR_VERSION=90aa9ae77845665b7638404a2a5e6a4dcce6d489
 # version set
-go install -v ${ANR_REPO_PATH}@${ANR_VERSION}
+go install -v "${ANR_REPO_PATH}"@"${ANR_VERSION}"
 
 #################################
 # run "avalanche-network-runner" server
@@ -249,12 +249,12 @@ echo "running e2e tests"
 --avalanchego-log-level "${AGO_LOGLEVEL}" \
 --network-runner-grpc-endpoint="0.0.0.0:12352" \
 --network-runner-grpc-gateway-endpoint="0.0.0.0:12353" \
---avalanchego-path=${AVALANCHEGO_PATH} \
---avalanchego-plugin-dir=${AVALANCHEGO_PLUGIN_DIR} \
---vm-genesis-path=${TMPDIR}/morpheusvm.genesis \
---vm-config-path=${TMPDIR}/morpheusvm.config \
---subnet-config-path=${TMPDIR}/morpheusvm.subnet \
---output-path=${TMPDIR}/avalanchego-${VERSION}/output.yaml \
+--avalanchego-path="${AVALANCHEGO_PATH}" \
+--avalanchego-plugin-dir="${AVALANCHEGO_PLUGIN_DIR}" \
+--vm-genesis-path="${TMPDIR}"/morpheusvm.genesis \
+--vm-config-path="${TMPDIR}"/morpheusvm.config \
+--subnet-config-path="${TMPDIR}"/morpheusvm.subnet \
+--output-path="${TMPDIR}"/avalanchego-"${VERSION}"/output.yaml \
 --mode="${MODE}"
 
 ############################

--- a/examples/morpheusvm/scripts/tests.lint.sh
+++ b/examples/morpheusvm/scripts/tests.lint.sh
@@ -54,7 +54,8 @@ function test_license_header {
   local files=()
   while IFS= read -r line; do files+=("$line"); done < <(find . -type f -name '*.go' ! -name '*.pb.go' ! -name 'mock_*.go')
 
-  # ignore 3rd party code
+  # Provision of the list of flags requires word splitting, so disable the shellcheck
+  # shellcheck disable=SC2086
   go-license \
   --config ./license.yml \
   ${_addlicense_flags} \

--- a/examples/morpheusvm/scripts/tests.load.sh
+++ b/examples/morpheusvm/scripts/tests.load.sh
@@ -31,4 +31,4 @@ run \
 --vms 5 \
 --accts 10000 \
 --txs 500000 \
---trace=${TRACE}
+--trace="${TRACE}"

--- a/examples/morpheusvm/scripts/tests.unit.sh
+++ b/examples/morpheusvm/scripts/tests.unit.sh
@@ -15,4 +15,6 @@ if ! [[ "$0" =~ scripts/tests.unit.sh ]]; then
   exit 255
 fi
 
+# Provision of the list of tests requires word splitting, so disable the shellcheck
+# shellcheck disable=SC2046
 go test -race -timeout="10m" -coverprofile="coverage.out" -covermode="atomic" $(go list ./... | grep -v tests)

--- a/examples/tokenvm/cmd/token-wallet/scripts/build.sh
+++ b/examples/tokenvm/cmd/token-wallet/scripts/build.sh
@@ -31,7 +31,7 @@ fi
 rm -rf token-wallet.zip
 
 # Exit early if not publishing
-if [ ${PUBLISH} == false ]; then
+if [ "${PUBLISH}" == false ]; then
   echo "not publishing app"
   ditto -c -k --keepParent build/bin/Token\ Wallet.app token-wallet.zip
   exit 0
@@ -39,16 +39,16 @@ fi
 echo "publishing app"
 
 # Sign code
-codesign -s ${APP_SIGNING_KEY_ID} --deep  --timestamp -o runtime -v build/bin/Token\ Wallet.app
+codesign -s "${APP_SIGNING_KEY_ID}" --deep  --timestamp -o runtime -v build/bin/Token\ Wallet.app
 ditto -c -k --keepParent build/bin/Token\ Wallet.app token-wallet.zip
 
 # Need to sign to allow for app to be opened on other computers
-xcrun altool --notarize-app --primary-bundle-id com.ava-labs.token-wallet --username ${APPLE_NOTARIZATION_USERNAME} --password "@keychain:altool" --file token-wallet.zip
+xcrun altool --notarize-app --primary-bundle-id com.ava-labs.token-wallet --username "${APPLE_NOTARIZATION_USERNAME}" --password "@keychain:altool" --file token-wallet.zip
 
 # Log until exit
-read -p "Input APPLE_NOTARIZATION_REQUEST_ID: " APPLE_NOTARIZATION_REQUEST_ID
+read -r -p "Input APPLE_NOTARIZATION_REQUEST_ID: " APPLE_NOTARIZATION_REQUEST_ID
 while true
 do
-  xcrun altool --notarization-info ${APPLE_NOTARIZATION_REQUEST_ID} -u ${APPLE_NOTARIZATION_USERNAME} -p "@keychain:altool"
+  xcrun altool --notarization-info "${APPLE_NOTARIZATION_REQUEST_ID}" -u "${APPLE_NOTARIZATION_USERNAME}" -p "@keychain:altool"
   sleep 15
 done

--- a/examples/tokenvm/scripts/build.sh
+++ b/examples/tokenvm/scripts/build.sh
@@ -18,12 +18,8 @@ TOKENVM_PATH=$(
     cd .. && pwd
 )
 
-realpath() {
-    [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
-}
-
 if [[ $# -eq 1 ]]; then
-    BINARY_PATH=$(realpath $1)
+    BINARY_PATH=$(realpath "$1")
 elif [[ $# -eq 0 ]]; then
     # Set default binary directory location
     name="tHBYNu8ikqo4MWMHehC9iKB9mR5tB3DWzbkYmTfe9buWQ5GZ8"
@@ -33,23 +29,23 @@ else
     exit 1
 fi
 
-cd $TOKENVM_PATH
+cd "$TOKENVM_PATH"
 
 echo "Building tokenvm in $BINARY_PATH"
-mkdir -p $(dirname $BINARY_PATH)
-go build -o $BINARY_PATH ./cmd/tokenvm
+mkdir -p "$(dirname "$BINARY_PATH")"
+go build -o "$BINARY_PATH" ./cmd/tokenvm
 
 CLI_PATH=$TOKENVM_PATH/build/token-cli
 echo "Building token-cli in $CLI_PATH"
-mkdir -p $(dirname $CLI_PATH)
-go build -o $CLI_PATH ./cmd/token-cli
+mkdir -p "$(dirname "$CLI_PATH")"
+go build -o "$CLI_PATH" ./cmd/token-cli
 
 FAUCET_PATH=$TOKENVM_PATH/build/token-faucet
 echo "Building token-faucet in $FAUCET_PATH"
-mkdir -p $(dirname $FAUCET_PATH)
-go build -o $FAUCET_PATH ./cmd/token-faucet
+mkdir -p "$(dirname "$FAUCET_PATH")"
+go build -o "$FAUCET_PATH" ./cmd/token-faucet
 
 FEED_PATH=$TOKENVM_PATH/build/token-feed
 echo "Building token-feed in $FEED_PATH"
-mkdir -p $(dirname $FEED_PATH)
-go build -o $FEED_PATH ./cmd/token-feed
+mkdir -p "$(dirname "$FEED_PATH")"
+go build -o "$FEED_PATH" ./cmd/token-feed

--- a/examples/tokenvm/scripts/deploy.devnet.sh
+++ b/examples/tokenvm/scripts/deploy.devnet.sh
@@ -36,9 +36,9 @@ DEPLOYER_OS_TYPE=$(uname | tr '[:upper:]' '[:lower:]')
 export DEPLOYER_OS_TYPE
 echo DEPLOYER_OS_TYPE: "${DEPLOYER_OS_TYPE}"
 export AVALANCHEGO_VERSION="1.10.12"
-echo AVALANCHEGO_VERSION: ${AVALANCHEGO_VERSION}
+echo AVALANCHEGO_VERSION: "${AVALANCHEGO_VERSION}"
 export HYPERSDK_VERSION="0.0.15-rc.1"
-echo HYPERSDK_VERSION: ${HYPERSDK_VERSION}
+echo HYPERSDK_VERSION: "${HYPERSDK_VERSION}"
 # TODO: set deploy os/arch
 
 # Check valid setup
@@ -96,8 +96,8 @@ if [ -f /tmp/avalanche-ops-cache/tokenvm ]; then
 else
   wget "https://github.com/ava-labs/hypersdk/releases/download/v${HYPERSDK_VERSION}/tokenvm_${HYPERSDK_VERSION}_linux_amd64.tar.gz"
   mkdir -p /tmp/token-installs
-  tar -xvf tokenvm_${HYPERSDK_VERSION}_linux_amd64.tar.gz -C /tmp/token-installs
-  rm -rf tokenvm_${HYPERSDK_VERSION}_linux_amd64.tar.gz
+  tar -xvf tokenvm_"${HYPERSDK_VERSION}"_linux_amd64.tar.gz -C /tmp/token-installs
+  rm -rf tokenvm_"${HYPERSDK_VERSION}"_linux_amd64.tar.gz
   mv /tmp/token-installs/tokenvm "${DEPLOY_ARTIFACT_PREFIX}/tokenvm"
   mv /tmp/token-installs/token-cli "${DEPLOY_ARTIFACT_PREFIX}/token-cli-dev"
   rm -rf /tmp/token-installs
@@ -127,8 +127,8 @@ EOF
 MAX_UINT64=18446744073709551615
 "${DEPLOY_ARTIFACT_PREFIX}/token-cli" genesis generate "${DEPLOY_ARTIFACT_PREFIX}/allocations.json" \
 --genesis-file "${DEPLOY_ARTIFACT_PREFIX}/tokenvm-genesis.json" \
---max-block-units 1800000,${MAX_UINT64},${MAX_UINT64},${MAX_UINT64},${MAX_UINT64} \
---window-target-units ${MAX_UINT64},${MAX_UINT64},${MAX_UINT64},${MAX_UINT64},${MAX_UINT64} \
+--max-block-units 1800000,"${MAX_UINT64}","${MAX_UINT64}","${MAX_UINT64}","${MAX_UINT64}" \
+--window-target-units "${MAX_UINT64}","${MAX_UINT64}","${MAX_UINT64}","${MAX_UINT64}","${MAX_UINT64}" \
 --min-block-gap 250
 cat "${DEPLOY_ARTIFACT_PREFIX}/tokenvm-genesis.json"
 
@@ -164,7 +164,7 @@ echo created avalanche-ops spec file: "${SPEC_FILE}"
 
 # Create key file dir
 KEY_FILES_DIR=keys
-mkdir -p ${KEY_FILES_DIR}
+mkdir -p "${KEY_FILES_DIR}"
 
 # Create dummy metrics file (can't not upload)
 # TODO: fix this
@@ -189,7 +189,7 @@ echo 'planning DEVNET deploy...'
 --upload-artifacts-prometheus-metrics-rules-file-path "${DEPLOY_ARTIFACT_PREFIX}/metrics.yml" \
 --network-name custom \
 --staking-amount-in-avax 2000 \
---avalanchego-release-tag v${AVALANCHEGO_VERSION} \
+--avalanchego-release-tag v"${AVALANCHEGO_VERSION}" \
 --create-dev-machine \
 --keys-to-generate 5 \
 --subnet-config-file "${DEPLOY_ARTIFACT_PREFIX}/tokenvm-subnet-config.json" \
@@ -199,7 +199,7 @@ echo 'planning DEVNET deploy...'
 --chain-config-file "${DEPLOY_ARTIFACT_PREFIX}/tokenvm-chain-config.json" \
 --enable-ssh \
 --spec-file-path "${SPEC_FILE}" \
---key-files-dir ${KEY_FILES_DIR} \
+--key-files-dir "${KEY_FILES_DIR}" \
 --profile-name "${AWS_PROFILE_NAME}"
 
 # Disable rate limits in config

--- a/examples/tokenvm/scripts/deploy.devnet.sh
+++ b/examples/tokenvm/scripts/deploy.devnet.sh
@@ -7,7 +7,7 @@ set -o pipefail
 # Ensure we return back to current directory
 pw=$(pwd)
 function cleanup() {
-  cd $pw
+  cd "$pw"
 }
 trap cleanup EXIT
 
@@ -21,18 +21,20 @@ mkdir -p /tmp/avalanche-ops-cache
 # Create deployment directory (avalanche-ops creates metadata in cwd)
 DATE=$(date '+%m%d%Y-%H%M%S')
 DEPLOY_PREFIX=~/avalanche-ops-deploys/${DATE}
-mkdir -p ${DEPLOY_PREFIX}
+mkdir -p "${DEPLOY_PREFIX}"
 DEPLOY_ARTIFACT_PREFIX=${DEPLOY_PREFIX}/artifacts
-mkdir -p ${DEPLOY_ARTIFACT_PREFIX}
-echo create deployment folder: ${DEPLOY_PREFIX}
-cd ${DEPLOY_PREFIX}
+mkdir -p "${DEPLOY_ARTIFACT_PREFIX}"
+echo create deployment folder: "${DEPLOY_PREFIX}"
+cd "${DEPLOY_PREFIX}"
 
 # Set constants
-export DEPLOYER_ARCH_TYPE=$(uname -m)
-[ $DEPLOYER_ARCH_TYPE = x86_64 ] && DEPLOYER_ARCH_TYPE=amd64
-echo DEPLOYER_ARCH_TYPE: ${DEPLOYER_ARCH_TYPE}
-export DEPLOYER_OS_TYPE=$(uname | tr '[:upper:]' '[:lower:]')
-echo DEPLOYER_OS_TYPE: ${DEPLOYER_OS_TYPE}
+DEPLOYER_ARCH_TYPE=$(uname -m)
+export DEPLOYER_ARCH_TYPE
+[ "$DEPLOYER_ARCH_TYPE" = x86_64 ] && DEPLOYER_ARCH_TYPE=amd64
+echo DEPLOYER_ARCH_TYPE: "${DEPLOYER_ARCH_TYPE}"
+DEPLOYER_OS_TYPE=$(uname | tr '[:upper:]' '[:lower:]')
+export DEPLOYER_OS_TYPE
+echo DEPLOYER_OS_TYPE: "${DEPLOYER_OS_TYPE}"
 export AVALANCHEGO_VERSION="1.10.12"
 echo AVALANCHEGO_VERSION: ${AVALANCHEGO_VERSION}
 export HYPERSDK_VERSION="0.0.15-rc.1"
@@ -40,11 +42,11 @@ echo HYPERSDK_VERSION: ${HYPERSDK_VERSION}
 # TODO: set deploy os/arch
 
 # Check valid setup
-if [ ${DEPLOYER_OS_TYPE} != 'darwin' ]; then
+if [ "${DEPLOYER_OS_TYPE}" != 'darwin' ]; then
   echo 'os is not supported' >&2
   exit 1
 fi
-if [ ${DEPLOYER_ARCH_TYPE} != 'arm64' ]; then
+if [ "${DEPLOYER_ARCH_TYPE}" != 'arm64' ]; then
   echo 'arch is not supported' >&2
   exit 1
 fi
@@ -60,60 +62,60 @@ fi
 # Install avalanche-ops
 echo 'installing avalanche-ops...'
 if [ -f /tmp/avalanche-ops-cache/avalancheup-aws ]; then
-  cp /tmp/avalanche-ops-cache/avalancheup-aws ${DEPLOY_ARTIFACT_PREFIX}/avalancheup-aws
+  cp /tmp/avalanche-ops-cache/avalancheup-aws "${DEPLOY_ARTIFACT_PREFIX}/avalancheup-aws"
   echo 'found avalanche-ops in cache'
 else
   wget https://github.com/ava-labs/avalanche-ops/releases/download/latest/avalancheup-aws.aarch64-apple-darwin
-  mv ./avalancheup-aws.aarch64-apple-darwin ${DEPLOY_ARTIFACT_PREFIX}/avalancheup-aws
-  chmod +x ${DEPLOY_ARTIFACT_PREFIX}/avalancheup-aws
-  cp ${DEPLOY_ARTIFACT_PREFIX}/avalancheup-aws /tmp/avalanche-ops-cache/avalancheup-aws
+  mv ./avalancheup-aws.aarch64-apple-darwin "${DEPLOY_ARTIFACT_PREFIX}/avalancheup-aws"
+  chmod +x "${DEPLOY_ARTIFACT_PREFIX}/avalancheup-aws"
+  cp "${DEPLOY_ARTIFACT_PREFIX}/avalancheup-aws" /tmp/avalanche-ops-cache/avalancheup-aws
 fi
-${DEPLOY_ARTIFACT_PREFIX}/avalancheup-aws --help
+"${DEPLOY_ARTIFACT_PREFIX}/avalancheup-aws" --help
 
 # Install token-cli
 echo 'installing token-cli...'
 if [ -f /tmp/avalanche-ops-cache/token-cli ]; then
-  cp /tmp/avalanche-ops-cache/token-cli ${DEPLOY_ARTIFACT_PREFIX}/token-cli
+  cp /tmp/avalanche-ops-cache/token-cli "${DEPLOY_ARTIFACT_PREFIX}/token-cli"
   echo 'found token-cli in cache'
 else
   wget "https://github.com/ava-labs/hypersdk/releases/download/v${HYPERSDK_VERSION}/tokenvm_${HYPERSDK_VERSION}_${DEPLOYER_OS_TYPE}_${DEPLOYER_ARCH_TYPE}.tar.gz"
   mkdir -p /tmp/token-installs
-  tar -xvf tokenvm_${HYPERSDK_VERSION}_${DEPLOYER_OS_TYPE}_${DEPLOYER_ARCH_TYPE}.tar.gz -C /tmp/token-installs
-  rm -rf tokenvm_${HYPERSDK_VERSION}_${DEPLOYER_OS_TYPE}_${DEPLOYER_ARCH_TYPE}.tar.gz
-  mv /tmp/token-installs/token-cli ${DEPLOY_ARTIFACT_PREFIX}/token-cli
+  tar -xvf "tokenvm_${HYPERSDK_VERSION}_${DEPLOYER_OS_TYPE}_${DEPLOYER_ARCH_TYPE}.tar.gz" -C /tmp/token-installs
+  rm -rf "tokenvm_${HYPERSDK_VERSION}_${DEPLOYER_OS_TYPE}_${DEPLOYER_ARCH_TYPE}.tar.gz"
+  mv /tmp/token-installs/token-cli "${DEPLOY_ARTIFACT_PREFIX}/token-cli"
   rm -rf /tmp/token-installs
-  cp ${DEPLOY_ARTIFACT_PREFIX}/token-cli /tmp/avalanche-ops-cache/token-cli
+  cp "${DEPLOY_ARTIFACT_PREFIX}/token-cli" /tmp/avalanche-ops-cache/token-cli
 fi
 
 # Download tokenvm
 echo 'downloading tokenvm...'
 if [ -f /tmp/avalanche-ops-cache/tokenvm ]; then
-  cp /tmp/avalanche-ops-cache/tokenvm ${DEPLOY_ARTIFACT_PREFIX}/tokenvm
-  cp /tmp/avalanche-ops-cache/token-cli-dev ${DEPLOY_ARTIFACT_PREFIX}/token-cli-dev
+  cp /tmp/avalanche-ops-cache/tokenvm "${DEPLOY_ARTIFACT_PREFIX}/tokenvm"
+  cp /tmp/avalanche-ops-cache/token-cli-dev "${DEPLOY_ARTIFACT_PREFIX}/token-cli-dev"
   echo 'found tokenvm in cache'
 else
   wget "https://github.com/ava-labs/hypersdk/releases/download/v${HYPERSDK_VERSION}/tokenvm_${HYPERSDK_VERSION}_linux_amd64.tar.gz"
   mkdir -p /tmp/token-installs
   tar -xvf tokenvm_${HYPERSDK_VERSION}_linux_amd64.tar.gz -C /tmp/token-installs
   rm -rf tokenvm_${HYPERSDK_VERSION}_linux_amd64.tar.gz
-  mv /tmp/token-installs/tokenvm ${DEPLOY_ARTIFACT_PREFIX}/tokenvm
-  mv /tmp/token-installs/token-cli ${DEPLOY_ARTIFACT_PREFIX}/token-cli-dev
+  mv /tmp/token-installs/tokenvm "${DEPLOY_ARTIFACT_PREFIX}/tokenvm"
+  mv /tmp/token-installs/token-cli "${DEPLOY_ARTIFACT_PREFIX}/token-cli-dev"
   rm -rf /tmp/token-installs
-  cp ${DEPLOY_ARTIFACT_PREFIX}/tokenvm /tmp/avalanche-ops-cache/tokenvm
-  cp ${DEPLOY_ARTIFACT_PREFIX}/token-cli-dev /tmp/avalanche-ops-cache/token-cli-dev
+  cp "${DEPLOY_ARTIFACT_PREFIX}/tokenvm" /tmp/avalanche-ops-cache/tokenvm
+  cp "${DEPLOY_ARTIFACT_PREFIX}/token-cli-dev" /tmp/avalanche-ops-cache/token-cli-dev
 fi
 
 # Setup genesis and configuration files
-cat <<EOF > ${DEPLOY_ARTIFACT_PREFIX}/tokenvm-subnet-config.json
+cat <<EOF > "${DEPLOY_ARTIFACT_PREFIX}/tokenvm-subnet-config.json"
 {
   "proposerMinBlockDelay": 0,
   "proposerNumHistoricalBlocks": 50000
 }
 EOF
-cat ${DEPLOY_ARTIFACT_PREFIX}/tokenvm-subnet-config.json
+cat "${DEPLOY_ARTIFACT_PREFIX}/tokenvm-subnet-config.json"
 
 # TODO: make address configurable via ENV
-cat <<EOF > ${DEPLOY_ARTIFACT_PREFIX}/allocations.json
+cat <<EOF > "${DEPLOY_ARTIFACT_PREFIX}/allocations.json"
 [
   {"address":"token1rvzhmceq997zntgvravfagsks6w0ryud3rylh4cdvayry0dl97nsjzf3yp", "balance":1000000000000000}
 ]
@@ -123,14 +125,14 @@ EOF
 #
 # TODO: make fee params configurable via ENV
 MAX_UINT64=18446744073709551615
-${DEPLOY_ARTIFACT_PREFIX}/token-cli genesis generate ${DEPLOY_ARTIFACT_PREFIX}/allocations.json \
---genesis-file ${DEPLOY_ARTIFACT_PREFIX}/tokenvm-genesis.json \
+"${DEPLOY_ARTIFACT_PREFIX}/token-cli" genesis generate "${DEPLOY_ARTIFACT_PREFIX}/allocations.json" \
+--genesis-file "${DEPLOY_ARTIFACT_PREFIX}/tokenvm-genesis.json" \
 --max-block-units 1800000,${MAX_UINT64},${MAX_UINT64},${MAX_UINT64},${MAX_UINT64} \
 --window-target-units ${MAX_UINT64},${MAX_UINT64},${MAX_UINT64},${MAX_UINT64},${MAX_UINT64} \
 --min-block-gap 250
-cat ${DEPLOY_ARTIFACT_PREFIX}/tokenvm-genesis.json
+cat "${DEPLOY_ARTIFACT_PREFIX}/tokenvm-genesis.json"
 
-cat <<EOF > ${DEPLOY_ARTIFACT_PREFIX}/tokenvm-chain-config.json
+cat <<EOF > "${DEPLOY_ARTIFACT_PREFIX}/tokenvm-chain-config.json"
 {
   "logLevel": "info",
   "mempoolSize": 10000000,
@@ -146,19 +148,19 @@ cat <<EOF > ${DEPLOY_ARTIFACT_PREFIX}/tokenvm-chain-config.json
   "continuousProfilerDir":"/data/tokenvm-profiles"
 }
 EOF
-cat ${DEPLOY_ARTIFACT_PREFIX}/tokenvm-chain-config.json
+cat "${DEPLOY_ARTIFACT_PREFIX}/tokenvm-chain-config.json"
 
 # Plan network deploy
 if [ ! -f /tmp/avalanche-ops-cache/aws-profile ]; then
   echo 'what is your AWS profile name?'
-  read prof_name
-  echo ${prof_name} > /tmp/avalanche-ops-cache/aws-profile
+  read -r prof_name
+  echo "${prof_name}" > /tmp/avalanche-ops-cache/aws-profile
 fi
 AWS_PROFILE_NAME=$(cat "/tmp/avalanche-ops-cache/aws-profile")
 
 # Create spec file
 SPEC_FILE=./aops-${DATE}.yml
-echo created avalanche-ops spec file: ${SPEC_FILE}
+echo created avalanche-ops spec file: "${SPEC_FILE}"
 
 # Create key file dir
 KEY_FILES_DIR=keys
@@ -170,11 +172,11 @@ cat <<EOF > "${DEPLOY_ARTIFACT_PREFIX}/metrics.yml"
 filters:
   - regex: ^*$
 EOF
-cat ${DEPLOY_ARTIFACT_PREFIX}/metrics.yml
+cat "${DEPLOY_ARTIFACT_PREFIX}/metrics.yml"
 
 echo 'planning DEVNET deploy...'
 # TODO: increase size once dev machine is working
-${DEPLOY_ARTIFACT_PREFIX}/avalancheup-aws default-spec \
+"${DEPLOY_ARTIFACT_PREFIX}/avalancheup-aws" default-spec \
 --arch-type amd64 \
 --os-type ubuntu20.04 \
 --anchor-nodes 3 \
@@ -184,44 +186,44 @@ ${DEPLOY_ARTIFACT_PREFIX}/avalancheup-aws default-spec \
 --instance-types='{"us-west-2":["c5.4xlarge"],"us-east-2":["c5.4xlarge"],"eu-west-1":["c5.4xlarge"]}' \
 --ip-mode=ephemeral \
 --metrics-fetch-interval-seconds 0 \
---upload-artifacts-prometheus-metrics-rules-file-path ${DEPLOY_ARTIFACT_PREFIX}/metrics.yml \
+--upload-artifacts-prometheus-metrics-rules-file-path "${DEPLOY_ARTIFACT_PREFIX}/metrics.yml" \
 --network-name custom \
 --staking-amount-in-avax 2000 \
 --avalanchego-release-tag v${AVALANCHEGO_VERSION} \
 --create-dev-machine \
 --keys-to-generate 5 \
---subnet-config-file ${DEPLOY_ARTIFACT_PREFIX}/tokenvm-subnet-config.json \
---vm-binary-file ${DEPLOY_ARTIFACT_PREFIX}/tokenvm \
+--subnet-config-file "${DEPLOY_ARTIFACT_PREFIX}/tokenvm-subnet-config.json" \
+--vm-binary-file "${DEPLOY_ARTIFACT_PREFIX}/tokenvm" \
 --chain-name tokenvm \
---chain-genesis-file ${DEPLOY_ARTIFACT_PREFIX}/tokenvm-genesis.json \
---chain-config-file ${DEPLOY_ARTIFACT_PREFIX}/tokenvm-chain-config.json \
+--chain-genesis-file "${DEPLOY_ARTIFACT_PREFIX}/tokenvm-genesis.json" \
+--chain-config-file "${DEPLOY_ARTIFACT_PREFIX}/tokenvm-chain-config.json" \
 --enable-ssh \
---spec-file-path ${SPEC_FILE} \
+--spec-file-path "${SPEC_FILE}" \
 --key-files-dir ${KEY_FILES_DIR} \
---profile-name ${AWS_PROFILE_NAME}
+--profile-name "${AWS_PROFILE_NAME}"
 
 # Disable rate limits in config
 echo 'updating YAML with new rate limits...'
-yq -i '.avalanchego_config.throttler-inbound-validator-alloc-size = 10737418240' ${SPEC_FILE}
-yq -i '.avalanchego_config.throttler-inbound-at-large-alloc-size = 10737418240' ${SPEC_FILE}
-yq -i '.avalanchego_config.throttler-inbound-node-max-processing-msgs = 100000' ${SPEC_FILE}
-yq -i '.avalanchego_config.throttler-inbound-bandwidth-refill-rate = 1073741824' ${SPEC_FILE}
-yq -i '.avalanchego_config.throttler-inbound-bandwidth-max-burst-size = 1073741824' ${SPEC_FILE}
-yq -i '.avalanchego_config.throttler-inbound-cpu-validator-alloc = 100000' ${SPEC_FILE}
-yq -i '.avalanchego_config.throttler-inbound-disk-validator-alloc = 10737418240000' ${SPEC_FILE}
-yq -i '.avalanchego_config.throttler-outbound-validator-alloc-size = 10737418240' ${SPEC_FILE}
-yq -i '.avalanchego_config.throttler-outbound-at-large-alloc-size = 10737418240' ${SPEC_FILE}
-yq -i '.avalanchego_config.consensus-on-accept-gossip-validator-size = 10' ${SPEC_FILE}
-yq -i '.avalanchego_config.consensus-on-accept-gossip-non-validator-size = 0' ${SPEC_FILE}
-yq -i '.avalanchego_config.consensus-on-accept-gossip-peer-size = 10' ${SPEC_FILE}
-yq -i '.avalanchego_config.consensus-accepted-frontier-gossip-peer-size = 10' ${SPEC_FILE}
-yq -i '.avalanchego_config.consensus-app-concurrency = 8' ${SPEC_FILE}
-yq -i '.avalanchego_config.network-compression-type = "zstd"'  ${SPEC_FILE}
+yq -i '.avalanchego_config.throttler-inbound-validator-alloc-size = 10737418240' "${SPEC_FILE}"
+yq -i '.avalanchego_config.throttler-inbound-at-large-alloc-size = 10737418240' "${SPEC_FILE}"
+yq -i '.avalanchego_config.throttler-inbound-node-max-processing-msgs = 100000' "${SPEC_FILE}"
+yq -i '.avalanchego_config.throttler-inbound-bandwidth-refill-rate = 1073741824' "${SPEC_FILE}"
+yq -i '.avalanchego_config.throttler-inbound-bandwidth-max-burst-size = 1073741824' "${SPEC_FILE}"
+yq -i '.avalanchego_config.throttler-inbound-cpu-validator-alloc = 100000' "${SPEC_FILE}"
+yq -i '.avalanchego_config.throttler-inbound-disk-validator-alloc = 10737418240000' "${SPEC_FILE}"
+yq -i '.avalanchego_config.throttler-outbound-validator-alloc-size = 10737418240' "${SPEC_FILE}"
+yq -i '.avalanchego_config.throttler-outbound-at-large-alloc-size = 10737418240' "${SPEC_FILE}"
+yq -i '.avalanchego_config.consensus-on-accept-gossip-validator-size = 10' "${SPEC_FILE}"
+yq -i '.avalanchego_config.consensus-on-accept-gossip-non-validator-size = 0' "${SPEC_FILE}"
+yq -i '.avalanchego_config.consensus-on-accept-gossip-peer-size = 10' "${SPEC_FILE}"
+yq -i '.avalanchego_config.consensus-accepted-frontier-gossip-peer-size = 10' "${SPEC_FILE}"
+yq -i '.avalanchego_config.consensus-app-concurrency = 8' "${SPEC_FILE}"
+yq -i '.avalanchego_config.network-compression-type = "zstd"'  "${SPEC_FILE}"
 
 # Deploy DEVNET
 echo 'deploying DEVNET...'
-${DEPLOY_ARTIFACT_PREFIX}/avalancheup-aws apply \
---spec-file-path ${SPEC_FILE}
+"${DEPLOY_ARTIFACT_PREFIX}/avalancheup-aws" apply \
+--spec-file-path "${SPEC_FILE}"
 echo 'DEVNET deployed'
 
 # Prepare dev machine
@@ -229,24 +231,24 @@ echo 'DEVNET deployed'
 # TODO: prepare 1 dev machine per region
 echo 'setting up dev machine...'
 ACCESS_KEY=./aops-${DATE}-ec2-access.us-west-2.key
-chmod 400 ${ACCESS_KEY}
-DEV_MACHINE_IP=$(yq '.dev_machine_ips[0]' ${SPEC_FILE})
-until (scp -o "StrictHostKeyChecking=no" -i ${ACCESS_KEY} ${SPEC_FILE} ubuntu@${DEV_MACHINE_IP}:/home/ubuntu/aops.yml)
+chmod 400 "${ACCESS_KEY}"
+DEV_MACHINE_IP=$(yq '.dev_machine_ips[0]' "${SPEC_FILE}")
+until (scp -o "StrictHostKeyChecking=no" -i "${ACCESS_KEY}" "${SPEC_FILE}" "ubuntu@${DEV_MACHINE_IP}:/home/ubuntu/aops.yml")
 do
   # During initial setup, ssh access may fail
   echo 'scp failed...trying again'
   sleep 5
 done
-cd $pw
-scp -o "StrictHostKeyChecking=no" -i ${DEPLOY_PREFIX}/${ACCESS_KEY} ${DEPLOY_ARTIFACT_PREFIX}/token-cli-dev ubuntu@${DEV_MACHINE_IP}:/tmp/token-cli
-scp -o "StrictHostKeyChecking=no" -i ${DEPLOY_PREFIX}/${ACCESS_KEY} demo.pk ubuntu@${DEV_MACHINE_IP}:/home/ubuntu/demo.pk
-scp -o "StrictHostKeyChecking=no" -i ${DEPLOY_PREFIX}/${ACCESS_KEY} scripts/setup.dev-machine.sh ubuntu@${DEV_MACHINE_IP}:/home/ubuntu/setup.sh
-ssh -o "StrictHostKeyChecking=no" -i ${DEPLOY_PREFIX}/${ACCESS_KEY} ubuntu@${DEV_MACHINE_IP} /home/ubuntu/setup.sh
+cd "$pw"
+scp -o "StrictHostKeyChecking=no" -i "${DEPLOY_PREFIX}/${ACCESS_KEY}" "${DEPLOY_ARTIFACT_PREFIX}/token-cli-dev" "ubuntu@${DEV_MACHINE_IP}:/tmp/token-cli"
+scp -o "StrictHostKeyChecking=no" -i "${DEPLOY_PREFIX}/${ACCESS_KEY}" demo.pk "ubuntu@${DEV_MACHINE_IP}:/home/ubuntu/demo.pk"
+scp -o "StrictHostKeyChecking=no" -i "${DEPLOY_PREFIX}/${ACCESS_KEY}" scripts/setup.dev-machine.sh "ubuntu@${DEV_MACHINE_IP}:/home/ubuntu/setup.sh"
+ssh -o "StrictHostKeyChecking=no" -i "${DEPLOY_PREFIX}/${ACCESS_KEY}" "ubuntu@${DEV_MACHINE_IP}" /home/ubuntu/setup.sh
 echo 'setup dev machine'
 
 # Generate prometheus link
-${DEPLOY_ARTIFACT_PREFIX}/token-cli chain import-ops ${DEPLOY_PREFIX}/${SPEC_FILE}
-${DEPLOY_ARTIFACT_PREFIX}/token-cli prometheus generate --prometheus-start=false --prometheus-base-uri=http://${DEV_MACHINE_IP}:9090
+"${DEPLOY_ARTIFACT_PREFIX}/token-cli" chain import-ops "${DEPLOY_PREFIX}/${SPEC_FILE}"
+"${DEPLOY_ARTIFACT_PREFIX}/token-cli" prometheus generate --prometheus-start=false --prometheus-base-uri="http://${DEV_MACHINE_IP}:9090"
 
 # Print final logs
 cat << EOF

--- a/examples/tokenvm/scripts/run.sh
+++ b/examples/tokenvm/scripts/run.sh
@@ -44,22 +44,20 @@ if ${UNLIMITED_USAGE}; then
 fi
 
 echo "Running with:"
-echo AGO_LOGLEVEL: ${AGO_LOGLEVEL}
-echo LOGLEVEL: ${LOGLEVEL}
+echo AGO_LOGLEVEL: "${AGO_LOGLEVEL}"
+echo LOGLEVEL: "${LOGLEVEL}"
 echo VERSION: ${VERSION}
-echo MODE: ${MODE}
-echo STATESYNC_DELAY \(ns\): ${STATESYNC_DELAY}
-echo MIN_BLOCK_GAP \(ms\): ${MIN_BLOCK_GAP}
-echo STORE_TXS: ${STORE_TXS}
+echo MODE: "${MODE}"
+echo STATESYNC_DELAY \(ns\): "${STATESYNC_DELAY}"
+echo MIN_BLOCK_GAP \(ms\): "${MIN_BLOCK_GAP}"
+echo STORE_TXS: "${STORE_TXS}"
 echo WINDOW_TARGET_UNITS: ${WINDOW_TARGET_UNITS}
 echo MAX_BLOCK_UNITS: ${MAX_BLOCK_UNITS}
-echo ADDRESS: ${ADDRESS}
+echo ADDRESS: "${ADDRESS}"
 
 ############################
 # build avalanchego
 # https://github.com/ava-labs/avalanchego/releases
-GOARCH=$(go env GOARCH)
-GOOS=$(go env GOOS)
 TMPDIR=/tmp/hypersdk
 
 echo "working directory: $TMPDIR"
@@ -87,7 +85,7 @@ if [ ! -f "$AVALANCHEGO_PATH" ]; then
   ./scripts/build.sh
   mv build/avalanchego ${TMPDIR}/avalanchego-${VERSION}
 
-  cd ${CWD}
+  cd "${CWD}"
 else
   echo "using previously built avalanchego"
 fi
@@ -132,12 +130,12 @@ if [[ -z "${GENESIS_PATH}" ]]; then
   ${TMPDIR}/token-cli genesis generate ${TMPDIR}/allocations.json \
   --window-target-units ${WINDOW_TARGET_UNITS} \
   --max-block-units ${MAX_BLOCK_UNITS} \
-  --min-block-gap ${MIN_BLOCK_GAP} \
+  --min-block-gap "${MIN_BLOCK_GAP}" \
   --genesis-file ${TMPDIR}/tokenvm.genesis
 else
   echo "copying custom genesis file"
   rm -f ${TMPDIR}/tokenvm.genesis
-  cp ${GENESIS_PATH} ${TMPDIR}/tokenvm.genesis
+  cp "${GENESIS_PATH}" ${TMPDIR}/tokenvm.genesis
 fi
 
 ############################
@@ -226,7 +224,6 @@ $BIN server \
 --log-level verbo \
 --port=":12352" \
 --grpc-gateway-port=":12353" &
-PID=${!}
 
 ############################
 # By default, it runs all e2e test cases!
@@ -254,7 +251,7 @@ echo "running e2e tests"
 ./tests/e2e/e2e.test \
 --ginkgo.v \
 --network-runner-log-level verbo \
---avalanchego-log-level ${AGO_LOGLEVEL} \
+--avalanchego-log-level "${AGO_LOGLEVEL}" \
 --network-runner-grpc-endpoint="0.0.0.0:12352" \
 --network-runner-grpc-gateway-endpoint="0.0.0.0:12353" \
 --avalanchego-path=${AVALANCHEGO_PATH} \
@@ -263,7 +260,7 @@ echo "running e2e tests"
 --vm-config-path=${TMPDIR}/tokenvm.config \
 --subnet-config-path=${TMPDIR}/tokenvm.subnet \
 --output-path=${TMPDIR}/avalanchego-${VERSION}/output.yaml \
---mode=${MODE}
+--mode="${MODE}"
 
 ############################
 if [[ ${MODE} == "run" || ${MODE} == "run-single" ]]; then

--- a/examples/tokenvm/scripts/run.sh
+++ b/examples/tokenvm/scripts/run.sh
@@ -46,13 +46,13 @@ fi
 echo "Running with:"
 echo AGO_LOGLEVEL: "${AGO_LOGLEVEL}"
 echo LOGLEVEL: "${LOGLEVEL}"
-echo VERSION: ${VERSION}
+echo VERSION: "${VERSION}"
 echo MODE: "${MODE}"
 echo STATESYNC_DELAY \(ns\): "${STATESYNC_DELAY}"
 echo MIN_BLOCK_GAP \(ms\): "${MIN_BLOCK_GAP}"
 echo STORE_TXS: "${STORE_TXS}"
-echo WINDOW_TARGET_UNITS: ${WINDOW_TARGET_UNITS}
-echo MAX_BLOCK_UNITS: ${MAX_BLOCK_UNITS}
+echo WINDOW_TARGET_UNITS: "${WINDOW_TARGET_UNITS}"
+echo MAX_BLOCK_UNITS: "${MAX_BLOCK_UNITS}"
 echo ADDRESS: "${ADDRESS}"
 
 ############################
@@ -70,20 +70,20 @@ if [ ! -f "$AVALANCHEGO_PATH" ]; then
   CWD=$(pwd)
 
   # Clear old folders
-  rm -rf ${TMPDIR}/avalanchego-${VERSION}
-  mkdir -p ${TMPDIR}/avalanchego-${VERSION}
-  rm -rf ${TMPDIR}/avalanchego-src
-  mkdir -p ${TMPDIR}/avalanchego-src
+  rm -rf "${TMPDIR}"/avalanchego-"${VERSION}"
+  mkdir -p "${TMPDIR}"/avalanchego-"${VERSION}"
+  rm -rf "${TMPDIR}"/avalanchego-src
+  mkdir -p "${TMPDIR}"/avalanchego-src
 
   # Download src
-  cd ${TMPDIR}/avalanchego-src
+  cd "${TMPDIR}"/avalanchego-src
   git clone https://github.com/ava-labs/avalanchego.git
   cd avalanchego
-  git checkout ${VERSION}
+  git checkout "${VERSION}"
 
   # Build avalanchego
   ./scripts/build.sh
-  mv build/avalanchego ${TMPDIR}/avalanchego-${VERSION}
+  mv build/avalanchego "${TMPDIR}"/avalanchego-"${VERSION}"
 
   cd "${CWD}"
 else
@@ -96,18 +96,18 @@ fi
 echo "building tokenvm"
 
 # delete previous (if exists)
-rm -f ${TMPDIR}/avalanchego-${VERSION}/plugins/tHBYNu8ikqo4MWMHehC9iKB9mR5tB3DWzbkYmTfe9buWQ5GZ8
+rm -f "${TMPDIR}"/avalanchego-"${VERSION}"/plugins/tHBYNu8ikqo4MWMHehC9iKB9mR5tB3DWzbkYmTfe9buWQ5GZ8
 
 # rebuild with latest code
 go build \
--o ${TMPDIR}/avalanchego-${VERSION}/plugins/tHBYNu8ikqo4MWMHehC9iKB9mR5tB3DWzbkYmTfe9buWQ5GZ8 \
+-o "${TMPDIR}"/avalanchego-"${VERSION}"/plugins/tHBYNu8ikqo4MWMHehC9iKB9mR5tB3DWzbkYmTfe9buWQ5GZ8 \
 ./cmd/tokenvm
 
 echo "building token-cli"
-go build -v -o ${TMPDIR}/token-cli ./cmd/token-cli
+go build -v -o "${TMPDIR}"/token-cli ./cmd/token-cli
 
 # log everything in the avalanchego directory
-find ${TMPDIR}/avalanchego-${VERSION}
+find "${TMPDIR}"/avalanchego-"${VERSION}"
 
 ############################
 
@@ -119,23 +119,23 @@ find ${TMPDIR}/avalanchego-${VERSION}
 # if you are starting your own devnet (otherwise anyone can access
 # funds using the included demo.pk)
 echo "creating allocations file"
-cat <<EOF > ${TMPDIR}/allocations.json
+cat <<EOF > "${TMPDIR}"/allocations.json
 [{"address":"${ADDRESS}", "balance":10000000000000000000}]
 EOF
 
 GENESIS_PATH=$2
 if [[ -z "${GENESIS_PATH}" ]]; then
   echo "creating VM genesis file with allocations"
-  rm -f ${TMPDIR}/tokenvm.genesis
-  ${TMPDIR}/token-cli genesis generate ${TMPDIR}/allocations.json \
-  --window-target-units ${WINDOW_TARGET_UNITS} \
-  --max-block-units ${MAX_BLOCK_UNITS} \
+  rm -f "${TMPDIR}"/tokenvm.genesis
+  "${TMPDIR}"/token-cli genesis generate "${TMPDIR}"/allocations.json \
+  --window-target-units "${WINDOW_TARGET_UNITS}" \
+  --max-block-units "${MAX_BLOCK_UNITS}" \
   --min-block-gap "${MIN_BLOCK_GAP}" \
-  --genesis-file ${TMPDIR}/tokenvm.genesis
+  --genesis-file "${TMPDIR}"/tokenvm.genesis
 else
   echo "copying custom genesis file"
-  rm -f ${TMPDIR}/tokenvm.genesis
-  cp "${GENESIS_PATH}" ${TMPDIR}/tokenvm.genesis
+  rm -f "${TMPDIR}"/tokenvm.genesis
+  cp "${GENESIS_PATH}" "${TMPDIR}"/tokenvm.genesis
 fi
 
 ############################
@@ -146,9 +146,9 @@ fi
 # else malicious entities can attempt to stuff memory with dust orders to cause
 # an OOM.
 echo "creating vm config"
-rm -f ${TMPDIR}/tokenvm.config
-rm -rf ${TMPDIR}/tokenvm-e2e-profiles
-cat <<EOF > ${TMPDIR}/tokenvm.config
+rm -f "${TMPDIR}"/tokenvm.config
+rm -rf "${TMPDIR}"/tokenvm-e2e-profiles
+cat <<EOF > "${TMPDIR}"/tokenvm.config
 {
   "mempoolSize": 10000000,
   "mempoolSponsorSize": 10000000,
@@ -165,15 +165,15 @@ cat <<EOF > ${TMPDIR}/tokenvm.config
   "stateSyncServerDelay": ${STATESYNC_DELAY}
 }
 EOF
-mkdir -p ${TMPDIR}/tokenvm-e2e-profiles
+mkdir -p "${TMPDIR}"/tokenvm-e2e-profiles
 
 ############################
 
 ############################
 
 echo "creating subnet config"
-rm -f ${TMPDIR}/tokenvm.subnet
-cat <<EOF > ${TMPDIR}/tokenvm.subnet
+rm -f "${TMPDIR}"/tokenvm.subnet
+cat <<EOF > "${TMPDIR}"/tokenvm.subnet
 {
   "proposerMinBlockDelay": 0,
   "proposerNumHistoricalBlocks": 50000
@@ -204,7 +204,7 @@ ACK_GINKGO_RC=true ginkgo build ./tests/e2e
 ANR_REPO_PATH=github.com/ava-labs/avalanche-network-runner
 ANR_VERSION=90aa9ae77845665b7638404a2a5e6a4dcce6d489
 # version set
-go install -v ${ANR_REPO_PATH}@${ANR_VERSION}
+go install -v "${ANR_REPO_PATH}"@"${ANR_VERSION}"
 
 #################################
 # run "avalanche-network-runner" server
@@ -254,12 +254,12 @@ echo "running e2e tests"
 --avalanchego-log-level "${AGO_LOGLEVEL}" \
 --network-runner-grpc-endpoint="0.0.0.0:12352" \
 --network-runner-grpc-gateway-endpoint="0.0.0.0:12353" \
---avalanchego-path=${AVALANCHEGO_PATH} \
---avalanchego-plugin-dir=${AVALANCHEGO_PLUGIN_DIR} \
---vm-genesis-path=${TMPDIR}/tokenvm.genesis \
---vm-config-path=${TMPDIR}/tokenvm.config \
---subnet-config-path=${TMPDIR}/tokenvm.subnet \
---output-path=${TMPDIR}/avalanchego-${VERSION}/output.yaml \
+--avalanchego-path="${AVALANCHEGO_PATH}" \
+--avalanchego-plugin-dir="${AVALANCHEGO_PLUGIN_DIR}" \
+--vm-genesis-path="${TMPDIR}"/tokenvm.genesis \
+--vm-config-path="${TMPDIR}"/tokenvm.config \
+--subnet-config-path="${TMPDIR}"/tokenvm.subnet \
+--output-path="${TMPDIR}"/avalanchego-"${VERSION}"/output.yaml \
 --mode="${MODE}"
 
 ############################

--- a/examples/tokenvm/scripts/tests.lint.sh
+++ b/examples/tokenvm/scripts/tests.lint.sh
@@ -54,7 +54,8 @@ function test_license_header {
   local files=()
   while IFS= read -r line; do files+=("$line"); done < <(find . -type f -name '*.go' ! -name '*.pb.go' ! -name 'mock_*.go')
 
-  # ignore 3rd party code
+  # Provision of the list of flags requires word splitting, so disable the shellcheck
+  # shellcheck disable=SC2086
   go-license \
   --config ./license.yml \
   ${_addlicense_flags} \

--- a/examples/tokenvm/scripts/tests.load.sh
+++ b/examples/tokenvm/scripts/tests.load.sh
@@ -31,4 +31,4 @@ run \
 --vms 5 \
 --accts 10000 \
 --txs 500000 \
---trace=${TRACE}
+--trace="${TRACE}"

--- a/examples/tokenvm/scripts/tests.unit.sh
+++ b/examples/tokenvm/scripts/tests.unit.sh
@@ -15,4 +15,6 @@ if ! [[ "$0" =~ scripts/tests.unit.sh ]]; then
   exit 255
 fi
 
+# Provision of the list of tests requires word splitting, so disable the shellcheck
+# shellcheck disable=SC2046
 go test -race -timeout="10m" -coverprofile="coverage.out" -covermode="atomic" $(go list ./... | grep -v tests)

--- a/scripts/fix.lint.sh
+++ b/scripts/fix.lint.sh
@@ -14,7 +14,7 @@ fi
 
 echo "adding license header"
 go install -v github.com/palantir/go-license@latest
-go-license --config=./license.yml **/*.go
+go-license --config=./license.yml -- **/*.go
 
 echo "gofumpt files"
 go install mvdan.cc/gofumpt@latest

--- a/scripts/mock.gen.sh
+++ b/scripts/mock.gen.sh
@@ -26,10 +26,10 @@ go install -v github.com/palantir/go-license@latest
 input="scripts/mocks.mockgen.txt"
 while IFS= read -r line
 do
-  IFS='=' read src_import_path interface_name output_path <<< "${line}"
-  package_name=$(basename $(dirname $output_path))
+  IFS='=' read -r src_import_path interface_name output_path <<< "${line}"
+  package_name=$(basename "$(dirname "$output_path")")
   echo "Generating ${output_path}..."
-  mockgen -package=${package_name} -destination=${output_path} ${src_import_path} ${interface_name}
+  mockgen -package="${package_name}" -destination="${output_path}" "${src_import_path}" "${interface_name}"
 
   go-license \
   --config=./license.yml \

--- a/scripts/tests.lint.sh
+++ b/scripts/tests.lint.sh
@@ -49,7 +49,8 @@ function test_license_header {
   local files=()
   while IFS= read -r line; do files+=("$line"); done < <(find . -type f -name '*.go' ! -name '*.pb.go' ! -name 'mock_*.go')
 
-  # ignore 3rd party code
+  # Provision of the list of flags requires word splitting, so disable the shellcheck
+  # shellcheck disable=SC2086
   go-license \
   --config ./license.yml \
   ${_addlicense_flags} \

--- a/scripts/tests.shellcheck.sh
+++ b/scripts/tests.shellcheck.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+VERSION="v0.9.0"
+
+function get_version {
+  local target_path=$1
+  if command -v "${target_path}" > /dev/null; then
+    echo "v$("${target_path}" --version | grep version: | awk '{print $2}')"
+  fi
+}
+
+REPO_ROOT=$( cd "$( dirname "${BASH_SOURCE[0]}" )"; cd .. && pwd )
+
+SYSTEM_VERSION="$(get_version shellcheck)"
+if [[ "${SYSTEM_VERSION}" == "${VERSION}" ]]; then
+  SHELLCHECK=shellcheck
+else
+  # Try to install a local version
+  SHELLCHECK="${REPO_ROOT}/bin/shellcheck"
+  LOCAL_VERSION="$(get_version "${SHELLCHECK}")"
+  if [[ -z "${LOCAL_VERSION}" || "${LOCAL_VERSION}" != "${VERSION}" ]]; then
+    if which sw_vers &> /dev/null; then
+      echo "on macos, only x86_64 binaries are available so rosetta is required"
+      echo "to avoid using rosetta, install via homebrew: brew install shellcheck"
+      DIST=darwin.x86_64
+    else
+      # Linux - binaries for common arches *should* be available
+      arch="$(uname -i)"
+      DIST="linux.${arch}"
+    fi
+    curl -s -L "https://github.com/koalaman/shellcheck/releases/download/${VERSION}/shellcheck-${VERSION}.${DIST}.tar.xz" | tar Jxv -C /tmp > /dev/null
+    mkdir -p "$(dirname "${SHELLCHECK}")"
+    cp /tmp/shellcheck-"${VERSION}"/shellcheck "${SHELLCHECK}"
+  fi
+fi
+
+find "${REPO_ROOT}" -name "*.sh" -type f -print0 | xargs -0 "${SHELLCHECK}" "${@}"

--- a/scripts/tests.shellcheck.sh
+++ b/scripts/tests.shellcheck.sh
@@ -44,4 +44,10 @@ else
   fi
 fi
 
-find . -name "*.sh" -type f -printf '%P\0' | xargs -0 "${SHELLCHECK}" "${@}"
+# `find *` is the simplest way to ensure find does not include a
+# leading `.` in filenames it emits. A leading `.` will prevent the
+# use of `git apply` to fix reported shellcheck issues. This is
+# compatible with both macos and linux (unlike the use of -printf).
+#
+# shellcheck disable=SC2035
+find * -name "*.sh" -type f -print0 | xargs -0 "${SHELLCHECK}" "${@}"

--- a/scripts/tests.shellcheck.sh
+++ b/scripts/tests.shellcheck.sh
@@ -2,6 +2,16 @@
 
 set -euo pipefail
 
+# This script can also be used to correct the problems detected by shellcheck by invoking as follows:
+#
+# ./scripts/tests.shellcheck.sh -f diff | git apply
+#
+
+if ! [[ "$0" =~ scripts/tests.shellcheck.sh ]]; then
+  echo "must be run from repository root"
+  exit 255
+fi
+
 VERSION="v0.9.0"
 
 function get_version {
@@ -11,14 +21,12 @@ function get_version {
   fi
 }
 
-REPO_ROOT=$( cd "$( dirname "${BASH_SOURCE[0]}" )"; cd .. && pwd )
-
 SYSTEM_VERSION="$(get_version shellcheck)"
 if [[ "${SYSTEM_VERSION}" == "${VERSION}" ]]; then
   SHELLCHECK=shellcheck
 else
   # Try to install a local version
-  SHELLCHECK="${REPO_ROOT}/bin/shellcheck"
+  SHELLCHECK=./bin/shellcheck
   LOCAL_VERSION="$(get_version "${SHELLCHECK}")"
   if [[ -z "${LOCAL_VERSION}" || "${LOCAL_VERSION}" != "${VERSION}" ]]; then
     if which sw_vers &> /dev/null; then
@@ -36,4 +44,4 @@ else
   fi
 fi
 
-find "${REPO_ROOT}" -name "*.sh" -type f -print0 | xargs -0 "${SHELLCHECK}" "${@}"
+find . -name "*.sh" -type f -printf '%P\0' | xargs -0 "${SHELLCHECK}" "${@}"

--- a/scripts/tests.unit.sh
+++ b/scripts/tests.unit.sh
@@ -15,4 +15,6 @@ HYPERSDK_PATH=$(
 )
 source "$HYPERSDK_PATH"/scripts/constants.sh
 
+# Provision of the list of tests requires word splitting, so disable the shellcheck
+# shellcheck disable=SC2046
 go test -race -timeout="3m" -coverprofile="coverage.out" -covermode="atomic" $(go list ./... | grep -v tests)


### PR DESCRIPTION
# #lintallthethings!

We lint code, why not shell scripts? In addition to simplifying the avoidance of common shell errors, the [shellcheck wiki](https://www.shellcheck.net/wiki) has lots of documentation for all the error types it checks for.

Execution is fast enough for the whole repo (1s) that I don't think there is any point in making a VM-specific check.

### Testing

In addition to CI, local testing on arm64 linux and macos verified the logic for downloading and using a local (vs one in the path) shellcheck.

Related: [AvalancheGo PR](https://github.com/ava-labs/avalanchego/pull/2650)

Closes #699