### PR TITLE
[executor] handling read/allocate/write-keys in the execution engine

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -168,7 +168,7 @@ func (e *Executor) Run(conflicts state.Keys, f func() error) {
 	if t.dependencies != nil && t.dependencies.Len() > 0 {
 		// Ensure that we don't schedule a transaction that is
 		// blocked by another transaction currently running
-		for _, bID := range t.dependencies {
+		for bID := range t.dependencies {
 			// don't execute if any dependency task is in blocking
 			if e.blocking.Contains(bID) {
 				if e.metrics != nil {

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -143,20 +143,17 @@ func (e *Executor) Run(conflicts state.Keys, f func() error) {
 				}
 				// key has ONLY a Read permission
 				if v == state.Read {
-					// lt contains either Allocate or Write permission. If lt had only a Read
-					// permission, no dependency or blocking would be added
-					if latest.Permissions.Has(state.Allocate) || latest.Permissions.Has(state.Write) {
-						t.dependencies.Add(lt.id) // t depends on lt to execute
-						lt.blocking.Add(id)       // lt is blocking this current task
-						// If lt is blocking any other txn, we need to record this
-						// to prevent subsequent txns that depend on lt from executing
-						// at the same time
-						e.blocking.Add(lt.id)
-					}
+					t.dependencies.Add(lt.id) // t depends on lt to execute
+					lt.blocking.Add(id)       // lt is blocking this current task
+					// If lt is blocking any other txn, we need to record this
+					// to prevent subsequent txns that depend on lt from executing
+					// at the same time
+					e.blocking.Add(lt.id)
+					continue
 				}
 
-				// key contains a Write permission
-				if v.Has(state.Write) {
+				// key contains a Allocate or Write permission
+				if v.Has(state.Allocate) || v.Has(state.Write) {
 					// lt contains either Read, Allocate, or Write
 					if latest.Permissions.Has(state.Read) || latest.Permissions.Has(state.Allocate) || latest.Permissions.Has(state.Write) {
 						t.dependencies.Add(lt.id)

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -166,6 +166,14 @@ func (e *Executor) Run(conflicts state.Keys, f func() error) {
 
 				t.dependencies.Add(lt.id)
 				lt.blocking.Add(id)
+				for b := range key.concurrentReads {
+					bt := e.tasks[b]
+					// TODO: remove executed check
+					if !bt.executed {
+						t.dependencies.Add(bt.id)
+						bt.blocking.Add(id)
+					}
+				}				
 			}
 		}
 		// reads are blocked on itself

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -68,8 +68,9 @@ func New(items, concurrency int, metrics Metrics) *Executor {
 		edges:      make(map[string]*keyData, items*2), // TODO: tune this
 		executable: make(chan *task, items),            // ensure we don't block while holding lock
 	}
+	e.wg.Add(concurrency)
 	for i := 0; i < concurrency; i++ {
-		e.createWorker()
+		go e.runWorker()
 	}
 	return e
 }
@@ -84,49 +85,45 @@ type task struct {
 	executed bool
 }
 
-func (e *Executor) createWorker() {
-	e.wg.Add(1)
+func (e *Executor) runWorker() {
+	defer e.wg.Done()
 
-	go func() {
-		defer e.wg.Done()
-
-		for {
-			select {
-			case t, ok := <-e.executable:
-				if !ok {
-					return
-				}
-				if err := t.f(); err != nil {
-					e.stopOnce.Do(func() {
-						e.err = err
-						close(e.stop)
-					})
-					return
-				}
-
-				e.l.Lock()
-				for b := range t.blocking { // works fine on non-initialized map
-					bt := e.tasks[b]
-					bt.dependencies.Remove(t.id)
-					if bt.dependencies.Len() == 0 { // must be non-nil to be blocked
-						bt.dependencies = nil // free memory
-						e.executable <- bt
-					}
-				}
-				t.blocking = nil // free memory
-				t.executed = true
-				e.completed++
-				if e.done && e.completed == len(e.tasks) {
-					// We will close here if there are unexecuted tasks
-					// when we call [Wait].
-					close(e.executable)
-				}
-				e.l.Unlock()
-			case <-e.stop:
+	for {
+		select {
+		case t, ok := <-e.executable:
+			if !ok {
 				return
 			}
+			if err := t.f(); err != nil {
+				e.stopOnce.Do(func() {
+					e.err = err
+					close(e.stop)
+				})
+				return
+			}
+
+			e.l.Lock()
+			for b := range t.blocking { // works fine on non-initialized map
+				bt := e.tasks[b]
+				bt.dependencies.Remove(t.id)
+				if bt.dependencies.Len() == 0 { // must be non-nil to be blocked
+					bt.dependencies = nil // free memory
+					e.executable <- bt
+				}
+			}
+			t.blocking = nil // free memory
+			t.executed = true
+			e.completed++
+			if e.done && e.completed == len(e.tasks) {
+				// We will close here if there are unexecuted tasks
+				// when we call [Wait].
+				close(e.executable)
+			}
+			e.l.Unlock()
+		case <-e.stop:
+			return
 		}
-	}()
+	}
 }
 
 // Run executes [f] after all previously enqueued [f] with

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 	"testing"
 	"time"
-	//"fmt"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/stretchr/testify/require"

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"testing"
 	"time"
+	"fmt"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/stretchr/testify/require"
@@ -83,10 +84,10 @@ func TestExecutorSimpleConflict(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		s := make(state.Keys, (i + 1))
 		for k := 0; k < i+1; k++ {
-			s.Add(ids.GenerateTestID().String(), state.Read|state.Write)
+			s.Add(ids.GenerateTestID().String(), state.Read)
 		}
 		if i%10 == 0 {
-			s.Add(conflictKey, state.Read|state.Write)
+			s.Add(conflictKey, state.Write)
 		}
 		ti := i
 		e.Run(s, func() error {
@@ -101,6 +102,7 @@ func TestExecutorSimpleConflict(t *testing.T) {
 		})
 	}
 	require.NoError(e.Wait())
+	fmt.Printf("complete %v\n", completed)
 	require.Equal([]int{0, 10, 20, 30, 40, 50, 60, 70, 80, 90}, completed[90:])
 }
 
@@ -116,13 +118,13 @@ func TestExecutorMultiConflict(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		s := make(state.Keys, (i + 1))
 		for k := 0; k < i+1; k++ {
-			s.Add(ids.GenerateTestID().String(), state.Read|state.Write)
+			s.Add(ids.GenerateTestID().String(), state.Write)
 		}
 		if i%10 == 0 {
-			s.Add(conflictKey, state.Read|state.Write)
+			s.Add(conflictKey, state.Write)
 		}
 		if i == 15 || i == 20 {
-			s.Add(conflictKey2, state.Read|state.Write)
+			s.Add(conflictKey2, state.Write)
 		}
 		ti := i
 		e.Run(s, func() error {
@@ -154,7 +156,7 @@ func TestEarlyExit(t *testing.T) {
 	for i := 0; i < 500; i++ {
 		s := make(state.Keys, (i + 1))
 		for k := 0; k < i+1; k++ {
-			s.Add(ids.GenerateTestID().String(), state.Read|state.Write)
+			s.Add(ids.GenerateTestID().String(), state.Write)
 		}
 		ti := i
 		e.Run(s, func() error {
@@ -181,7 +183,7 @@ func TestStop(t *testing.T) {
 	for i := 0; i < 500; i++ {
 		s := make(state.Keys, (i + 1))
 		for k := 0; k < i+1; k++ {
-			s.Add(ids.GenerateTestID().String(), state.Read|state.Write)
+			s.Add(ids.GenerateTestID().String(), state.Write)
 		}
 		ti := i
 		e.Run(s, func() error {

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -318,8 +318,6 @@ func TestManyWrites(t *testing.T) {
 		s.Add(conflictKey, state.Read)
 		ti := i
 		e.Run(s, func() error {
-			time.Sleep(1 * time.Second)
-
 			l.Lock()
 			completed = append(completed, ti)
 			l.Unlock()

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 	"testing"
 	"time"
-	"fmt"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/stretchr/testify/require"
@@ -102,7 +101,6 @@ func TestExecutorSimpleConflict(t *testing.T) {
 		})
 	}
 	require.NoError(e.Wait())
-	fmt.Printf("complete %v\n", completed)
 	require.Equal([]int{0, 10, 20, 30, 40, 50, 60, 70, 80, 90}, completed[90:])
 }
 
@@ -118,7 +116,7 @@ func TestExecutorMultiConflict(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		s := make(state.Keys, (i + 1))
 		for k := 0; k < i+1; k++ {
-			s.Add(ids.GenerateTestID().String(), state.Write)
+			s.Add(ids.GenerateTestID().String(), state.Read)
 		}
 		if i%10 == 0 {
 			s.Add(conflictKey, state.Write)
@@ -156,7 +154,7 @@ func TestEarlyExit(t *testing.T) {
 	for i := 0; i < 500; i++ {
 		s := make(state.Keys, (i + 1))
 		for k := 0; k < i+1; k++ {
-			s.Add(ids.GenerateTestID().String(), state.Write)
+			s.Add(ids.GenerateTestID().String(), state.Read|state.Write)
 		}
 		ti := i
 		e.Run(s, func() error {
@@ -183,7 +181,7 @@ func TestStop(t *testing.T) {
 	for i := 0; i < 500; i++ {
 		s := make(state.Keys, (i + 1))
 		for k := 0; k < i+1; k++ {
-			s.Add(ids.GenerateTestID().String(), state.Write)
+			s.Add(ids.GenerateTestID().String(), state.Read|state.Write)
 		}
 		ti := i
 		e.Run(s, func() error {

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -4,11 +4,10 @@
 package executor
 
 import (
-	_ "errors"
+	"errors"
 	"sync"
 	"testing"
 	"time"
-	_ "fmt"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/stretchr/testify/require"
@@ -16,7 +15,7 @@ import (
 	"github.com/ava-labs/hypersdk/state"
 )
 
-/*func TestExecutorNoConflicts(t *testing.T) {
+func TestExecutorNoConflicts(t *testing.T) {
 	var (
 		require   = require.New(t)
 		l         sync.Mutex
@@ -71,9 +70,9 @@ func TestExecutorNoConflictsSlow(t *testing.T) {
 	require.NoError(e.Wait()) // existing task is running
 	require.Len(completed, 100)
 	require.Equal(0, completed[99])
-}*/
+}
 
-/*func TestExecutorSimpleConflict(t *testing.T) {
+func TestExecutorSimpleConflict(t *testing.T) {
 	var (
 		require     = require.New(t)
 		conflictKey = ids.GenerateTestID().String()
@@ -81,7 +80,6 @@ func TestExecutorNoConflictsSlow(t *testing.T) {
 		completed   = make([]int, 0, 100)
 		e           = New(100, 4, nil)
 	)
-	fmt.Printf("CONFLICT key %v\n", conflictKey)
 	for i := 0; i < 100; i++ {
 		s := make(state.Keys, (i + 1))
 		for k := 0; k < i+1; k++ {
@@ -198,7 +196,7 @@ func TestStop(t *testing.T) {
 	}
 	require.Less(len(completed), 500)
 	require.ErrorIs(e.Wait(), ErrStopped) // no task running
-}*/
+}
 
 // W->W->W->...
 func TestManyWrites(t *testing.T) {
@@ -250,6 +248,9 @@ func TestManyReads(t *testing.T) {
 		s.Add(conflictKey, state.Read)
 		ti := i
 		e.Run(s, func() error {
+			if ti%2 == 0 {
+				time.Sleep(1 * time.Second)
+			}
 			l.Lock()
 			completed = append(completed, ti)
 			l.Unlock()
@@ -337,7 +338,7 @@ func TestReadThenWrite(t *testing.T) {
 }
 
 // W->R->R->...W->R->R->...
-/*func TestWriteThenReadRepeated(t *testing.T) {
+func TestWriteThenReadRepeated(t *testing.T) {
 	var (
 		require     = require.New(t)
 		conflictKey = ids.GenerateTestID().String()
@@ -373,10 +374,10 @@ func TestReadThenWrite(t *testing.T) {
 	require.Equal(49, completed[49]) // Second write to execute
 	// 50..99 are ran in parallel, so non-deterministic
 	require.Len(completed, 100)
-}*/
+}
 
 // R->R->W->R->W->R->R...
-/*func TestReadThenWriteRepeated(t *testing.T) {
+func TestReadThenWriteRepeated(t *testing.T) {
 	var (
 		require     = require.New(t)
 		conflictKey = ids.GenerateTestID().String()
@@ -413,4 +414,4 @@ func TestReadThenWrite(t *testing.T) {
 	require.Equal(12, completed[12])
 	// 13..99 are ran in parallel, so non-deterministic
 	require.Len(completed, 100)
-}*/
+}

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -198,74 +198,6 @@ func TestStop(t *testing.T) {
 	}
 	require.Less(len(completed), 500)
 	require.ErrorIs(e.Wait(), ErrStopped) // no task running
-}
-
-func TestWriteAllocKeyThenAddRead(t *testing.T) {
-	var (
-		require     = require.New(t)
-		conflictKey = ids.GenerateTestID().String()
-		l           sync.Mutex
-		completed   = make([]int, 0, 100)
-		e           = New(100, 4, nil)
-	)
-	for i := 0; i < 100; i++ {
-		s := make(state.Keys, (i + 1))
-		for k := 0; k < i+1; k++ {
-			s.Add(ids.GenerateTestID().String(), state.Read|state.Write)
-		}
-		if i < 10 && i%2 == 0 {
-			s.Add(conflictKey, state.Allocate|state.Write)
-		} else if i < 10 && i%2 != 0 {
-			s.Add(conflictKey, state.Read)
-		}
-		ti := i
-		e.Run(s, func() error {
-			if ti == 0 {
-				time.Sleep(3 * time.Second)
-			}
-
-			l.Lock()
-			completed = append(completed, ti)
-			l.Unlock()
-			return nil
-		})
-	}
-	require.NoError(e.Wait())
-	require.Equal([]int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, completed[90:])
-}
-
-func TestAllKeyThenAddWrite(t *testing.T) {
-	var (
-		require     = require.New(t)
-		conflictKey = ids.GenerateTestID().String()
-		l           sync.Mutex
-		completed   = make([]int, 0, 100)
-		e           = New(100, 4, nil)
-	)
-	for i := 0; i < 100; i++ {
-		s := make(state.Keys, (i + 1))
-		for k := 0; k < i+1; k++ {
-			s.Add(ids.GenerateTestID().String(), state.Read|state.Write)
-		}
-		if i < 10 && i%2 == 0 {
-			s.Add(conflictKey, state.All)
-		} else if i < 10 && i%2 != 0 {
-			s.Add(conflictKey, state.Write)
-		}
-		ti := i
-		e.Run(s, func() error {
-			if ti == 0 {
-				time.Sleep(3 * time.Second)
-			}
-
-			l.Lock()
-			completed = append(completed, ti)
-			l.Unlock()
-			return nil
-		})
-	}
-	require.NoError(e.Wait())
-	require.Equal([]int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, completed[90:])
 }*/
 
 // W->W->W->...
@@ -366,45 +298,6 @@ func TestWriteThenRead(t *testing.T) {
 	require.Len(completed, 100)
 }
 
-// W->R->R->...W->R->R->...
-/*func TestWriteThenReadRepeated(t *testing.T) {
-	var (
-		require     = require.New(t)
-		conflictKey = ids.GenerateTestID().String()
-		l           sync.Mutex
-		completed   = make([]int, 0, 100)
-		e           = New(100, 4, nil)
-	)
-	for i := 0; i < 100; i++ {
-		s := make(state.Keys, (i + 1))
-		for k := 0; k < i+1; k++ {
-			s.Add(ids.GenerateTestID().String(), state.Write)
-		}
-		if i == 0 || i == 49 {
-			s.Add(conflictKey, state.Write)
-		} else {
-			s.Add(conflictKey, state.Read)
-		}
-		ti := i
-		e.Run(s, func() error {
-			if ti == 0 {
-				time.Sleep(1 * time.Second)
-			}
-
-			l.Lock()
-			completed = append(completed, ti)
-			l.Unlock()
-			return nil
-		})
-	}
-	require.NoError(e.Wait())
-	require.Equal(0, completed[0]) // First write to execute
-	// 1..48 are ran in parallel, so non-deterministic
-	require.Equal(49, completed[49]) // Second write to execute
-	// 50..99 are ran in parallel, so non-deterministic
-	require.Len(completed, 100)
-}
-
 // R->R->W...
 func TestReadThenWrite(t *testing.T) {
 	var (
@@ -443,8 +336,47 @@ func TestReadThenWrite(t *testing.T) {
 	require.Len(completed, 100)
 }
 
+// W->R->R->...W->R->R->...
+/*func TestWriteThenReadRepeated(t *testing.T) {
+	var (
+		require     = require.New(t)
+		conflictKey = ids.GenerateTestID().String()
+		l           sync.Mutex
+		completed   = make([]int, 0, 100)
+		e           = New(100, 4, nil)
+	)
+	for i := 0; i < 100; i++ {
+		s := make(state.Keys, (i + 1))
+		for k := 0; k < i+1; k++ {
+			s.Add(ids.GenerateTestID().String(), state.Write)
+		}
+		if i == 0 || i == 49 {
+			s.Add(conflictKey, state.Write)
+		} else {
+			s.Add(conflictKey, state.Read)
+		}
+		ti := i
+		e.Run(s, func() error {
+			if ti == 0 {
+				time.Sleep(1 * time.Second)
+			}
+
+			l.Lock()
+			completed = append(completed, ti)
+			l.Unlock()
+			return nil
+		})
+	}
+	require.NoError(e.Wait())
+	require.Equal(0, completed[0]) // First write to execute
+	// 1..48 are ran in parallel, so non-deterministic
+	require.Equal(49, completed[49]) // Second write to execute
+	// 50..99 are ran in parallel, so non-deterministic
+	require.Len(completed, 100)
+}*/
+
 // R->R->W->R->W->R->R...
-func TestReadThenWriteRepeated(t *testing.T) {
+/*func TestReadThenWriteRepeated(t *testing.T) {
 	var (
 		require     = require.New(t)
 		conflictKey = ids.GenerateTestID().String()

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -302,7 +302,7 @@ func TestManyWrites(t *testing.T) {
 }
 
 // R->R->R->...
-/*func TestManyReads(t *testing.T) {
+func TestManyReads(t *testing.T) {
 	var (
 		require     = require.New(t)
 		conflictKey = ids.GenerateTestID().String()
@@ -367,7 +367,7 @@ func TestWriteThenRead(t *testing.T) {
 }
 
 // W->R->R->...W->R->R->...
-func TestWriteThenReadRepeated(t *testing.T) {
+/*func TestWriteThenReadRepeated(t *testing.T) {
 	var (
 		require     = require.New(t)
 		conflictKey = ids.GenerateTestID().String()

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -4,10 +4,11 @@
 package executor
 
 import (
-	"errors"
+	_ "errors"
 	"sync"
 	"testing"
 	"time"
+	_ "fmt"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/stretchr/testify/require"
@@ -15,7 +16,7 @@ import (
 	"github.com/ava-labs/hypersdk/state"
 )
 
-func TestExecutorNoConflicts(t *testing.T) {
+/*func TestExecutorNoConflicts(t *testing.T) {
 	var (
 		require   = require.New(t)
 		l         sync.Mutex
@@ -70,9 +71,9 @@ func TestExecutorNoConflictsSlow(t *testing.T) {
 	require.NoError(e.Wait()) // existing task is running
 	require.Len(completed, 100)
 	require.Equal(0, completed[99])
-}
+}*/
 
-func TestExecutorSimpleConflict(t *testing.T) {
+/*func TestExecutorSimpleConflict(t *testing.T) {
 	var (
 		require     = require.New(t)
 		conflictKey = ids.GenerateTestID().String()
@@ -80,6 +81,7 @@ func TestExecutorSimpleConflict(t *testing.T) {
 		completed   = make([]int, 0, 100)
 		e           = New(100, 4, nil)
 	)
+	fmt.Printf("CONFLICT key %v\n", conflictKey)
 	for i := 0; i < 100; i++ {
 		s := make(state.Keys, (i + 1))
 		for k := 0; k < i+1; k++ {
@@ -264,7 +266,7 @@ func TestAllKeyThenAddWrite(t *testing.T) {
 	}
 	require.NoError(e.Wait())
 	require.Equal([]int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, completed[90:])
-}
+}*/
 
 // W->W->W->...
 func TestManyWrites(t *testing.T) {
@@ -300,7 +302,7 @@ func TestManyWrites(t *testing.T) {
 }
 
 // R->R->R->...
-func TestManyReads(t *testing.T) {
+/*func TestManyReads(t *testing.T) {
 	var (
 		require     = require.New(t)
 		conflictKey = ids.GenerateTestID().String()
@@ -481,4 +483,4 @@ func TestReadThenWriteRepeated(t *testing.T) {
 	require.Equal(12, completed[12])
 	// 13..99 are ran in parallel, so non-deterministic
 	require.Len(completed, 100)
-}
+}*/


### PR DESCRIPTION
Closes #701, #709 . This is a copy from #715 

### Overview

Please see the 2nd comment in #701 for the overall approach. Some modifications were made from the original idea. 

The executor keeps track of the last blocked Allocate/Write task in `edges`. It contains `data` which holds up to 1 Allocate/Write and possibly many Reads. This ensures that Reads can't happen before Writes, and Writes can't happen before Reads. Furthermore, this enforces the tasks to execute in the order they were enqueued, in the case of high contention.

### Review Guide

Within `executor.go` the following logic/structs would be important:

- `data`: Key information that is held within `edges`
- `Run(..)`: Updated algorithm to record dependencies.
- `runWorker()`: Removes any concurrent Reads that are executed so that the set only holds not-yet-executed Reads

The high-level algorithm of recording dependencies are as follows:

- Have we seen this key? 
   - If no, add it and set `allocateWrite` or `reads` based on the key permission.
- Have we requested an Allocate/Write key before? 
   - If no, then set `allocateWrite` if the key is an Allocate/Write key
- Have we executed the requested Allocate/Write?
   - If yes, update the last blocked task to our current task
   - If no, update the dependencies (reads are blocked by writes, writes are blocked by reads)

### Test Plan

- Added unit tests in `executor_test.go`, coverage is ~95%
- Existing unit tests in `executor_test.go` pass
- Integration tests in MorpheusVM and TokenVM pass
- CI
 
### TODOs

- [x] Add more unit tests
- [x] Handle GetValue caching