### PR TITLE
Rename "smart-pointer" on the Rust side

### DIFF
--- a/x/programs/rust/sdk_macros/src/lib.rs
+++ b/x/programs/rust/sdk_macros/src/lib.rs
@@ -11,7 +11,7 @@ use syn::{
 
 fn convert_param(param_name: &Ident) -> proc_macro2::TokenStream {
     quote! {
-        unsafe { wasmlanche_sdk::memory::from_smart_ptr(#param_name).expect("error serializing ptr") }
+        unsafe { wasmlanche_sdk::memory::from_host_ptr(#param_name).expect("error serializing ptr") }
     }
 }
 

--- a/x/programs/rust/wasmlanche_sdk/src/host/program.rs
+++ b/x/programs/rust/wasmlanche_sdk/src/host/program.rs
@@ -1,6 +1,6 @@
 //! The `program` module provides functions for calling other programs.
 use crate::errors::StateError;
-use crate::memory::to_smart_ptr;
+use crate::memory::to_host_ptr;
 use crate::program::Program;
 
 #[link(wasm_import_module = "program")]
@@ -16,9 +16,9 @@ pub(crate) fn call(
     args: &[u8],
     max_units: i64,
 ) -> Result<i64, StateError> {
-    let target = to_smart_ptr(target.id())?;
-    let function = to_smart_ptr(function_name.as_bytes())?;
-    let args = to_smart_ptr(args)?;
+    let target = to_host_ptr(target.id())?;
+    let function = to_host_ptr(function_name.as_bytes())?;
+    let args = to_host_ptr(args)?;
 
     Ok(unsafe { _call_program(target, function, args, max_units) })
 }

--- a/x/programs/rust/wasmlanche_sdk/src/host/state.rs
+++ b/x/programs/rust/wasmlanche_sdk/src/host/state.rs
@@ -1,7 +1,7 @@
 //! The `state` module provides functions for interacting with persistent
 //! storage exposed by the host.
 use crate::errors::StateError;
-use crate::memory::to_smart_ptr;
+use crate::memory::to_host_ptr;
 use crate::{program::Program, state::Key};
 use borsh::{to_vec, BorshSerialize};
 
@@ -21,9 +21,9 @@ where
 {
     let value_bytes = to_vec(value).map_err(|_| StateError::Serialization)?;
     // prepend length to both key & value
-    let caller = to_smart_ptr(caller.id())?;
-    let value = to_smart_ptr(&value_bytes)?;
-    let key = to_smart_ptr(key)?;
+    let caller = to_host_ptr(caller.id())?;
+    let value = to_host_ptr(&value_bytes)?;
+    let key = to_host_ptr(key)?;
 
     match unsafe { _put(caller, key, value) } {
         0 => Ok(()),
@@ -34,7 +34,7 @@ where
 /// Gets the bytes associated with the key from the host.
 pub(crate) unsafe fn get_bytes(caller: &Program, key: &Key) -> Result<i64, StateError> {
     // prepend length to key
-    let caller = to_smart_ptr(caller.id())?;
-    let key = to_smart_ptr(key)?;
+    let caller = to_host_ptr(caller.id())?;
+    let key = to_host_ptr(key)?;
     Ok(unsafe { _get(caller, key) })
 }

--- a/x/programs/rust/wasmlanche_sdk/src/state.rs
+++ b/x/programs/rust/wasmlanche_sdk/src/state.rs
@@ -1,7 +1,7 @@
 use crate::{
     errors::StateError,
     host::{get_bytes, put_bytes},
-    memory::from_smart_ptr,
+    memory::from_host_ptr,
     program::Program,
 };
 use borsh::{BorshDeserialize, BorshSerialize};
@@ -51,7 +51,7 @@ impl State {
         }
 
         // Wrap in OK for now, change from_raw_ptr to return Result
-        unsafe { from_smart_ptr(val_ptr) }
+        unsafe { from_host_ptr(val_ptr) }
     }
 }
 


### PR DESCRIPTION
While this is a little silly, "smart pointers" are an explicit concept in Rust [^1].

[^1]: https://doc.rust-lang.org/book/ch15-00-smart-pointers.html

