### PR TITLE
[x/programs] poc - simulator over grpc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [
     "x/programs/rust/sdk_macros",
     "x/programs/rust/wasmlanche_sdk",
     "x/programs/rust/examples/token",
-    "x/programs/rust/examples/counter",
+    "x/programs/rust/examples/counter", "x/programs/rust/simulator_client",
 ]
 resolver = "2"
 

--- a/x/programs/cmd/simulator/cmd/root.go
+++ b/x/programs/cmd/simulator/cmd/root.go
@@ -4,41 +4,12 @@
 package cmd
 
 import (
-	"context"
-	"encoding/json"
 	"fmt"
 	"os"
-	"path"
 
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
-
-	"github.com/ava-labs/avalanchego/api/metrics"
-	"github.com/ava-labs/avalanchego/ids"
-	"github.com/ava-labs/avalanchego/snow"
-	"github.com/ava-labs/avalanchego/snow/engine/common"
-	"github.com/ava-labs/avalanchego/utils/crypto/bls"
-	"github.com/ava-labs/avalanchego/utils/logging"
-	"github.com/ava-labs/hypersdk/pebble"
-	"github.com/ava-labs/hypersdk/state"
-	"github.com/ava-labs/hypersdk/vm"
-
-	"github.com/ava-labs/hypersdk/x/programs/cmd/simulator/vm/controller"
-	"github.com/ava-labs/hypersdk/x/programs/cmd/simulator/vm/genesis"
 )
-
-const (
-	simulatorFolder = ".simulator"
-)
-
-type simulator struct {
-	log      logging.Logger
-	logLevel string
-
-	vm      *vm.VM
-	db      *state.SimpleMutable
-	genesis *genesis.Genesis
-}
 
 func NewRootCmd() *cobra.Command {
 	s := &simulator{}
@@ -84,98 +55,4 @@ func NewRootCmd() *cobra.Command {
 	})
 
 	return cmd
-}
-
-func (s *simulator) Init() error {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return nil
-	}
-	basePath := path.Join(homeDir, simulatorFolder)
-	dbPath := path.Join(basePath, "db")
-
-	// TODO: allow for user defined ids.
-	nodeID := ids.GenerateTestNodeID()
-	networkID := uint32(1)
-	subnetID := ids.GenerateTestID()
-	chainID := ids.GenerateTestID()
-
-	loggingConfig := logging.Config{}
-	loggingConfig.LogLevel, err = logging.ToLevel(s.logLevel)
-	if err != nil {
-		return err
-	}
-	loggingConfig.Directory = path.Join(basePath, "logs")
-	loggingConfig.LogFormat = logging.JSON
-	loggingConfig.DisableWriterDisplaying = true
-
-	// setup simulator logger
-	logFactory := newLogFactory(loggingConfig)
-	s.log, err = logFactory.Make("simulator")
-	if err != nil {
-		logFactory.Close()
-		return nil
-	}
-
-	sk, err := bls.NewSecretKey()
-	if err != nil {
-		return nil
-	}
-
-	// setup pebble and db manager
-	pdb, _, err := pebble.New(dbPath, pebble.NewDefaultConfig())
-	if err != nil {
-		return nil
-	}
-
-	genesisBytes, err := json.Marshal(genesis.Default())
-	if err != nil {
-		return nil
-	}
-
-	snowCtx := &snow.Context{
-		NetworkID:    networkID,
-		SubnetID:     subnetID,
-		ChainID:      chainID,
-		NodeID:       nodeID,
-		Log:          logging.NoLog{}, // TODO: use real logger
-		ChainDataDir: dbPath,
-		Metrics:      metrics.NewOptionalGatherer(),
-		PublicKey:    bls.PublicFromSecretKey(sk),
-	}
-
-	toEngine := make(chan common.Message, 1)
-
-	// initialize the simulator VM
-	vm := controller.New()
-	err = vm.Initialize(
-		context.TODO(),
-		snowCtx,
-		pdb,
-		genesisBytes,
-		nil,
-		nil,
-		toEngine,
-		nil,
-		nil,
-	)
-	if err != nil {
-		return err
-	}
-	s.vm = vm
-	// force the vm to be ready because it has no peers.
-	s.vm.ForceReady()
-
-	stateDB, err := s.vm.State()
-	if err != nil {
-		return err
-	}
-	s.db = state.NewSimpleMutable(stateDB)
-	s.genesis = genesis.Default()
-
-	s.log.Info("simulator initialized",
-		zap.String("log-level", s.logLevel),
-	)
-
-	return nil
 }

--- a/x/programs/cmd/simulator/cmd/simulator.go
+++ b/x/programs/cmd/simulator/cmd/simulator.go
@@ -1,0 +1,152 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path"
+
+	"github.com/ava-labs/avalanchego/api/metrics"
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/snow"
+	"github.com/ava-labs/avalanchego/snow/engine/common"
+	"github.com/ava-labs/avalanchego/utils/crypto/bls"
+	"github.com/ava-labs/avalanchego/utils/logging"
+	"github.com/ava-labs/hypersdk/crypto/ed25519"
+	"github.com/ava-labs/hypersdk/pebble"
+	"github.com/ava-labs/hypersdk/state"
+	"github.com/ava-labs/hypersdk/vm"
+	"github.com/ava-labs/hypersdk/x/programs/cmd/simulator/vm/controller"
+	"github.com/ava-labs/hypersdk/x/programs/cmd/simulator/vm/genesis"
+	"go.uber.org/zap"
+)
+
+const (
+	simulatorFolder = ".simulator"
+)
+
+func NewSimulator(logLevel string) *simulator {
+	return &simulator{
+		logLevel: logLevel,
+	}
+}
+
+type simulator struct {
+	log      logging.Logger
+	logLevel string
+
+	vm      *vm.VM
+	db      *state.SimpleMutable
+	genesis *genesis.Genesis
+}
+
+func (s *simulator) GracefulStop(ctx context.Context) {
+	err := s.vm.Shutdown(ctx)
+	if err != nil {
+		s.log.Error("simulator vm closed with error",
+			zap.Error(err),
+		)
+	}
+}
+
+func (s *simulator) Init() error {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return nil
+	}
+	basePath := path.Join(homeDir, simulatorFolder)
+	dbPath := path.Join(basePath, "db")
+
+	// TODO: allow for user defined ids.
+	nodeID := ids.GenerateTestNodeID()
+	networkID := uint32(1)
+	subnetID := ids.GenerateTestID()
+	chainID := ids.GenerateTestID()
+
+	loggingConfig := logging.Config{}
+	loggingConfig.LogLevel, err = logging.ToLevel(s.logLevel)
+	if err != nil {
+		return fmt.Errorf("setting log level %v", err)
+	}
+	loggingConfig.Directory = path.Join(basePath, "logs")
+	loggingConfig.LogFormat = logging.JSON
+	loggingConfig.DisableWriterDisplaying = true
+
+	// setup simulator logger
+	logFactory := newLogFactory(loggingConfig)
+	s.log, err = logFactory.Make("simulator")
+	if err != nil {
+		logFactory.Close()
+		return nil
+	}
+	s.log.Info("simulator initializing",
+		zap.String("log-level", s.logLevel),
+	)
+
+	sk, err := bls.NewSecretKey()
+	if err != nil {
+		return nil
+	}
+
+	// setup pebble and db manager
+	pdb, _, err := pebble.New(dbPath, pebble.NewDefaultConfig())
+	if err != nil {
+		return nil
+	}
+
+	genesisBytes, err := json.Marshal(genesis.Default())
+	if err != nil {
+		return nil
+	}
+
+	snowCtx := &snow.Context{
+		NetworkID:    networkID,
+		SubnetID:     subnetID,
+		ChainID:      chainID,
+		NodeID:       nodeID,
+		Log:          logging.NoLog{}, // TODO: use real logger
+		ChainDataDir: dbPath,
+		Metrics:      metrics.NewOptionalGatherer(),
+		PublicKey:    bls.PublicFromSecretKey(sk),
+	}
+
+	toEngine := make(chan common.Message, 1)
+
+	// initialize the simulator VM
+	vm := controller.New()
+	err = vm.Initialize(
+		context.TODO(),
+		snowCtx,
+		pdb,
+		genesisBytes,
+		nil,
+		nil,
+		toEngine,
+		nil,
+		nil,
+	)
+	if err != nil {
+		return fmt.Errorf("vm init: %v", err)
+	}
+	s.vm = vm
+	// force the vm to be ready because it has no peers.
+	s.vm.ForceReady()
+
+	stateDB, err := s.vm.State()
+	if err != nil {
+		return err
+	}
+	s.db = state.NewSimpleMutable(stateDB)
+	s.genesis = genesis.Default()
+
+	s.log.Info("simulator initialized",
+		zap.String("log-level", s.logLevel),
+	)
+
+	return nil
+}
+
+func (s *simulator) CreateKey(ctx context.Context, name string) (ed25519.PublicKey, error) {
+	return keyCreateFunc(ctx, s.db, name)
+}

--- a/x/programs/cmd/simulator_api/api/service.proto
+++ b/x/programs/cmd/simulator_api/api/service.proto
@@ -7,10 +7,10 @@ message CreateKeyRequest {
     string name = 1;
 }
 
-message PublicKey {
-    string value = 1;
+message CreateKeyResponse {
+    string name = 1;
 }
 
 service Simulator {
-    rpc CreateKey(CreateKeyRequest) returns (PublicKey);
+    rpc CreateKey(CreateKeyRequest) returns (CreateKeyResponse);
 }

--- a/x/programs/cmd/simulator_api/api/service.proto
+++ b/x/programs/cmd/simulator_api/api/service.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+package api;
+
+option go_package = "github.com/ava-labs/hypersdk/x/programs/cmd/simulator_api/api";
+
+message CreateKeyRequest {
+    string name = 1;
+}
+
+message PublicKey {
+    string value = 1;
+}
+
+service Simulator {
+    rpc CreateKey(CreateKeyRequest) returns (PublicKey);
+}

--- a/x/programs/cmd/simulator_api/main.go
+++ b/x/programs/cmd/simulator_api/main.go
@@ -1,7 +1,9 @@
+//go:generate protoc --go_out=. --go_opt=paths=source_relative --go-grpc_out=. --go-grpc_opt=paths=source_relative ./api/service.proto
 package main
 
 import (
 	context "context"
+	"errors"
 	"flag"
 	"fmt"
 	"net"
@@ -64,12 +66,12 @@ type simulatorServer struct {
 	api.UnimplementedSimulatorServer
 }
 
-func (x *simulatorServer) CreateKey(ctx context.Context, in *api.CreateKeyRequest) (*api.PublicKey, error) {
+func (x *simulatorServer) CreateKey(ctx context.Context, in *api.CreateKeyRequest) (*api.CreateKeyResponse, error) {
 	_, err := x.simulator.CreateKey(ctx, in.GetName())
-	if err != nil {
+	if err != nil && !errors.Is(err, cmd.ErrDuplicateKeyName) {
 		return nil, err
 	}
-	return &api.PublicKey{
-		Value: in.GetName(),
+	return &api.CreateKeyResponse{
+		Name: in.GetName(),
 	}, nil
 }

--- a/x/programs/cmd/simulator_api/main.go
+++ b/x/programs/cmd/simulator_api/main.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	context "context"
+	"flag"
+	"fmt"
+	"net"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/ava-labs/hypersdk/crypto/ed25519"
+
+	"github.com/ava-labs/hypersdk/x/programs/cmd/simulator/cmd"
+	"github.com/ava-labs/hypersdk/x/programs/cmd/simulator_api/api"
+	"google.golang.org/grpc"
+)
+
+var (
+	port     = flag.Int("port", 50051, "The server port")
+	logLevel = flag.String("log-level", "info", "log level")
+)
+
+func main() {
+	flag.Parse()
+	lis, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", *port))
+	if err != nil {
+		panic(err)
+	}
+
+	opt := []grpc.ServerOption{}
+	grpcServer := grpc.NewServer(opt...)
+	simulator := cmd.NewSimulator(*logLevel)
+	if err := simulator.Init(); err != nil {
+		panic(err)
+	}
+	defer simulator.GracefulStop(context.Background())
+
+	api.RegisterSimulatorServer(grpcServer, newSimulatorServer(simulator))
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		grpcServer.Serve(lis)
+	}()
+	<-sigCh
+	grpcServer.GracefulStop()
+
+}
+
+type Simulator interface {
+	Init() error
+	CreateKey(ctx context.Context, name string) (ed25519.PublicKey, error)
+}
+
+func newSimulatorServer(simulator Simulator) api.SimulatorServer {
+	return &simulatorServer{
+		simulator: simulator,
+	}
+}
+
+type simulatorServer struct {
+	simulator Simulator
+	api.UnimplementedSimulatorServer
+}
+
+func (x *simulatorServer) CreateKey(ctx context.Context, in *api.CreateKeyRequest) (*api.PublicKey, error) {
+	_, err := x.simulator.CreateKey(ctx, in.GetName())
+	if err != nil {
+		return nil, err
+	}
+	return &api.PublicKey{
+		Value: in.GetName(),
+	}, nil
+}

--- a/x/programs/rust/examples/counter/Cargo.toml
+++ b/x/programs/rust/examples/counter/Cargo.toml
@@ -8,6 +8,17 @@ edition = "2021"
 [dependencies]
 wasmlanche_sdk = { version = "0.1.0", path = "../../wasmlanche_sdk" }
 
+[dev-dependencies]
+wasmlanche_sdk = { version = "0.1.0", path = "../../wasmlanche_sdk", features=["simulator"]}
+simulator_client = { version = "0.1.0", path = "../../simulator_client" }
+async-std = { version = "1.6", features = ["attributes"]}
+serde_json = "1.0.68"
+serial_test = "2.0.0"
+tonic = "0.11"
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
+libc = "0.2"
+nix = { version="0.28.0", features = ["process", "signal"] }
+
 [lib]
 crate-type = ["cdylib"] # set the crate(needed for cargo build to work properly)
 

--- a/x/programs/rust/examples/counter/scripts/tests.simulator.sh
+++ b/x/programs/rust/examples/counter/scripts/tests.simulator.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if ! [[ "$0" =~ scripts/tests.simulator.sh ]]; then
+  echo "must be run from counter crate root"
+  exit 255
+fi
+
+simulator_path="${PWD}"/../../../cmd/simulator_api
+simulator_bin="${simulator_path}"/bin/simulator
+
+# Set environment variables for the test
+
+# The path to the simulator binary
+export SIMULATOR_PATH="${simulator_bin}"
+
+# The path to the compiled Wasm program to be tested
+export PROGRAM_PATH="${PWD}"/build/counter.wasm
+
+echo "Building Counter example..."
+./../../scripts/build.sh
+
+example_path=$(pwd)
+echo "Downloading dependencies..."
+cd "${simulator_path}"
+go mod download
+
+echo "Building Simulator..."
+go build -o "${simulator_bin}" "${simulator_path}"
+
+echo "Running Simulator Tests..."
+cd "${example_path}"
+cargo test -- --include-ignored --nocapture

--- a/x/programs/rust/examples/counter/scripts/tests.simulator.sh
+++ b/x/programs/rust/examples/counter/scripts/tests.simulator.sh
@@ -27,7 +27,7 @@ cd "${simulator_path}"
 go mod download
 
 echo "Building Simulator..."
-go build -o "${simulator_bin}" "${simulator_path}"
+go generate && go build -o "${simulator_bin}" "${simulator_path}"
 
 echo "Running Simulator Tests..."
 cd "${example_path}"

--- a/x/programs/rust/examples/counter/src/lib.rs
+++ b/x/programs/rust/examples/counter/src/lib.rs
@@ -62,3 +62,5 @@ pub fn get_value_external(_: Program, target: Program, max_units: i64, of: Addre
         .call_function("get_value", params!(&of), max_units)
         .unwrap()
 }
+
+

--- a/x/programs/rust/examples/counter/tests/simulate.rs
+++ b/x/programs/rust/examples/counter/tests/simulate.rs
@@ -1,0 +1,67 @@
+//mod simulate;
+use async_std;
+use nix::sys::signal::{kill, Signal};
+use nix::unistd::Pid;
+use serial_test::serial;
+use simulator_client::{CreateKeyRequest, PublicKey, SimulatorClient};
+use std::borrow::Borrow;
+use std::env;
+use std::sync::WaitTimeoutResult;
+use std::{process::Child, process::Command};
+use std::{thread, time};
+use tokio;
+use tonic::{self, IntoRequest};
+use wasmlanche_sdk::simulator;
+
+// export SIMULATOR_PATH=/path/to/simulator
+// export PROGRAM_PATH=/path/to/program.wasm
+// cargo cargo test --package token --lib nocapture -- tests::test_token_plan --exact --nocapture --ignored
+struct SimulatorLife {
+    child: Child,
+    cleaned: bool,
+}
+
+impl SimulatorLife {
+    fn new() -> SimulatorLife {
+        let s_path = env::var(simulator::PATH_KEY).expect("SIMULATOR_PATH not set");
+        let server_process = Command::new(s_path)
+            .spawn()
+            .expect("failed to spawn simulator");
+        SimulatorLife {
+            child: server_process,
+            cleaned: false,
+        }
+    }
+    fn cleanup(&mut self) {
+        let pid = Pid::from_raw(self.child.id() as i32);
+        kill(pid, Signal::SIGTERM).unwrap();
+        println!("stoped simulator");
+        self.cleaned = true;
+    }
+}
+
+impl Drop for SimulatorLife {
+    fn drop(&mut self) {
+        if !self.cleaned {
+            self.cleanup()
+        }
+    }
+}
+
+#[tokio::test]
+#[serial]
+//#[ignore = "requires SIMULATOR_PATH and PROGRAM_PATH to be set"]
+async fn test_counter_plan() -> Result<(), Box<dyn std::error::Error>> {
+    let mut simulator_life = SimulatorLife::new();
+    //let ten_millis = time::Duration::from_millis(5000);
+    thread::sleep(time::Duration::from_millis(1000));
+    let mut client = SimulatorClient::connect("http://127.0.0.1:50051").await?;
+
+    let request = tonic::Request::new(CreateKeyRequest {
+        name: "alice".into(),
+    });
+    let response = client.create_key(request).await?.into_inner();
+    assert_ne!(response.value, "");
+    simulator_life.cleanup();
+    Ok(())
+}

--- a/x/programs/rust/examples/counter/tests/simulate.rs
+++ b/x/programs/rust/examples/counter/tests/simulate.rs
@@ -3,8 +3,7 @@ use async_std;
 use nix::sys::signal::{kill, Signal};
 use nix::unistd::Pid;
 use serial_test::serial;
-use simulator_client::{CreateKeyRequest, PublicKey, SimulatorClient};
-use std::borrow::Borrow;
+use simulator_client::api::{simulator_client::SimulatorClient,CreateKeyRequest};
 use std::env;
 use std::sync::WaitTimeoutResult;
 use std::{process::Child, process::Command};
@@ -52,16 +51,16 @@ impl Drop for SimulatorLife {
 #[serial]
 //#[ignore = "requires SIMULATOR_PATH and PROGRAM_PATH to be set"]
 async fn test_counter_plan() -> Result<(), Box<dyn std::error::Error>> {
-    let mut simulator_life = SimulatorLife::new();
-    //let ten_millis = time::Duration::from_millis(5000);
-    thread::sleep(time::Duration::from_millis(1000));
+    let simulator_life = SimulatorLife::new();
+    // TODO use better mechanism than waiting
+    thread::sleep(time::Duration::from_millis(2500));
     let mut client = SimulatorClient::connect("http://127.0.0.1:50051").await?;
 
     let request = tonic::Request::new(CreateKeyRequest {
         name: "alice".into(),
     });
     let response = client.create_key(request).await?.into_inner();
-    assert_ne!(response.value, "");
-    simulator_life.cleanup();
+    assert_eq!(response.name, "alice");
+    //simulator_life.cleanup();
     Ok(())
 }

--- a/x/programs/rust/simulator_client/Cargo.toml
+++ b/x/programs/rust/simulator_client/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "simulator_client"
+version = "0.1.0"
+edition = "2021"
+type = "lib"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+tonic = "0.11"
+prost = "0.12.3"
+
+[build-dependencies]
+tonic-build = "0.11"

--- a/x/programs/rust/simulator_client/build.rs
+++ b/x/programs/rust/simulator_client/build.rs
@@ -1,0 +1,10 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tonic_build::configure()
+         .build_server(false)
+         .out_dir("src/")
+         .compile(
+             &["../../cmd/simulator_api/api/service.proto"],
+             &["../../cmd/simulator_api/api/"]
+         )?;
+    Ok(())
+}

--- a/x/programs/rust/simulator_client/src/api.rs
+++ b/x/programs/rust/simulator_client/src/api.rs
@@ -1,0 +1,118 @@
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CreateKeyRequest {
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PublicKey {
+    #[prost(string, tag = "1")]
+    pub value: ::prost::alloc::string::String,
+}
+/// Generated client implementations.
+pub mod simulator_client {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
+    #[derive(Debug, Clone)]
+    pub struct SimulatorClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    impl SimulatorClient<tonic::transport::Channel> {
+        /// Attempt to create a new client by connecting to a given endpoint.
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> SimulatorClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::Error: Into<StdError>,
+        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> SimulatorClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
+        {
+            SimulatorClient::new(InterceptedService::new(inner, interceptor))
+        }
+        /// Compress requests with the given encoding.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
+            self
+        }
+        /// Enable decompressing responses.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
+        pub async fn create_key(
+            &mut self,
+            request: impl tonic::IntoRequest<super::CreateKeyRequest>,
+        ) -> std::result::Result<tonic::Response<super::PublicKey>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/api.Simulator/CreateKey");
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new("api.Simulator", "CreateKey"));
+            self.inner.unary(req, path, codec).await
+        }
+    }
+}

--- a/x/programs/rust/simulator_client/src/api.rs
+++ b/x/programs/rust/simulator_client/src/api.rs
@@ -6,9 +6,9 @@ pub struct CreateKeyRequest {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct PublicKey {
+pub struct CreateKeyResponse {
     #[prost(string, tag = "1")]
-    pub value: ::prost::alloc::string::String,
+    pub name: ::prost::alloc::string::String,
 }
 /// Generated client implementations.
 pub mod simulator_client {
@@ -98,7 +98,10 @@ pub mod simulator_client {
         pub async fn create_key(
             &mut self,
             request: impl tonic::IntoRequest<super::CreateKeyRequest>,
-        ) -> std::result::Result<tonic::Response<super::PublicKey>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::CreateKeyResponse>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await

--- a/x/programs/rust/simulator_client/src/lib.rs
+++ b/x/programs/rust/simulator_client/src/lib.rs
@@ -1,3 +1,1 @@
 pub mod api;
-
-pub use api::{*, simulator_client::SimulatorClient};

--- a/x/programs/rust/simulator_client/src/lib.rs
+++ b/x/programs/rust/simulator_client/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod api;
+
+pub use api::{*, simulator_client::SimulatorClient};


### PR DESCRIPTION
This Draft PR is related to #734 .
It does the following:

- create a new binary simulator_api alongside the simulator reusing same engine but add grpc transport over it.
- define the grpc proto files in simulator_api
- create a rust lib with generated client from the grpc proto file. (it cannot be embedded in `wasmlanche_sdk` because of some issue building dependencies with `wasm32` target
- define a short example of how to use the client in `counter` tests.

Implemented commands:

- [x] createKey
- [ ] createProgram
- [ ] run