### PR TITLE
Use better errors in wasmlanche-macros

### DIFF
--- a/x/programs/rust/sdk_macros/Cargo.toml
+++ b/x/programs/rust/sdk_macros/Cargo.toml
@@ -9,4 +9,8 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0.67"
 quote = "1.0.33"
-syn = { version = "2.0.37", features = ["full"] }
+syn = { version = "2.0.37", features = ["full", "extra-traits"] }
+
+[dev-dependencies]
+trybuild = "1.0.89"
+wasmlanche-sdk = { path = "../wasmlanche-sdk" }

--- a/x/programs/rust/sdk_macros/tests/compile.rs
+++ b/x/programs/rust/sdk_macros/tests/compile.rs
@@ -1,0 +1,5 @@
+#[test]
+fn ui() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/ui/**/*.rs");
+}

--- a/x/programs/rust/sdk_macros/tests/ui/first-param.rs
+++ b/x/programs/rust/sdk_macros/tests/ui/first-param.rs
@@ -1,0 +1,6 @@
+use sdk_macros::public;
+
+#[public]
+pub fn test(a: u32) {}
+
+fn main() {}

--- a/x/programs/rust/sdk_macros/tests/ui/first-param.stderr
+++ b/x/programs/rust/sdk_macros/tests/ui/first-param.stderr
@@ -1,0 +1,5 @@
+error: The first paramter of a function with the `#[public]` attribute must be of type `wasmlanche_sdk::program::Program`
+ --> tests/ui/first-param.rs:4:16
+  |
+4 | pub fn test(a: u32) {}
+  |                ^^^

--- a/x/programs/rust/sdk_macros/tests/ui/ignore-second-param.rs
+++ b/x/programs/rust/sdk_macros/tests/ui/ignore-second-param.rs
@@ -1,0 +1,8 @@
+use sdk_macros::public;
+#[allow(unused_imports)]
+use wasmlanche_sdk::program::Program;
+
+#[public]
+pub fn test(_: Program, _: u32) {}
+
+fn main() {}

--- a/x/programs/rust/sdk_macros/tests/ui/ignore-second-param.stderr
+++ b/x/programs/rust/sdk_macros/tests/ui/ignore-second-param.stderr
@@ -1,0 +1,5 @@
+error: Functions with the `#[public]` attribute can only ignore the first parameter.
+ --> tests/ui/ignore-second-param.rs:6:25
+  |
+6 | pub fn test(_: Program, _: u32) {}
+  |                         ^

--- a/x/programs/rust/sdk_macros/tests/ui/not-pub.rs
+++ b/x/programs/rust/sdk_macros/tests/ui/not-pub.rs
@@ -1,0 +1,9 @@
+use sdk_macros::public;
+
+#[allow(unused_imports)]
+use wasmlanche_sdk::program::Program;
+
+#[public]
+fn test(_: Program) {}
+
+fn main() {}

--- a/x/programs/rust/sdk_macros/tests/ui/not-pub.stderr
+++ b/x/programs/rust/sdk_macros/tests/ui/not-pub.stderr
@@ -1,0 +1,5 @@
+error: Functions with the `#[public]` attribute must have `pub` visibility.
+ --> tests/ui/not-pub.rs:7:1
+  |
+7 | fn test(_: Program) {}
+  | ^^

--- a/x/programs/rust/sdk_macros/tests/ui/receiver.rs
+++ b/x/programs/rust/sdk_macros/tests/ui/receiver.rs
@@ -1,0 +1,10 @@
+use sdk_macros::public;
+
+struct Foo;
+
+impl Foo {
+    #[public]
+    pub fn test(&self) {}
+}
+
+fn main() {}

--- a/x/programs/rust/sdk_macros/tests/ui/receiver.stderr
+++ b/x/programs/rust/sdk_macros/tests/ui/receiver.stderr
@@ -1,0 +1,5 @@
+error: The first paramter of a function with the `#[public]` attribute must be of type `wasmlanche_sdk::program::Program`
+ --> tests/ui/receiver.rs:7:17
+  |
+7 |     pub fn test(&self) {}
+  |                 ^

--- a/x/programs/rust/sdk_macros/tests/ui/user-defined-program-type.rs
+++ b/x/programs/rust/sdk_macros/tests/ui/user-defined-program-type.rs
@@ -1,0 +1,8 @@
+use sdk_macros::public;
+
+struct Program;
+
+#[public]
+pub fn test(_: Program) {}
+
+fn main() {}

--- a/x/programs/rust/sdk_macros/tests/ui/user-defined-program-type.stderr
+++ b/x/programs/rust/sdk_macros/tests/ui/user-defined-program-type.stderr
@@ -1,0 +1,25 @@
+error[E0308]: mismatched types
+ --> tests/ui/user-defined-program-type.rs:5:1
+  |
+5 | #[public]
+  | ^^^^^^^^^ expected `Program`, found `wasmlanche_sdk::program::Program`
+6 | pub fn test(_: Program) {}
+  |        ---- arguments to this function are incorrect
+  |
+  = note: `wasmlanche_sdk::program::Program` and `Program` have similar names, but are actually distinct types
+note: `wasmlanche_sdk::program::Program` is defined in crate `wasmlanche_sdk`
+ --> $WORKSPACE/x/programs/rust/wasmlanche-sdk/src/program.rs
+  |
+  | pub struct Program([u8; Self::LEN]);
+  | ^^^^^^^^^^^^^^^^^^
+note: `Program` is defined in the current crate
+ --> tests/ui/user-defined-program-type.rs:3:1
+  |
+3 | struct Program;
+  | ^^^^^^^^^^^^^^
+note: function defined here
+ --> tests/ui/user-defined-program-type.rs:6:8
+  |
+6 | pub fn test(_: Program) {}
+  |        ^^^^ ----------
+  = note: this error originates in the attribute macro `public` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/x/programs/rust/sdk_macros/tests/ui/wild.rs
+++ b/x/programs/rust/sdk_macros/tests/ui/wild.rs
@@ -1,0 +1,8 @@
+use sdk_macros::public;
+
+struct Program;
+
+#[public]
+pub fn test(_: Program, _: usize) {}
+
+fn main() {}

--- a/x/programs/rust/sdk_macros/tests/ui/wild.stderr
+++ b/x/programs/rust/sdk_macros/tests/ui/wild.stderr
@@ -1,0 +1,5 @@
+error: Functions with the `#[public]` attribute can only ignore the first parameter.
+ --> tests/ui/wild.rs:6:25
+  |
+6 | pub fn test(_: Program, _: usize) {}
+  |                         ^


### PR DESCRIPTION
We shouldn't be panicking in macros, it doesn't provide good error messages. Here are the error messages with the changes.

![image](https://github.com/ava-labs/hypersdk/assets/3286504/4798d8aa-0481-4bde-a0b9-e20efb1b340a)

The above is just a (flawed) example. The actual errors are in the new `.stderr` files.


