### PR TITLE
[ci] fix unit tests

### DIFF
--- a/examples/morpheusvm/scripts/tests.unit.sh
+++ b/examples/morpheusvm/scripts/tests.unit.sh
@@ -17,4 +17,4 @@ fi
 
 # Provision of the list of tests requires word splitting, so disable the shellcheck
 # shellcheck disable=SC2046
-go test -race -timeout="10m" -coverprofile="coverage.out" -covermode="atomic" $(go list ./... | grep -v tests)
+go test -race -timeout="10m" -coverprofile="coverage.out" -covermode="atomic" $(find . -name "*.go" | grep -v "./cmd" | grep -v "./tests" | xargs -n1 dirname | sort -u | xargs)

--- a/examples/tokenvm/scripts/tests.unit.sh
+++ b/examples/tokenvm/scripts/tests.unit.sh
@@ -17,4 +17,4 @@ fi
 
 # Provision of the list of tests requires word splitting, so disable the shellcheck
 # shellcheck disable=SC2046
-go test -race -timeout="10m" -coverprofile="coverage.out" -covermode="atomic" $(go list ./... | grep -v tests)
+go test -race -timeout="10m" -coverprofile="coverage.out" -covermode="atomic" $(find . -name "*.go" | grep -v "./cmd" | grep -v "./tests" | xargs -n1 dirname | sort -u | xargs)

--- a/scripts/tests.unit.sh
+++ b/scripts/tests.unit.sh
@@ -17,4 +17,4 @@ source "$HYPERSDK_PATH"/scripts/constants.sh
 
 # Provision of the list of tests requires word splitting, so disable the shellcheck
 # shellcheck disable=SC2046
-go test -race -timeout="3m" -coverprofile="coverage.out" -covermode="atomic" $(go list ./... | grep -v tests)
+go test -race -timeout="3m" -coverprofile="coverage.out" -covermode="atomic" $(find . -name "*.go" | grep -v "./examples" | grep -v "./x/programs/cmd" |xargs -n1 dirname | sort -u | xargs)

--- a/scripts/tests.unit.sh
+++ b/scripts/tests.unit.sh
@@ -17,4 +17,4 @@ source "$HYPERSDK_PATH"/scripts/constants.sh
 
 # Provision of the list of tests requires word splitting, so disable the shellcheck
 # shellcheck disable=SC2046
-go test -race -timeout="3m" -coverprofile="coverage.out" -covermode="atomic" $(find . -name "*.go" | grep -v "./examples" | grep -v "./x/programs/cmd" |xargs -n1 dirname | sort -u | xargs)
+go test -race -timeout="3m" -coverprofile="coverage.out" -covermode="atomic" $(find . -name "*.go" | grep -v "./x/programs/cmd" | grep -v "./examples/morpheusvm" | grep -v "./examples/tokenvm" | xargs -n1 dirname | sort -u | xargs)


### PR DESCRIPTION
Turns out CI has been erroring silently on the `tokenvm`:
```
cmd/token-wallet/main.go:17:12: pattern all:frontend/dist: no matching files found
```

![image](https://github.com/ava-labs/hypersdk/assets/13023275/c2a2cf04-c124-4403-93bc-e1656319c6a5)

Thanks to @wlawt for spotting this!
