### PR TITLE
[vryx] optimistic chunk sig verification

### DIFF
--- a/chain/dependencies.go
+++ b/chain/dependencies.go
@@ -115,6 +115,7 @@ type VM interface {
 	NextChunkCertificate(ctx context.Context) (*ChunkCertificate, bool)
 	HasChunk(ctx context.Context, slot int64, id ids.ID) bool
 	RestoreChunkCertificates(context.Context, []*ChunkCertificate)
+	IsSeenChunk(context.Context, ids.ID) bool
 
 	IsValidHeight(ctx context.Context, height uint64) (bool, error)
 	CacheValidators(ctx context.Context, height uint64)

--- a/chain/dependencies.go
+++ b/chain/dependencies.go
@@ -116,6 +116,8 @@ type VM interface {
 	HasChunk(ctx context.Context, slot int64, id ids.ID) bool
 	RestoreChunkCertificates(context.Context, []*ChunkCertificate)
 	IsSeenChunk(context.Context, ids.ID) bool
+	CertChan() chan *ChunkCertificate
+	GetChunk(int64, ids.ID) (*Chunk, error)
 
 	IsValidHeight(ctx context.Context, height uint64) (bool, error)
 	CacheValidators(ctx context.Context, height uint64)

--- a/chain/dependencies.go
+++ b/chain/dependencies.go
@@ -33,6 +33,11 @@ type Parser interface {
 }
 
 type Metrics interface {
+	RecordOptimisticChunkVerify(time.Duration)
+	RecordAlreadyVerifiedChunk()
+	RecordExecutedChunks(int)
+	RecordUnusedVerifiedChunks(int)
+
 	RecordWaitAuth(time.Duration)
 	RecordWaitExec(time.Duration)
 	RecordWaitProcessor(time.Duration)

--- a/chain/engine.go
+++ b/chain/engine.go
@@ -144,6 +144,7 @@ func (e *Engine) processJob(job *engineJob) {
 		p.Add(ctx, len(chunks), chunk, !e.verified.Has(cid))
 		chunks = append(chunks, chunk)
 	}
+	e.verified.SetMin(job.blk.StatefulBlock.Timestamp) // cleanup unneeded verification statuses
 	txSet, ts, chunkResults, err := p.Wait()
 	if err != nil {
 		e.vm.Logger().Error("chunk processing failed", zap.Error(err))

--- a/chain/engine.go
+++ b/chain/engine.go
@@ -21,8 +21,9 @@ import (
 
 // TODO: unify with chunk wrapper
 type simpleChunkWrapper struct {
-	chunk ids.ID
-	slot  int64
+	chunk   ids.ID
+	slot    int64
+	success bool
 }
 
 func (scw *simpleChunkWrapper) ID() ids.ID {
@@ -141,8 +142,8 @@ func (e *Engine) processJob(job *engineJob) {
 		if err != nil {
 			panic(err)
 		}
-		_, ok := e.verified.Remove(cid)
-		p.Add(ctx, len(chunks), chunk, !ok)
+		cw, _ := e.verified.Remove(cid)
+		p.Add(ctx, len(chunks), chunk, cw)
 		chunks = append(chunks, chunk)
 	}
 	uselessVerification := len(e.verified.SetMin(job.blk.StatefulBlock.Timestamp)) // cleanup unneeded verification statuses

--- a/chain/engine.go
+++ b/chain/engine.go
@@ -336,6 +336,8 @@ func (e *Engine) Run() {
 				continue
 			}
 			// TODO: how to persist verification status if we don't keep in memory?
+			// -> eheap with verification status
+			// -> re-add chunk to channel if not yet on-disk?
 			e.vm.GetChunk(
 			// TODO: use VM recently accepted chunks to check if should skip
 			// TODO: need to verify signatures first before checking tx accuracy if

--- a/chain/engine.go
+++ b/chain/engine.go
@@ -342,6 +342,7 @@ func (e *Engine) Run() {
 			// TODO: use VM recently accepted chunks to check if should skip
 			// TODO: need to verify signatures first before checking tx accuracy if
 			// we want this early feature (otherwise, non-deterministic verification)
+			// -> pretty easy to include all valid signatures that can't pay fees anyways (useless) so this is fine
 		case job := <-e.backlog:
 			e.processJob(job)
 		case <-e.vm.StopChan():

--- a/chain/engine.go
+++ b/chain/engine.go
@@ -331,11 +331,12 @@ func (e *Engine) Run() {
 		select {
 		case cert := <-e.chunks:
 			// Need to ensure this stream is deduped (can't just send as soon as a chunk is ready)
-			if e.vm.IsSeenChunk(context.TODO(), chunkID) {
+			if e.vm.IsSeenChunk(context.TODO(), cert.Chunk) {
 				// Will process during execution loop or already processed
 				continue
 			}
-			e.vm.GetChunk
+			// TODO: how to persist verification status if we don't keep in memory?
+			e.vm.GetChunk(
 			// TODO: use VM recently accepted chunks to check if should skip
 			// TODO: need to verify signatures first before checking tx accuracy if
 			// we want this early feature (otherwise, non-deterministic verification)

--- a/chain/engine.go
+++ b/chain/engine.go
@@ -329,16 +329,13 @@ func (e *Engine) Run() {
 
 		// Check to see if any chunks are ready for signature verification (if there is nothing else to do)
 		select {
-		case chunk := <-e.chunks:
-			// TODO: need to ensure this stream is deduped (can't just send as soon as a chunk is ready)
-			chunkID, err := chunk.ID()
-			if err != nil {
-				panic(err)
-			}
+		case cert := <-e.chunks:
+			// Need to ensure this stream is deduped (can't just send as soon as a chunk is ready)
 			if e.vm.IsSeenChunk(context.TODO(), chunkID) {
 				// Will process during execution loop or already processed
 				continue
 			}
+			e.vm.GetChunk
 			// TODO: use VM recently accepted chunks to check if should skip
 			// TODO: need to verify signatures first before checking tx accuracy if
 			// we want this early feature (otherwise, non-deterministic verification)

--- a/chain/engine.go
+++ b/chain/engine.go
@@ -330,6 +330,7 @@ func (e *Engine) Run() {
 		// Check to see if any chunks are ready for signature verification (if there is nothing else to do)
 		select {
 		case chunk := <-e.chunks:
+			// TODO: need to ensure this stream is deduped (can't just send as soon as a chunk is ready)
 			chunkID, err := chunk.ID()
 			if err != nil {
 				panic(err)

--- a/chain/engine.go
+++ b/chain/engine.go
@@ -62,261 +62,276 @@ func NewEngine(vm VM, maxBacklog int) *Engine {
 	}
 }
 
+func (e *Engine) processJob(job *engineJob) {
+	log := e.vm.Logger()
+	e.vm.RecordEngineBacklog(-1)
+
+	estart := time.Now()
+	ctx := context.Background() // TODO: cleanup
+
+	// Setup state
+	parentView := e.latestView
+	r := e.vm.Rules(job.blk.StatefulBlock.Timestamp)
+
+	// Fetch parent height key and ensure block height is valid
+	heightKey := HeightKey(e.vm.StateManager().HeightKey())
+	parentHeightRaw, err := parentView.GetValue(ctx, heightKey)
+	if err != nil {
+		panic(err)
+	}
+	parentHeight := binary.BigEndian.Uint64(parentHeightRaw)
+	if job.blk.Height() != parentHeight+1 {
+		// TODO: re-execute previous blocks to get to required state
+		panic(ErrInvalidBlockHeight)
+	}
+
+	// Fetch latest block context (used for reliable and recent warp verification)
+	var (
+		pHeight             *uint64
+		shouldUpdatePHeight bool
+	)
+	pHeightKey := PHeightKey(e.vm.StateManager().PHeightKey())
+	pHeightRaw, err := parentView.GetValue(ctx, pHeightKey)
+	if err == nil {
+		h := binary.BigEndian.Uint64(pHeightRaw)
+		pHeight = &h
+	}
+	if pHeight == nil || *pHeight < job.blk.PHeight { // use latest P-Chain height during verification
+		shouldUpdatePHeight = true
+		pHeight = &job.blk.PHeight
+	}
+
+	// Fetch PChainHeight for this epoch
+	//
+	// We don't need to check timestamps here becuase we already handled that in block verification.
+	epoch := utils.Epoch(job.blk.StatefulBlock.Timestamp, r.GetEpochDuration())
+	_, epochHeights, err := e.GetEpochHeights(ctx, []uint64{epoch, epoch + 1})
+	if err != nil {
+		panic(err)
+	}
+
+	// Process chunks
+	//
+	// We know that if any new available chunks are added that block context must be non-nil (so warp messages will be processed).
+	startProcessor := time.Now()
+	p := NewProcessor(e.vm, e, pHeight, epochHeights, len(job.blk.AvailableChunks), job.blk.StatefulBlock.Timestamp, parentView, r)
+	chunks := make([]*Chunk, 0, len(job.blk.AvailableChunks))
+	for chunk := range job.chunks {
+		// Handle fetched chunk
+		p.Add(ctx, len(chunks), chunk)
+		chunks = append(chunks, chunk)
+	}
+	txSet, ts, chunkResults, err := p.Wait()
+	if err != nil {
+		e.vm.Logger().Error("chunk processing failed", zap.Error(err))
+		panic(err)
+	}
+	if len(chunks) != len(job.blk.AvailableChunks) {
+		e.vm.Logger().Warn("did not receive all chunks from engine, exiting execution")
+		return
+	}
+	e.vm.RecordWaitProcessor(time.Since(startProcessor))
+
+	// TODO: pay beneficiary all tips for processing chunk
+	//
+	// TODO: add configuration for how much of base fee to pay (could be 100% in a payment network, however,
+	// this allows miner to drive up fees without consequence as they get their fees back)
+
+	// Create FilteredChunks
+	//
+	// TODO: send chunk material here as soon as processed to speed up confirmation latency
+	txCount := 0
+	filteredChunks := make([]*FilteredChunk, len(chunkResults))
+	for i, chunkResult := range chunkResults {
+		var (
+			validResults = make([]*Result, 0, len(chunkResult))
+			chunk        = chunks[i]
+			cert         = job.blk.AvailableChunks[i]
+			txs          = make([]*Transaction, 0, len(chunkResult))
+			reward       uint64
+
+			warpResults set.Bits64
+			warpCount   uint
+		)
+		for j, txResult := range chunkResult {
+			txCount++
+			tx := chunk.Txs[j]
+			if !txResult.Valid {
+				// Remove txID from txSet if it was invalid and
+				// it was the first txID of its kind seen in the block.
+				if bl, ok := txSet[tx.ID()]; ok {
+					if bl.chunk == i && bl.index == j {
+						delete(txSet, tx.ID())
+					}
+				}
+
+				// TODO: handle case where Freezable (claim bond from user + freeze user)
+				// TODO: need to ensure that mark tx in set to prevent freezable replay?
+
+				// TODO: track invalid tx count
+				continue
+			}
+			validResults = append(validResults, txResult)
+			txs = append(txs, tx)
+			if tx.WarpMessage != nil {
+				if txResult.WarpVerified {
+					warpResults.Add(warpCount)
+				}
+				warpCount++
+			}
+
+			// Add fee to reward
+			newReward, err := math.Add64(reward, txResult.Fee)
+			if err != nil {
+				panic(err)
+			}
+			reward = newReward
+		}
+
+		// TODO: Pay beneficiary proportion of reward
+		// TODO: scale reward based on % of stake that signed cert
+		p.vm.Logger().Debug("rewarding beneficiary", zap.Uint64("reward", reward))
+
+		// Create filtered chunk
+		filteredChunks[i] = &FilteredChunk{
+			Chunk: cert.Chunk,
+
+			Producer:    chunk.Producer,
+			Beneficiary: chunk.Beneficiary,
+
+			Txs:         txs,
+			WarpResults: warpResults,
+		}
+
+		// As soon as execution of transactions is finished, let the VM know so that it
+		// can notify subscribers.
+		e.vm.Executed(ctx, job.blk.Height(), filteredChunks[i], validResults) // handled async by the vm
+	}
+
+	// Update tracked p-chain height as long as it is increasing
+	if job.blk.PHeight > 0 { // if context is not set, don't update P-Chain height in state or populate epochs
+		if shouldUpdatePHeight {
+			if err := ts.Insert(ctx, pHeightKey, binary.BigEndian.AppendUint64(nil, job.blk.PHeight)); err != nil {
+				panic(err)
+			}
+			e.vm.Logger().Info("setting current p-chain height", zap.Uint64("height", job.blk.PHeight))
+		} else {
+			e.vm.Logger().Debug("ignoring p-chain height update", zap.Uint64("height", job.blk.PHeight))
+		}
+
+		// Ensure we are never stuck waiting for height information near the end of an epoch
+		//
+		// When validating data in a given epoch e, we need to know the p-chain height for epoch e and e+1. If either
+		// is not populated, we need to know by e that e+1 cannot be populated. If we only set e+2 below, we may
+		// not know whether e+1 is populated unitl we wait for e-1 execution to finish (as any block in e-1 could set
+		// the epoch height). This could cause verification to stutter across the boundary when it is taking longer than
+		// expected to set to the p-chain hegiht for an epoch.
+		nextEpoch := epoch + 3
+		nextEpochKey := EpochKey(e.vm.StateManager().EpochKey(nextEpoch))
+		epochValueRaw, err := parentView.GetValue(ctx, nextEpochKey) // <P-Chain Height>|<Fee Dimensions>
+		switch {
+		case err == nil:
+			e.vm.Logger().Debug(
+				"height already set for epoch",
+				zap.Uint64("epoch", nextEpoch),
+				zap.Uint64("height", binary.BigEndian.Uint64(epochValueRaw[:consts.Uint64Len])),
+			)
+		case err != nil && errors.Is(err, database.ErrNotFound):
+			value := make([]byte, consts.Uint64Len)
+			binary.BigEndian.PutUint64(value, job.blk.PHeight)
+			if err := ts.Insert(ctx, nextEpochKey, value); err != nil {
+				panic(err)
+			}
+			e.vm.CacheValidators(ctx, job.blk.PHeight) // optimistically fetch validators to prevent lockbacks
+			e.vm.Logger().Info(
+				"setting epoch height",
+				zap.Uint64("epoch", nextEpoch),
+				zap.Uint64("height", job.blk.PHeight),
+			)
+		default:
+			e.vm.Logger().Warn(
+				"unable to determine if should set epoch height",
+				zap.Uint64("epoch", nextEpoch),
+				zap.Error(err),
+			)
+		}
+	}
+
+	// Update chain metadata
+	if err := ts.Insert(ctx, heightKey, binary.BigEndian.AppendUint64(nil, job.blk.StatefulBlock.Height)); err != nil {
+		panic(err)
+	}
+	if err := ts.Insert(ctx, HeightKey(e.vm.StateManager().TimestampKey()), binary.BigEndian.AppendUint64(nil, uint64(job.blk.StatefulBlock.Timestamp))); err != nil {
+		panic(err)
+	}
+
+	// Create new view and persist to disk
+	e.vm.RecordStateChanges(ts.PendingChanges())
+	e.vm.RecordStateOperations(ts.OpIndex())
+	view, err := ts.ExportMerkleDBView(ctx, e.vm.Tracer(), parentView)
+	if err != nil {
+		panic(err)
+	}
+	commitStart := time.Now()
+	if err := view.CommitToDB(ctx); err != nil {
+		panic(err)
+	}
+	root, err := view.GetMerkleRoot(ctx)
+	if err != nil {
+		panic(err)
+	}
+	e.vm.RecordWaitCommit(time.Since(commitStart))
+
+	// Store and update parent view
+	validTxs := len(txSet)
+	e.outputsLock.Lock()
+	e.outputs[job.blk.StatefulBlock.Height] = &output{
+		txs:          txSet,
+		chunkResults: chunkResults,
+		root:         root,
+		chunks:       filteredChunks,
+	}
+	e.largestOutput = &job.blk.StatefulBlock.Height
+	e.outputsLock.Unlock()
+	e.latestView = state.View(e.vm.ForceState()) // Don't offer views that will be discarded
+
+	log.Info(
+		"executed block",
+		zap.Stringer("blkID", job.blk.ID()),
+		zap.Uint64("height", job.blk.StatefulBlock.Height),
+		zap.Int("valid txs", validTxs),
+		zap.Int("total txs", txCount),
+		zap.Int("chunks", len(filteredChunks)),
+		zap.Stringer("root", root),
+		zap.Duration("t", time.Since(estart)),
+	)
+	e.vm.RecordBlockExecute(time.Since(estart))
+	e.vm.RecordTxsValid(validTxs)
+	e.vm.RecordTxsIncluded(txCount)
+}
+
 func (e *Engine) Run() {
 	defer close(e.done)
-	log := e.vm.Logger()
 
 	// Get last accepted state
 	e.latestView = state.View(e.vm.ForceState()) // TODO: state may not be ready at this point
 
 	for {
+		// Check to see if anything is on the backlog or if we should stop
 		select {
 		case job := <-e.backlog:
-			e.vm.RecordEngineBacklog(-1)
+			e.processJob(job)
+			continue
+		case <-e.vm.StopChan():
+			return
+		default:
+		}
 
-			estart := time.Now()
-			ctx := context.Background() // TODO: cleanup
-
-			// Setup state
-			parentView := e.latestView
-			r := e.vm.Rules(job.blk.StatefulBlock.Timestamp)
-
-			// Fetch parent height key and ensure block height is valid
-			heightKey := HeightKey(e.vm.StateManager().HeightKey())
-			parentHeightRaw, err := parentView.GetValue(ctx, heightKey)
-			if err != nil {
-				panic(err)
-			}
-			parentHeight := binary.BigEndian.Uint64(parentHeightRaw)
-			if job.blk.Height() != parentHeight+1 {
-				// TODO: re-execute previous blocks to get to required state
-				panic(ErrInvalidBlockHeight)
-			}
-
-			// Fetch latest block context (used for reliable and recent warp verification)
-			var (
-				pHeight             *uint64
-				shouldUpdatePHeight bool
-			)
-			pHeightKey := PHeightKey(e.vm.StateManager().PHeightKey())
-			pHeightRaw, err := parentView.GetValue(ctx, pHeightKey)
-			if err == nil {
-				h := binary.BigEndian.Uint64(pHeightRaw)
-				pHeight = &h
-			}
-			if pHeight == nil || *pHeight < job.blk.PHeight { // use latest P-Chain height during verification
-				shouldUpdatePHeight = true
-				pHeight = &job.blk.PHeight
-			}
-
-			// Fetch PChainHeight for this epoch
-			//
-			// We don't need to check timestamps here becuase we already handled that in block verification.
-			epoch := utils.Epoch(job.blk.StatefulBlock.Timestamp, r.GetEpochDuration())
-			_, epochHeights, err := e.GetEpochHeights(ctx, []uint64{epoch, epoch + 1})
-			if err != nil {
-				panic(err)
-			}
-
-			// Process chunks
-			//
-			// We know that if any new available chunks are added that block context must be non-nil (so warp messages will be processed).
-			startProcessor := time.Now()
-			p := NewProcessor(e.vm, e, pHeight, epochHeights, len(job.blk.AvailableChunks), job.blk.StatefulBlock.Timestamp, parentView, r)
-			chunks := make([]*Chunk, 0, len(job.blk.AvailableChunks))
-			for chunk := range job.chunks {
-				// Handle fetched chunk
-				p.Add(ctx, len(chunks), chunk)
-				chunks = append(chunks, chunk)
-			}
-			txSet, ts, chunkResults, err := p.Wait()
-			if err != nil {
-				e.vm.Logger().Error("chunk processing failed", zap.Error(err))
-				panic(err)
-			}
-			if len(chunks) != len(job.blk.AvailableChunks) {
-				e.vm.Logger().Warn("did not receive all chunks from engine, exiting execution")
-				return
-			}
-			e.vm.RecordWaitProcessor(time.Since(startProcessor))
-
-			// TODO: pay beneficiary all tips for processing chunk
-			//
-			// TODO: add configuration for how much of base fee to pay (could be 100% in a payment network, however,
-			// this allows miner to drive up fees without consequence as they get their fees back)
-
-			// Create FilteredChunks
-			//
-			// TODO: send chunk material here as soon as processed to speed up confirmation latency
-			txCount := 0
-			filteredChunks := make([]*FilteredChunk, len(chunkResults))
-			for i, chunkResult := range chunkResults {
-				var (
-					validResults = make([]*Result, 0, len(chunkResult))
-					chunk        = chunks[i]
-					cert         = job.blk.AvailableChunks[i]
-					txs          = make([]*Transaction, 0, len(chunkResult))
-					reward       uint64
-
-					warpResults set.Bits64
-					warpCount   uint
-				)
-				for j, txResult := range chunkResult {
-					txCount++
-					tx := chunk.Txs[j]
-					if !txResult.Valid {
-						// Remove txID from txSet if it was invalid and
-						// it was the first txID of its kind seen in the block.
-						if bl, ok := txSet[tx.ID()]; ok {
-							if bl.chunk == i && bl.index == j {
-								delete(txSet, tx.ID())
-							}
-						}
-
-						// TODO: handle case where Freezable (claim bond from user + freeze user)
-						// TODO: need to ensure that mark tx in set to prevent freezable replay?
-
-						// TODO: track invalid tx count
-						continue
-					}
-					validResults = append(validResults, txResult)
-					txs = append(txs, tx)
-					if tx.WarpMessage != nil {
-						if txResult.WarpVerified {
-							warpResults.Add(warpCount)
-						}
-						warpCount++
-					}
-
-					// Add fee to reward
-					newReward, err := math.Add64(reward, txResult.Fee)
-					if err != nil {
-						panic(err)
-					}
-					reward = newReward
-				}
-
-				// TODO: Pay beneficiary proportion of reward
-				// TODO: scale reward based on % of stake that signed cert
-				p.vm.Logger().Debug("rewarding beneficiary", zap.Uint64("reward", reward))
-
-				// Create filtered chunk
-				filteredChunks[i] = &FilteredChunk{
-					Chunk: cert.Chunk,
-
-					Producer:    chunk.Producer,
-					Beneficiary: chunk.Beneficiary,
-
-					Txs:         txs,
-					WarpResults: warpResults,
-				}
-
-				// As soon as execution of transactions is finished, let the VM know so that it
-				// can notify subscribers.
-				e.vm.Executed(ctx, job.blk.Height(), filteredChunks[i], validResults) // handled async by the vm
-			}
-
-			// Update tracked p-chain height as long as it is increasing
-			if job.blk.PHeight > 0 { // if context is not set, don't update P-Chain height in state or populate epochs
-				if shouldUpdatePHeight {
-					if err := ts.Insert(ctx, pHeightKey, binary.BigEndian.AppendUint64(nil, job.blk.PHeight)); err != nil {
-						panic(err)
-					}
-					e.vm.Logger().Info("setting current p-chain height", zap.Uint64("height", job.blk.PHeight))
-				} else {
-					e.vm.Logger().Debug("ignoring p-chain height update", zap.Uint64("height", job.blk.PHeight))
-				}
-
-				// Ensure we are never stuck waiting for height information near the end of an epoch
-				//
-				// When validating data in a given epoch e, we need to know the p-chain height for epoch e and e+1. If either
-				// is not populated, we need to know by e that e+1 cannot be populated. If we only set e+2 below, we may
-				// not know whether e+1 is populated unitl we wait for e-1 execution to finish (as any block in e-1 could set
-				// the epoch height). This could cause verification to stutter across the boundary when it is taking longer than
-				// expected to set to the p-chain hegiht for an epoch.
-				nextEpoch := epoch + 3
-				nextEpochKey := EpochKey(e.vm.StateManager().EpochKey(nextEpoch))
-				epochValueRaw, err := parentView.GetValue(ctx, nextEpochKey) // <P-Chain Height>|<Fee Dimensions>
-				switch {
-				case err == nil:
-					e.vm.Logger().Debug(
-						"height already set for epoch",
-						zap.Uint64("epoch", nextEpoch),
-						zap.Uint64("height", binary.BigEndian.Uint64(epochValueRaw[:consts.Uint64Len])),
-					)
-				case err != nil && errors.Is(err, database.ErrNotFound):
-					value := make([]byte, consts.Uint64Len)
-					binary.BigEndian.PutUint64(value, job.blk.PHeight)
-					if err := ts.Insert(ctx, nextEpochKey, value); err != nil {
-						panic(err)
-					}
-					e.vm.CacheValidators(ctx, job.blk.PHeight) // optimistically fetch validators to prevent lockbacks
-					e.vm.Logger().Info(
-						"setting epoch height",
-						zap.Uint64("epoch", nextEpoch),
-						zap.Uint64("height", job.blk.PHeight),
-					)
-				default:
-					e.vm.Logger().Warn(
-						"unable to determine if should set epoch height",
-						zap.Uint64("epoch", nextEpoch),
-						zap.Error(err),
-					)
-				}
-			}
-
-			// Update chain metadata
-			if err := ts.Insert(ctx, heightKey, binary.BigEndian.AppendUint64(nil, job.blk.StatefulBlock.Height)); err != nil {
-				panic(err)
-			}
-			if err := ts.Insert(ctx, HeightKey(e.vm.StateManager().TimestampKey()), binary.BigEndian.AppendUint64(nil, uint64(job.blk.StatefulBlock.Timestamp))); err != nil {
-				panic(err)
-			}
-
-			// Create new view and persist to disk
-			e.vm.RecordStateChanges(ts.PendingChanges())
-			e.vm.RecordStateOperations(ts.OpIndex())
-			view, err := ts.ExportMerkleDBView(ctx, e.vm.Tracer(), parentView)
-			if err != nil {
-				panic(err)
-			}
-			commitStart := time.Now()
-			if err := view.CommitToDB(ctx); err != nil {
-				panic(err)
-			}
-			root, err := view.GetMerkleRoot(ctx)
-			if err != nil {
-				panic(err)
-			}
-			e.vm.RecordWaitCommit(time.Since(commitStart))
-
-			// Store and update parent view
-			validTxs := len(txSet)
-			e.outputsLock.Lock()
-			e.outputs[job.blk.StatefulBlock.Height] = &output{
-				txs:          txSet,
-				chunkResults: chunkResults,
-				root:         root,
-				chunks:       filteredChunks,
-			}
-			e.largestOutput = &job.blk.StatefulBlock.Height
-			e.outputsLock.Unlock()
-			e.latestView = state.View(e.vm.ForceState()) // Don't offer views that will be discarded
-
-			log.Info(
-				"executed block",
-				zap.Stringer("blkID", job.blk.ID()),
-				zap.Uint64("height", job.blk.StatefulBlock.Height),
-				zap.Int("valid txs", validTxs),
-				zap.Int("total txs", txCount),
-				zap.Int("chunks", len(filteredChunks)),
-				zap.Stringer("root", root),
-				zap.Duration("t", time.Since(estart)),
-			)
-			e.vm.RecordBlockExecute(time.Since(estart))
-			e.vm.RecordTxsValid(validTxs)
-			e.vm.RecordTxsIncluded(txCount)
-
+		// Check to see if any chunks are ready for signature verification (if there is nothing else to do)
+		select {
+		case chunk := <-e.chunks:
+		case job := <-e.backlog:
+			e.processJob(job)
 		case <-e.vm.StopChan():
 			return
 		}

--- a/chain/engine.go
+++ b/chain/engine.go
@@ -330,6 +330,17 @@ func (e *Engine) Run() {
 		// Check to see if any chunks are ready for signature verification (if there is nothing else to do)
 		select {
 		case chunk := <-e.chunks:
+			chunkID, err := chunk.ID()
+			if err != nil {
+				panic(err)
+			}
+			if e.vm.IsSeenChunk(context.TODO(), chunkID) {
+				// Will process during execution loop or already processed
+				continue
+			}
+			// TODO: use VM recently accepted chunks to check if should skip
+			// TODO: need to verify signatures first before checking tx accuracy if
+			// we want this early feature (otherwise, non-deterministic verification)
 		case job := <-e.backlog:
 			e.processJob(job)
 		case <-e.vm.StopChan():

--- a/chain/engine.go
+++ b/chain/engine.go
@@ -381,12 +381,14 @@ func (e *Engine) Run() {
 				// Don't verify chunks if not verifying
 				continue
 			}
+			start := time.Now()
+			result := VerifyChunkSignatures(e.vm, chunk)
 			e.verified.Add(&simpleChunkWrapper{
 				chunk:   cert.Chunk,
 				slot:    cert.Slot,
-				success: VerifyChunkSignatures(e.vm, chunk),
+				success: result,
 			})
-			e.vm.Logger().Info("optimistically verified chunk", zap.Stringer("chunkID", cert.Chunk))
+			e.vm.Logger().Info("optimistically verified chunk", zap.Stringer("chunkID", cert.Chunk), zap.Int("txs", len(chunk.Txs)), zap.Bool("success", result), zap.Duration("t", time.Since(start)))
 		case job := <-e.backlog:
 			e.processJob(job)
 		case <-e.vm.StopChan():

--- a/chain/processor.go
+++ b/chain/processor.go
@@ -236,7 +236,7 @@ func (p *Processor) markChunkTxsInvalid(chunkIndex, count int) {
 // Chunks MUST be added in order.
 //
 // Add must not be called concurrently
-func (p *Processor) Add(ctx context.Context, chunkIndex int, chunk *Chunk) {
+func (p *Processor) Add(ctx context.Context, chunkIndex int, chunk *Chunk, verifySigs bool) {
 	ctx, span := p.vm.Tracer().Start(ctx, "Processor.Add")
 	defer span.End()
 
@@ -261,7 +261,7 @@ func (p *Processor) Add(ctx context.Context, chunkIndex int, chunk *Chunk) {
 	//
 	// We need to do this before we check basic chunk correctness to support
 	// optimistic chunk signature verification.
-	if p.vm.GetVerifyAuth() && p.vm.NodeID() != chunk.Producer { // trust ourselves
+	if p.vm.GetVerifyAuth() && p.vm.NodeID() != chunk.Producer && verifySigs { // trust ourselves
 		authJob, err := p.authWorkers.NewJob(len(chunk.Txs))
 		if err != nil {
 			panic(err)

--- a/chain/processor.go
+++ b/chain/processor.go
@@ -256,9 +256,12 @@ func (p *Processor) Add(ctx context.Context, chunkIndex int, chunk *Chunk, cw *s
 		p.markChunkTxsInvalid(chunkIndex, chunkTxs)
 		return
 	}
-	if cw != nil && !cw.success {
-		p.markChunkTxsInvalid(chunkIndex, chunkTxs)
-		return
+	if cw != nil {
+		p.vm.RecordAlreadyVerifiedChunk()
+		if !cw.success {
+			p.markChunkTxsInvalid(chunkIndex, chunkTxs)
+			return
+		}
 	}
 
 	// Verify chunk signatures

--- a/chain/processor.go
+++ b/chain/processor.go
@@ -416,3 +416,26 @@ func (p *Processor) Wait() (map[ids.ID]*blockLoc, *tstate.TState, [][]*Result, e
 	p.vm.RecordWaitExec(time.Since(exectutorStart))
 	return p.txs, p.ts, p.results, nil
 }
+
+func VerifyChunkSignatures(vm VM, chunk *Chunk) bool {
+	authWorkers := workers.NewParallel(vm.GetAuthExecutionCores(), 4) // should never have more than 1 here
+	defer authWorkers.Stop()
+
+	authJob, err := authWorkers.NewJob(len(chunk.Txs))
+	if err != nil {
+		panic(err)
+	}
+	batchVerifier := NewAuthBatch(vm, authJob, chunk.authCounts)
+	for _, tx := range chunk.Txs {
+		// Enqueue transaction for execution
+		msg, err := tx.Digest()
+		if err != nil {
+			return false
+		}
+
+		// We can only pre-check transactions that would invalidate the chunk prior to verifying signatures.
+		batchVerifier.Add(msg, tx.Auth)
+	}
+	batchVerifier.Done(nil)
+	return authJob.Wait() == nil
+}

--- a/examples/morpheusvm/cmd/morpheus-cli/cmd/prometheus.go
+++ b/examples/morpheusvm/cmd/morpheus-cli/cmd/prometheus.go
@@ -100,6 +100,9 @@ var generatePrometheusCmd = &cobra.Command{
 			panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hypersdk_chain_chunk_build_sum[5s])/1000000/5", chainID))
 			utils.Outf("{{yellow}}chunk build (ms/s):{{/}} %s\n", panels[len(panels)-1])
 
+			panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hypersdk_chain_chunk_build_sum[5s])/1000000/increase(avalanche_%s_vm_hypersdk_chain_chunk_build_count[5s])", chainID, chainID))
+			utils.Outf("{{yellow}}chunk build (ms/chunk):{{/}} %s\n", panels[len(panels)-1])
+
 			panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hypersdk_chain_chunk_bytes_built[5s])/5", chainID))
 			utils.Outf("{{yellow}}chunk bytes built per second:{{/}} %s\n", panels[len(panels)-1])
 
@@ -123,6 +126,24 @@ var generatePrometheusCmd = &cobra.Command{
 
 			panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hypersdk_chain_block_execute_sum[5s])/1000000/increase(avalanche_%s_vm_hypersdk_chain_block_execute_count[5s])", chainID, chainID))
 			utils.Outf("{{yellow}}block execute [async] (ms/block):{{/}} %s\n", panels[len(panels)-1])
+
+			panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hypersdk_chain_chunks_executed[5s])/increase(avalanche_%s_vm_hypersdk_chain_block_execute_count[5s])", chainID, chainID))
+			utils.Outf("{{yellow}}chunks per executed block:{{/}} %s\n", panels[len(panels)-1])
+
+			panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hypersdk_chain_optimistic_chunk_verify_sum[5s])/1000000/increase(avalanche_%s_vm_hypersdk_chain_optimistic_chunk_verify_count[5s])", chainID, chainID))
+			utils.Outf("{{yellow}}optimistic chunk verify [async] (ms/chunk):{{/}} %s\n", panels[len(panels)-1])
+
+			panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hypersdk_chain_optimistic_chunk_verify_sum[5s])/1000000/5", chainID))
+			utils.Outf("{{yellow}}optimistic chunk verify [async] (ms/s):{{/}} %s\n", panels[len(panels)-1])
+
+			panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hypersdk_chain_optimistic_chunk_verify_sum[5s])/1000000/5 + increase(avalanche_%s_vm_hypersdk_chain_block_execute_sum[5s])/1000000/5", chainID, chainID))
+			utils.Outf("{{yellow}}executor busy (ms/s):{{/}} %s\n", panels[len(panels)-1])
+
+			panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hypersdk_chain_chunks_already_verified[5s])/increase(avalanche_%s_vm_hypersdk_chain_chunks_executed[5s])", chainID, chainID))
+			utils.Outf("{{yellow}}chunks pre-verified:{{/}} %s\n", panels[len(panels)-1])
+
+			panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hypersdk_chain_unused_chunk_verifications[5s])/5", chainID))
+			utils.Outf("{{yellow}}unused chunk verifications per second:{{/}} %s\n", panels[len(panels)-1])
 
 			panels = append(panels, fmt.Sprintf("avalanche_%s_vm_hypersdk_chain_engine_backlog", chainID))
 			utils.Outf("{{yellow}}block execution backlog:{{/}} %s\n", panels[len(panels)-1])

--- a/vm/chunk_manager.go
+++ b/vm/chunk_manager.go
@@ -642,8 +642,8 @@ func (c *ChunkManager) AppRequest(
 		}
 		slot := int64(binary.BigEndian.Uint64(rid[:consts.Uint64Len]))
 		id := ids.ID(rid[consts.Uint64Len:])
-		chunk, err := c.vm.GetChunk(slot, id)
-		if err != nil {
+		chunk, err := c.vm.GetChunkBytes(slot, id)
+		if chunk == nil || err != nil {
 			c.vm.Logger().Warn(
 				"unable to fetch chunk",
 				zap.Stringer("nodeID", nodeID),
@@ -654,11 +654,7 @@ func (c *ChunkManager) AppRequest(
 			c.appSender.SendAppError(ctx, nodeID, requestID, -1, err.Error()) // TODO: add error so caller knows it is missing
 			return nil
 		}
-		chunkBytes, err := chunk.Marshal()
-		if err != nil {
-			panic(err)
-		}
-		c.appSender.SendAppResponse(ctx, nodeID, requestID, chunkBytes)
+		c.appSender.SendAppResponse(ctx, nodeID, requestID, chunk)
 	case filteredChunkReq:
 		rid := request[1:]
 		if len(rid) != ids.IDLen {
@@ -666,8 +662,8 @@ func (c *ChunkManager) AppRequest(
 			return nil
 		}
 		id := ids.ID(rid)
-		chunk, err := c.vm.GetFilteredChunk(id)
-		if err != nil {
+		chunk, err := c.vm.GetFilteredChunkBytes(id)
+		if chunk == nil || err != nil {
 			c.vm.Logger().Warn(
 				"unable to fetch filtered chunk",
 				zap.Stringer("nodeID", nodeID),
@@ -677,11 +673,7 @@ func (c *ChunkManager) AppRequest(
 			c.appSender.SendAppError(ctx, nodeID, requestID, -1, err.Error()) // TODO: add error so caller knows it is missing
 			return nil
 		}
-		chunkBytes, err := chunk.Marshal()
-		if err != nil {
-			panic(err)
-		}
-		c.appSender.SendAppResponse(ctx, nodeID, requestID, chunkBytes)
+		c.appSender.SendAppResponse(ctx, nodeID, requestID, chunk)
 	default:
 		c.vm.Logger().Warn("dropping unknown message type", zap.Stringer("nodeID", nodeID))
 	}

--- a/vm/resolutions.go
+++ b/vm/resolutions.go
@@ -413,6 +413,11 @@ func (vm *VM) StopChan() chan struct{} {
 	return vm.stop
 }
 
+func (vm *VM) CertChan() chan *chain.ChunkCertificate {
+	// Used for optimistic cert verification
+	return vm.validCerts
+}
+
 func (vm *VM) EngineChan() chan<- common.Message {
 	return vm.toEngine
 }

--- a/vm/resolutions.go
+++ b/vm/resolutions.go
@@ -104,6 +104,10 @@ func (vm *VM) IsRepeatChunk(ctx context.Context, certs []*chain.ChunkCertificate
 	return vm.seenChunks.Contains(certs, marker, false)
 }
 
+func (vm *VM) IsSeenChunk(ctx context.Context, chunkID ids.ID) bool {
+	return vm.seenChunks.HasID(chunkID)
+}
+
 func (vm *VM) Verified(ctx context.Context, b *chain.StatelessBlock) {
 	ctx, span := vm.tracer.Start(ctx, "VM.Verified")
 	defer span.End()

--- a/vm/resolutions.go
+++ b/vm/resolutions.go
@@ -589,3 +589,19 @@ func (vm *VM) GetAuthBatchVerifier(authTypeID uint8, cores int, count int) (chai
 	}
 	return bv.GetBatchVerifier(cores, count), ok
 }
+
+func (vm *VM) RecordOptimisticChunkVerify(t time.Duration) {
+	vm.metrics.optimisticChunkVerify.Observe(float64(t))
+}
+
+func (vm *VM) RecordAlreadyVerifiedChunk() {
+	vm.metrics.chunksAlreadyVerified.Inc()
+}
+
+func (vm *VM) RecordExecutedChunks(c int) {
+	vm.metrics.chunksExecuted.Add(float64(c))
+}
+
+func (vm *VM) RecordUnusedVerifiedChunks(c int) {
+	vm.metrics.unusedChunkVerifications.Add(float64(c))
+}

--- a/vm/storage.go
+++ b/vm/storage.go
@@ -347,12 +347,17 @@ func (vm *VM) StoreChunk(chunk *chain.Chunk) error {
 func (vm *VM) GetChunk(slot int64, chunk ids.ID) (*chain.Chunk, error) {
 	b, err := vm.blobDB.Get(ChunkFile(slot, chunk))
 	if errors.Is(err, database.ErrNotFound) {
+		// TODO: remove this pattern
 		return nil, nil
 	}
 	if err != nil {
 		return nil, err
 	}
 	return chain.UnmarshalChunk(b, vm)
+}
+
+func (vm *VM) GetChunkBytes(slot int64, chunk ids.ID) ([]byte, error) {
+	return vm.blobDB.Get(ChunkFile(slot, chunk))
 }
 
 func (vm *VM) HasChunk(_ context.Context, slot int64, chunk ids.ID) bool {
@@ -390,6 +395,10 @@ func (vm *VM) GetFilteredChunk(chunk ids.ID) (*chain.FilteredChunk, error) {
 		return nil, err
 	}
 	return chain.UnmarshalFilteredChunk(b, vm)
+}
+
+func (vm *VM) GetFilteredChunkBytes(chunk ids.ID) ([]byte, error) {
+	return vm.blobDB.Get(FilteredChunkFile(chunk))
 }
 
 func (vm *VM) RemoveFilteredChunk(chunk ids.ID) error {

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -94,6 +94,7 @@ type VM struct {
 	startSeenTime          int64
 	seenValidityWindowOnce sync.Once
 	seenValidityWindow     chan struct{}
+	validCerts             chan *chain.ChunkCertificate
 
 	// We cannot use a map here because we may parse blocks up in the ancestry
 	parsedBlocks *cache.LRU[ids.ID, *chain.StatelessBlock]
@@ -170,6 +171,7 @@ func (vm *VM) Initialize(
 	vm.seenTxs = emap.NewEMap[*chain.Transaction]()
 	vm.seenChunks = emap.NewEMap[*chain.ChunkCertificate]()
 	vm.seenValidityWindow = make(chan struct{})
+	vm.validCerts = make(chan *chain.ChunkCertificate, 256) // TODO: make a const
 	vm.ready = make(chan struct{})
 	vm.stop = make(chan struct{})
 	gatherer := ametrics.NewMultiGatherer()


### PR DESCRIPTION
The `hypersdk` now attempts to optimistically verify chunk signatures as soon as a chunk is attested (as long as the executor isn't busy processing a block).

**Additions and modifications to interfaces and structs:**

* [`chain/dependencies.go`](diffhunk://#diff-493fc040657d623dc557e54e46baf059d613bfe82adc14a8465721801cb63264R36-R40): Added new methods to the `Metrics` interface and the `VM` interface. These methods are related to recording metrics and fetching chunk information. [[1]](diffhunk://#diff-493fc040657d623dc557e54e46baf059d613bfe82adc14a8465721801cb63264R36-R40) [[2]](diffhunk://#diff-493fc040657d623dc557e54e46baf059d613bfe82adc14a8465721801cb63264R123-R125)
* [`chain/engine.go`](diffhunk://#diff-267df060160c03e05fe7d1ded739df8025c866aa178aab8c7c11bc08a2ecb7f5R16-R36): Added a new struct `simpleChunkWrapper` and a new field `verified` to the `Engine` struct. The `simpleChunkWrapper` struct is used to hold chunk information for verification, and `verified` is a heap of these wrappers. [[1]](diffhunk://#diff-267df060160c03e05fe7d1ded739df8025c866aa178aab8c7c11bc08a2ecb7f5R16-R36) [[2]](diffhunk://#diff-267df060160c03e05fe7d1ded739df8025c866aa178aab8c7c11bc08a2ecb7f5R66-R67)

**Modifications to existing methods:**

* [`chain/engine.go`](diffhunk://#diff-267df060160c03e05fe7d1ded739df8025c866aa178aab8c7c11bc08a2ecb7f5R80-L74): The `NewEngine` function now initializes the `verified` field. The `Run` function has been split into `Run` and `processJob`, with `Run` now focusing on managing the job processing loop and `processJob` handling the actual processing of a job. Additional logic has been added to handle optimistic verification of chunks and recording metrics. [[1]](diffhunk://#diff-267df060160c03e05fe7d1ded739df8025c866aa178aab8c7c11bc08a2ecb7f5R80-L74) [[2]](diffhunk://#diff-267df060160c03e05fe7d1ded739df8025c866aa178aab8c7c11bc08a2ecb7f5L129-R153) [[3]](diffhunk://#diff-267df060160c03e05fe7d1ded739df8025c866aa178aab8c7c11bc08a2ecb7f5R342-R393)
* [`chain/processor.go`](diffhunk://#diff-ea8cc6fbeac112c3e93bf5ff4062bde4096c8a4123d55e32c05e2cafc3f9928fL239-R239): The `Add` function now takes an additional parameter `cw` of type `*simpleChunkWrapper` and includes logic for handling pre-verified chunks. The function has been restructured to perform signature verification before checking basic chunk correctness. [[1]](diffhunk://#diff-ea8cc6fbeac112c3e93bf5ff4062bde4096c8a4123d55e32c05e2cafc3f9928fL239-R239) [[2]](diffhunk://#diff-ea8cc6fbeac112c3e93bf5ff4062bde4096c8a4123d55e32c05e2cafc3f9928fR254-R301) [[3]](diffhunk://#diff-ea8cc6fbeac112c3e93bf5ff4062bde4096c8a4123d55e32c05e2cafc3f9928fL281-L287) [[4]](diffhunk://#diff-ea8cc6fbeac112c3e93bf5ff4062bde4096c8a4123d55e32c05e2cafc3f9928fR341-R348) [[5]](diffhunk://#diff-ea8cc6fbeac112c3e93bf5ff4062bde4096c8a4123d55e32c05e2cafc3f9928fL363-L403)
* [`vm/chunk_manager.go`](diffhunk://#diff-48c321ce7ef2805acb0763effaad8377b67ee40fb3b01a854e6efe2fbf0feec9L99-R99): The `Update` function in the `CertStore` struct now returns a boolean indicating whether the certificate was updated. The `AppGossip` function has been updated to handle optimistic verification of chunks and to use the `GetChunkBytes` and `GetFilteredChunkBytes` methods instead of `GetChunk` and `GetFilteredChunk`. [[1]](diffhunk://#diff-48c321ce7ef2805acb0763effaad8377b67ee40fb3b01a854e6efe2fbf0feec9L99-R99) [[2]](diffhunk://#diff-48c321ce7ef2805acb0763effaad8377b67ee40fb3b01a854e6efe2fbf0feec9L110-R114) [[3]](diffhunk://#diff-48c321ce7ef2805acb0763effaad8377b67ee40fb3b01a854e6efe2fbf0feec9R468-R469) [[4]](diffhunk://#diff-48c321ce7ef2805acb0763effaad8377b67ee40fb3b01a854e6efe2fbf0feec9L537-R547) [[5]](diffhunk://#diff-48c321ce7ef2805acb0763effaad8377b67ee40fb3b01a854e6efe2fbf0feec9L640-R651) [[6]](diffhunk://#diff-48c321ce7ef2805acb0763effaad8377b67ee40fb3b01a854e6efe2fbf0feec9L652-R671) [[7]](diffhunk://#diff-48c321ce7ef2805acb0763effaad8377b67ee40fb3b01a854e6efe2fbf0feec9L675-R681)

**Logging and metrics:**

* [`examples/morpheusvm/cmd/morpheus-cli/cmd/prometheus.go`](diffhunk://#diff-79c8c59003ce3da75d8c1706bac656069efbb03a65a3dffaba9b85f211ccb01dR103-R105): Several new Prometheus panels have been added for monitoring various metrics related to chunk processing and verification. [[1]](diffhunk://#diff-79c8c59003ce3da75d8c1706bac656069efbb03a65a3dffaba9b85f211ccb01dR103-R105) [[2]](diffhunk://#diff-79c8c59003ce3da75d8c1706bac656069efbb03a65a3dffaba9b85f211ccb01dR130-R147)