### PR TITLE
x/programs: fix simulator test type error

### DIFF
--- a/x/programs/cmd/simulator/cmd/config_test.go
+++ b/x/programs/cmd/simulator/cmd/config_test.go
@@ -12,7 +12,7 @@ import (
 func TestValidateAssertion(t *testing.T) {
 	require := require.New(t)
 	tests := []struct {
-		actual    uint64
+		actual    int64
 		assertion Require
 		expected  bool
 		wantErr   bool


### PR DESCRIPTION
This should be merged because running a `go test` fails in x/programs simulator.