### PR TITLE
Validator driven transactions

### DIFF
--- a/chain/dependencies.go
+++ b/chain/dependencies.go
@@ -155,6 +155,9 @@ type Rules interface {
 
 	GetWarpConfig(sourceChainID ids.ID) (bool, uint64, uint64)
 
+	GetMinGapValidatorTransactions() int64 // timestamp
+	GetAllValidatorDrivenActions() []uint8 // action ids
+
 	FetchCustom(string) (any, bool)
 }
 

--- a/examples/morpheusvm/genesis/genesis.go
+++ b/examples/morpheusvm/genesis/genesis.go
@@ -59,6 +59,10 @@ type Genesis struct {
 
 	// Allocates
 	CustomAllocation []*CustomAllocation `json:"customAllocation"`
+
+	// Validator driven transactions
+	AllowedValidatorDrivenActions []uint8 `json:"allowedValidatorDrivenActions"`
+	MinGapValidatorTxs            int64   `json:"minGapValidatorTxs"`
 }
 
 func Default() *Genesis {
@@ -94,6 +98,10 @@ func Default() *Genesis {
 		StorageValueAllocateUnits: 5,
 		StorageKeyWriteUnits:      10,
 		StorageValueWriteUnits:    3,
+
+		AllowedValidatorDrivenActions: nil,
+		// -1 -> not enabled, 0 -> no gap is set, and other gaps
+		MinGapValidatorTxs: -1,
 	}
 }
 

--- a/examples/morpheusvm/genesis/rules.go
+++ b/examples/morpheusvm/genesis/rules.go
@@ -110,3 +110,11 @@ func (r *Rules) GetWindowTargetUnits() chain.Dimensions {
 func (*Rules) FetchCustom(string) (any, bool) {
 	return nil, false
 }
+
+func (r *Rules) GetMinGapValidatorTransactions() int64 {
+	return r.g.MinGapValidatorTxs
+}
+
+func (r *Rules) GetAllValidatorDrivenActions() []uint8 {
+	return r.g.AllowedValidatorDrivenActions
+}

--- a/examples/tokenvm/genesis/genesis.go
+++ b/examples/tokenvm/genesis/genesis.go
@@ -60,6 +60,10 @@ type Genesis struct {
 
 	// Allocates
 	CustomAllocation []*CustomAllocation `json:"customAllocation"`
+
+	// Validator driven transactions
+	AllowedValidatorDrivenActions []uint8 `json:"allowedValidatorDrivenActions"`
+	MinGapValidatorTxs            int64   `json:"minGapValidatorTxs"`
 }
 
 func Default() *Genesis {
@@ -95,6 +99,10 @@ func Default() *Genesis {
 		StorageValueAllocateUnits: 5,
 		StorageKeyWriteUnits:      10,
 		StorageValueWriteUnits:    3,
+
+		AllowedValidatorDrivenActions: nil,
+		// -1 -> not enabled, 0 -> no gap is set, and other gaps
+		MinGapValidatorTxs: -1,
 	}
 }
 

--- a/examples/tokenvm/genesis/rules.go
+++ b/examples/tokenvm/genesis/rules.go
@@ -114,3 +114,11 @@ func (r *Rules) GetWindowTargetUnits() chain.Dimensions {
 func (*Rules) FetchCustom(string) (any, bool) {
 	return nil, false
 }
+
+func (r *Rules) GetMinGapValidatorTransactions() int64 {
+	return r.g.MinGapValidatorTxs
+}
+
+func (r *Rules) GetAllValidatorDrivenActions() []uint8 {
+	return r.g.AllowedValidatorDrivenActions
+}


### PR DESCRIPTION
### Context
This PR covers: #336. This is a guess work of how the _Validator Driven Transactions_ should work. The idea is to use rules from genesis to check if the transaction is validator driven then use a flag to bypass some operations that's only needed by authenticated transactions. 

### Tests
e2e tests were passes but haven't been updated since I need to know if it's the right direction 