### PR TITLE
Use dtolnay Rust installation

### DIFF
--- a/.github/workflows/program-simulator-tests.yml
+++ b/.github/workflows/program-simulator-tests.yml
@@ -22,12 +22,7 @@ jobs:
           check-latest: true
           cache: true
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          profile: minimal
-          components: rustfmt, clippy
-          override: true
+        uses: dtolnay/rust-toolchain@stable
       - name: Run token simulator test
         working-directory: ./x/programs/rust/examples/token
         shell: bash


### PR DESCRIPTION
This installation is much more commonly used by very popular projects. It seems to just work better too. I'm not sure why nightly was even being used before

