### PR TITLE
[x/programs] Force `#[public]` functions to be `pub`

### DIFF
--- a/x/programs/rust/examples/counter/src/lib.rs
+++ b/x/programs/rust/examples/counter/src/lib.rs
@@ -8,7 +8,7 @@ enum StateKeys {
 
 /// Initializes the program address a count of 0.
 #[public]
-fn initialize_address(program: Program, address: Address) -> bool {
+pub fn initialize_address(program: Program, address: Address) -> bool {
     if program
         .state()
         .get::<i64, _>(StateKeys::Counter(address))
@@ -27,7 +27,7 @@ fn initialize_address(program: Program, address: Address) -> bool {
 
 /// Increments the count at the address by the amount.
 #[public]
-fn inc(program: Program, to: Address, amount: i64) -> bool {
+pub fn inc(program: Program, to: Address, amount: i64) -> bool {
     let counter = amount + get_value(program, to);
 
     program
@@ -40,7 +40,7 @@ fn inc(program: Program, to: Address, amount: i64) -> bool {
 
 /// Increments the count at the address by the amount for an external program.
 #[public]
-fn inc_external(_: Program, target: Program, max_units: i64, of: Address, amount: i64) -> i64 {
+pub fn inc_external(_: Program, target: Program, max_units: i64, of: Address, amount: i64) -> i64 {
     target
         .call_function("inc", params!(&of, &amount), max_units)
         .unwrap()
@@ -48,7 +48,7 @@ fn inc_external(_: Program, target: Program, max_units: i64, of: Address, amount
 
 /// Gets the count at the address.
 #[public]
-fn get_value(program: Program, of: Address) -> i64 {
+pub fn get_value(program: Program, of: Address) -> i64 {
     program
         .state()
         .get(StateKeys::Counter(of))
@@ -57,7 +57,7 @@ fn get_value(program: Program, of: Address) -> i64 {
 
 /// Gets the count at the address for an external program.
 #[public]
-fn get_value_external(_: Program, target: Program, max_units: i64, of: Address) -> i64 {
+pub fn get_value_external(_: Program, target: Program, max_units: i64, of: Address) -> i64 {
     target
         .call_function("get_value", params!(&of), max_units)
         .unwrap()

--- a/x/programs/rust/examples/token/src/lib.rs
+++ b/x/programs/rust/examples/token/src/lib.rs
@@ -275,7 +275,7 @@ mod tests {
                 "get_balance",
                 vec![
                     Param {
-                        value: program_id.into(),
+                        value: program_id,
                         param_type: ParamType::Id,
                     },
                     Param {
@@ -314,6 +314,6 @@ mod tests {
             .program_create::<PlanResponse>("owner", p_path.as_ref())
             .unwrap();
         assert_eq!(resp.error, None);
-        assert_eq!(resp.result.id.is_some(), true);
+        assert!(resp.result.id.is_some());
     }
 }

--- a/x/programs/rust/sdk_macros/src/lib.rs
+++ b/x/programs/rust/sdk_macros/src/lib.rs
@@ -5,7 +5,9 @@ use core::panic;
 use proc_macro::TokenStream;
 use proc_macro2::Span;
 use quote::quote;
-use syn::{parse_macro_input, Fields, FnArg, Ident, ItemEnum, ItemFn, Pat, PatType, Type};
+use syn::{
+    parse_macro_input, Fields, FnArg, Ident, ItemEnum, ItemFn, Pat, PatType, Type, Visibility,
+};
 
 fn convert_param(param_name: &Ident) -> proc_macro2::TokenStream {
     quote! {
@@ -21,6 +23,12 @@ fn convert_param(param_name: &Ident) -> proc_macro2::TokenStream {
 #[proc_macro_attribute]
 pub fn public(_: TokenStream, item: TokenStream) -> TokenStream {
     let input = parse_macro_input!(item as ItemFn);
+
+    if !matches!(input.vis, Visibility::Public(_)) {
+        let name = &input.sig.ident;
+        panic!("Function `{name}` must be pub to be marked with the `#[public]` attribute.");
+    }
+
     let name = &input.sig.ident;
     let input_args = &input.sig.inputs;
     let new_name = Ident::new(&format!("{}_guest", name), name.span()); // Create a new name for the generated function(name that will be called by the host)

--- a/x/programs/rust/wasmlanche_sdk/src/memory.rs
+++ b/x/programs/rust/wasmlanche_sdk/src/memory.rs
@@ -207,7 +207,7 @@ mod tests {
             let result = memory.range(data.len());
             assert_eq!(result, data);
             let data = vec![9, 9, 2];
-            memory.write(&data);
+            memory.write(data);
             let result = memory.range(ptr_len);
             assert_eq!(result, vec![9, 9, 2, 4, 5]);
         };


### PR DESCRIPTION
Closes #720

I know this is redundant, but it's better to force all the signatures to look the same. Prior to this change, `pub`, inherited, or `pub(restriction)` worked and made no difference. 

Error if `pub` isn't included
```sh
    Checking token v0.1.0 (/Users/richardpringle/code/hypersdk/x/programs/rust/examples/token)
error: custom attribute panicked
  --> x/programs/rust/examples/token/src/lib.rs:18:1
   |
18 | #[public]
   | ^^^^^^^^^
   |
   = help: message: Function `init` must be pub to be marked with the `#[public]` attribute.

error: could not compile `token` (lib) due to previous error
```

