### PR TITLE
`ci`: Upgrade all workflow actions to versions using Node 20

### DIFF
--- a/.github/workflows/auto-generated-checker.yml
+++ b/.github/workflows/auto-generated-checker.yml
@@ -10,9 +10,9 @@ jobs:
     name: Mocks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "1.20"
           check-latest: true

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
@@ -51,11 +51,11 @@ jobs:
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
-        
+
         # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         queries: security-extended,security-and-quality
 
-        
+
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
@@ -64,7 +64,7 @@ jobs:
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
 
-    #   If the Autobuild fails above, remove it and uncomment the following three lines. 
+    #   If the Autobuild fails above, remove it and uncomment the following three lines.
     #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
 
     # - run: |

--- a/.github/workflows/hypersdk-static-analysis.yml
+++ b/.github/workflows/hypersdk-static-analysis.yml
@@ -15,9 +15,9 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "1.20"
           check-latest: true

--- a/.github/workflows/hypersdk-unit-tests.yml
+++ b/.github/workflows/hypersdk-unit-tests.yml
@@ -17,9 +17,9 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "1.20"
           check-latest: true

--- a/.github/workflows/morpheusvm-load-tests.yml
+++ b/.github/workflows/morpheusvm-load-tests.yml
@@ -21,9 +21,9 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "1.20"
           check-latest: true

--- a/.github/workflows/morpheusvm-release.yml
+++ b/.github/workflows/morpheusvm-release.yml
@@ -19,9 +19,9 @@ jobs:
     if: ${{ github.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/tags/v') || contains(github.event.pull_request.labels.*.name, 'run all ci') }}
     steps:
       - name: Git checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "1.20"
           check-latest: true

--- a/.github/workflows/morpheusvm-static-analysis.yml
+++ b/.github/workflows/morpheusvm-static-analysis.yml
@@ -16,9 +16,9 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "1.20"
           check-latest: true

--- a/.github/workflows/morpheusvm-sync-tests.yml
+++ b/.github/workflows/morpheusvm-sync-tests.yml
@@ -18,9 +18,9 @@ jobs:
     timeout-minutes: 25
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "1.20"
           check-latest: true

--- a/.github/workflows/morpheusvm-unit-tests.yml
+++ b/.github/workflows/morpheusvm-unit-tests.yml
@@ -18,9 +18,9 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "1.20"
           check-latest: true
@@ -37,12 +37,12 @@ jobs:
         shell: bash
         run: scripts/tests.integration.sh
       - name: Archive code coverage results (text)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: code-coverage-out
           path: ./examples/morpheusvm/integration.coverage.out
       - name: Archive code coverage results (html)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: code-coverage-html
           path: ./examples/morpheusvm/integration.coverage.html

--- a/.github/workflows/rust-static-analysis.yml
+++ b/.github/workflows/rust-static-analysis.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Rust
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/tidy-checker.yml
+++ b/.github/workflows/tidy-checker.yml
@@ -10,9 +10,9 @@ jobs:
     name: Tidy
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "1.20"
           check-latest: true

--- a/.github/workflows/tokenvm-load-tests.yml
+++ b/.github/workflows/tokenvm-load-tests.yml
@@ -21,9 +21,9 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "1.20"
           check-latest: true

--- a/.github/workflows/tokenvm-release.yml
+++ b/.github/workflows/tokenvm-release.yml
@@ -18,9 +18,9 @@ jobs:
     if: ${{ github.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/tags/v') || contains(github.event.pull_request.labels.*.name, 'run all ci') }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "1.20"
           check-latest: true
@@ -35,7 +35,7 @@ jobs:
         env:
           PUBLISH: false
       - name: Archive Builds
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: token-wallet
           path: ./examples/tokenvm/cmd/token-wallet/token-wallet.zip
@@ -46,9 +46,9 @@ jobs:
     if: ${{ github.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/tags/v') || contains(github.event.pull_request.labels.*.name, 'run all ci') }}
     steps:
       - name: Git checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "1.20"
           check-latest: true

--- a/.github/workflows/tokenvm-static-analysis.yml
+++ b/.github/workflows/tokenvm-static-analysis.yml
@@ -16,9 +16,9 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "1.20"
           check-latest: true

--- a/.github/workflows/tokenvm-sync-tests.yml
+++ b/.github/workflows/tokenvm-sync-tests.yml
@@ -18,9 +18,9 @@ jobs:
     timeout-minutes: 25
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "1.20"
           check-latest: true

--- a/.github/workflows/tokenvm-unit-tests.yml
+++ b/.github/workflows/tokenvm-unit-tests.yml
@@ -18,9 +18,9 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "1.20"
           check-latest: true
@@ -37,12 +37,12 @@ jobs:
         shell: bash
         run: scripts/tests.integration.sh
       - name: Archive code coverage results (text)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: code-coverage-out
           path: ./examples/tokenvm/integration.coverage.out
       - name: Archive code coverage results (html)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: code-coverage-html
           path: ./examples/tokenvm/integration.coverage.html


### PR DESCRIPTION
Node 16 is deprecated and all the actions using 16 are adding warnings to our jobs that risk obscurring more important notifications.

Ref: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/