### PR TITLE
[vryx] separate auth work from engine

### DIFF
--- a/chain/builder.go
+++ b/chain/builder.go
@@ -49,9 +49,17 @@ func BuildBlock(
 			// TODO: ensure only 1 chunk per producer
 			// TOOD: prefer old chunks to new chunks for a given producer
 
+			// It is assumed that [NextChunkCertificate] will never return a duplicate chunk.
 			cert, ok := vm.NextChunkCertificate(ctx)
 			if !ok {
 				break
+			}
+
+			// Check that chunk is unique (should never happen)
+			if b.chunks.Contains(cert.Chunk) {
+				log.Warn("skipping duplicate chunk in same block", zap.Stringer("chunkID", cert.Chunk))
+				b.vm.RecordBlockBuildCertDropped()
+				continue
 			}
 
 			// Check that we actually have the chunk

--- a/chain/chunk.go
+++ b/chain/chunk.go
@@ -289,6 +289,10 @@ func (c *Chunk) VerifySignature(networkID uint32, chainID ids.ID) bool {
 	return bls.Verify(c.Signer, c.Signature, msg.Bytes())
 }
 
+func (c *Chunk) AuthCounts() map[uint8]int {
+	return c.authCounts
+}
+
 func UnmarshalChunk(raw []byte, parser Parser) (*Chunk, error) {
 	var (
 		actionRegistry, authRegistry = parser.Registry()

--- a/chain/dependencies.go
+++ b/chain/dependencies.go
@@ -76,12 +76,6 @@ type VM interface {
 	RequestChunks(uint64, []*ChunkCertificate, chan *Chunk)
 	SubnetID() ids.ID
 
-	// We don't include this in registry because it would never be used
-	// by any client of the hypersdk.
-	GetVerifyAuth() bool
-	GetAuthExecutionCores() int
-	GetAuthBatchVerifier(authTypeID uint8, cores, count int) (AuthBatchVerifier, bool)
-
 	IsBootstrapped() bool
 	LastAcceptedBlock() *StatelessBlock
 	GetStatelessBlock(context.Context, ids.ID) (*StatelessBlock, error)
@@ -94,13 +88,13 @@ type VM interface {
 	IsIssuedTx(context.Context, *Transaction) bool
 	IssueTx(context.Context, *Transaction)
 
+	GetAuthResult(ids.ID) bool
 	IsRepeatTx(context.Context, []*Transaction, set.Bits) set.Bits
 	IsRepeatChunk(context.Context, []*ChunkCertificate, set.Bits) set.Bits
 
 	Mempool() Mempool
 	GetTargetChunkBuildDuration() time.Duration
 	GetActionExecutionCores() int
-	IsRPCAuthorized(ids.ID) bool
 
 	Verified(context.Context, *StatelessBlock)
 	Rejected(context.Context, *StatelessBlock)

--- a/chain/dependencies.go
+++ b/chain/dependencies.go
@@ -117,7 +117,9 @@ type VM interface {
 	Sign(*warp.UnsignedMessage) ([]byte, error)
 	StopChan() chan struct{}
 
-	NextChunkCertificate(ctx context.Context) (*ChunkCertificate, bool)
+	StartCertStream(context.Context)
+	StreamCert(context.Context) (*ChunkCertificate, bool)
+	FinishCertStream(context.Context, []*ChunkCertificate)
 	HasChunk(ctx context.Context, slot int64, id ids.ID) bool
 	RestoreChunkCertificates(context.Context, []*ChunkCertificate)
 	IsSeenChunk(context.Context, ids.ID) bool

--- a/chain/processor.go
+++ b/chain/processor.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ava-labs/hypersdk/state"
 	"github.com/ava-labs/hypersdk/tstate"
 	"github.com/ava-labs/hypersdk/utils"
-	"github.com/ava-labs/hypersdk/workers"
 	"go.uber.org/zap"
 )
 
@@ -39,8 +38,7 @@ type Processor struct {
 
 	repeatWait time.Duration
 
-	authWorkers workers.Workers
-	authWait    time.Duration
+	authWait time.Duration
 
 	serialChecks          time.Duration
 	chunkUnits            time.Duration
@@ -88,8 +86,6 @@ func NewProcessor(
 		results: make([][]*Result, chunks),
 
 		frozenSponsors: set.NewSet[string](4),
-
-		authWorkers: workers.NewParallel(vm.GetAuthExecutionCores(), 4), // should never have more than 1 here
 	}
 }
 
@@ -205,36 +201,12 @@ func (p *Processor) Add(ctx context.Context, chunkIndex int, chunk *Chunk) {
 	//
 	// We need to do this before we check basic chunk correctness to support
 	// optimistic chunk signature verification.
-	if p.vm.GetVerifyAuth() && p.vm.NodeID() != chunk.Producer { // trust ourselves
-		authJob, err := p.authWorkers.NewJob(len(chunk.Txs))
-		if err != nil {
-			panic(err)
-		}
-		batchVerifier := NewAuthBatch(p.vm, authJob, chunk.authCounts)
-
-		for _, tx := range chunk.Txs {
-			// Skip if we already authorized this
-			if p.vm.IsRPCAuthorized(tx.ID()) {
-				p.vm.RecordRPCAuthorizedTx()
-				continue
-			}
-			// Enqueue transaction for execution
-			msg, err := tx.Digest()
-			if err != nil {
-				p.vm.Logger().Warn("could not compute tx digest", zap.Stringer("txID", tx.ID()), zap.Error(err))
-				p.markChunkTxsInvalid(chunkIndex, chunkTxs)
-				return
-			}
-			// We can only pre-check transactions that would invalidate the chunk prior to verifying signatures.
-			batchVerifier.Add(msg, tx.Auth)
-		}
-		authStart := time.Now()
-		batchVerifier.Done(func() { p.authWait += time.Since(authStart) })
-		if err := authJob.Wait(); err != nil {
-			p.vm.Logger().Warn("auth verification failed", zap.Stringer("chunkID", chunk.ID()), zap.Error(err))
-			p.markChunkTxsInvalid(chunkIndex, chunkTxs)
-			return
-		}
+	authStart := time.Now()
+	authResult := p.vm.GetAuthResult(chunk.ID())
+	p.authWait += time.Since(authStart)
+	if !authResult {
+		p.markChunkTxsInvalid(chunkIndex, chunkTxs)
+		return
 	}
 
 	// Confirm that chunk is well-formed
@@ -364,7 +336,6 @@ func (p *Processor) Add(ctx context.Context, chunkIndex int, chunk *Chunk) {
 
 func (p *Processor) Wait() (map[ids.ID]*blockLoc, *tstate.TState, [][]*Result, error) {
 	p.vm.RecordWaitRepeat(p.repeatWait)
-	p.authWorkers.Stop()            // must be stopped, otherwise goroutines grow indefinitely
 	p.vm.RecordWaitAuth(p.authWait) // we record once so we can see how much of a block was spend waiting (this is not the same as the total time)
 	exectutorStart := time.Now()
 	if err := p.exectutor.Wait(); err != nil {

--- a/examples/morpheusvm/cmd/morpheus-cli/cmd/prometheus.go
+++ b/examples/morpheusvm/cmd/morpheus-cli/cmd/prometheus.go
@@ -25,6 +25,9 @@ var generatePrometheusCmd = &cobra.Command{
 		return handler.Root().GeneratePrometheus(prometheusBaseURI, prometheusOpenBrowser, startPrometheus, prometheusFile, prometheusData, func(chainID ids.ID) []string {
 			panels := []string{}
 
+			panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hypersdk_vm_txs_included[5s])/5", chainID))
+			utils.Outf("{{yellow}}all transactions processed per second:{{/}} %s\n", panels[len(panels)-1])
+
 			panels = append(panels, fmt.Sprintf("avalanche_%s_blks_processing", chainID))
 			utils.Outf("{{yellow}}blocks processing:{{/}} %s\n", panels[len(panels)-1])
 
@@ -51,9 +54,6 @@ var generatePrometheusCmd = &cobra.Command{
 
 			panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hypersdk_vm_txs_received[5s])/5", chainID))
 			utils.Outf("{{yellow}}transactions received per second:{{/}} %s\n", panels[len(panels)-1])
-
-			panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hypersdk_vm_txs_included[5s])/5", chainID))
-			utils.Outf("{{yellow}}all transactions processed per second:{{/}} %s\n", panels[len(panels)-1])
 
 			panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hypersdk_vm_txs_invalid[5s])/5", chainID))
 			utils.Outf("{{yellow}}invalid transactions processed per second:{{/}} %s\n", panels[len(panels)-1])

--- a/examples/morpheusvm/cmd/morpheus-cli/cmd/prometheus.go
+++ b/examples/morpheusvm/cmd/morpheus-cli/cmd/prometheus.go
@@ -118,6 +118,15 @@ var generatePrometheusCmd = &cobra.Command{
 			panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hypersdk_chain_chunk_bytes_built[5s])/5", chainID))
 			utils.Outf("{{yellow}}chunk bytes built per second:{{/}} %s\n", panels[len(panels)-1])
 
+			panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hypersdk_chain_chunk_auth_sum[5s])/1000000/increase(avalanche_%s_vm_hypersdk_chain_chunk_auth_count[5s])", chainID, chainID))
+			utils.Outf("{{yellow}}chunk authorization (ms/chunk):{{/}} %s\n", panels[len(panels)-1])
+
+			panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hypersdk_chain_chunk_auth_count[5s])/5", chainID))
+			utils.Outf("{{yellow}}chunk authorizations per second:{{/}} %s\n", panels[len(panels)-1])
+
+			panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hypersdk_chain_chunk_auth_sum[5s])/1000000/5", chainID))
+			utils.Outf("{{yellow}}chunk authorization (ms/s):{{/}} %s\n", panels[len(panels)-1])
+
 			panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hypersdk_chain_block_build_count[5s])/5", chainID))
 			utils.Outf("{{yellow}}blocks built per second:{{/}} %s\n", panels[len(panels)-1])
 

--- a/examples/morpheusvm/cmd/morpheus-cli/cmd/prometheus.go
+++ b/examples/morpheusvm/cmd/morpheus-cli/cmd/prometheus.go
@@ -124,6 +124,9 @@ var generatePrometheusCmd = &cobra.Command{
 			panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hypersdk_chain_chunk_auth_count[5s])/5", chainID))
 			utils.Outf("{{yellow}}chunk authorizations per second:{{/}} %s\n", panels[len(panels)-1])
 
+			panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hypersdk_chain_useless_chunk_auth[5s])/5", chainID))
+			utils.Outf("{{yellow}}useless chunk authorizations per second:{{/}} %s\n", panels[len(panels)-1])
+
 			panels = append(panels, fmt.Sprintf("increase(avalanche_%s_vm_hypersdk_chain_chunk_auth_sum[5s])/1000000/5", chainID))
 			utils.Outf("{{yellow}}chunk authorization (ms/s):{{/}} %s\n", panels[len(panels)-1])
 

--- a/vm/chunk_authorizer.go
+++ b/vm/chunk_authorizer.go
@@ -90,7 +90,6 @@ func (c *ChunkAuthorizer) auth(id ids.ID) {
 	}
 	if !c.vm.config.GetVerifyAuth() || c.vm.snowCtx.NodeID == result.chunk.Producer { // trust ourself
 		result.result = truePtr
-		result.chunk = nil
 		close(result.done)
 		return
 	}
@@ -113,7 +112,6 @@ func (c *ChunkAuthorizer) auth(id ids.ID) {
 		if err != nil {
 			c.vm.Logger().Error("chunk failed auth", zap.Stringer("chunk", chunk.ID()), zap.Error(err))
 			result.result = falsePtr
-			result.chunk = nil
 			close(result.done)
 			return
 		}
@@ -133,7 +131,6 @@ func (c *ChunkAuthorizer) auth(id ids.ID) {
 		c.vm.Logger().Debug("chunk authorized", zap.Stringer("chunk", chunk.ID()))
 		result.result = truePtr
 	}
-	result.chunk = nil
 	close(result.done)
 }
 

--- a/vm/chunk_authorizer.go
+++ b/vm/chunk_authorizer.go
@@ -1,0 +1,172 @@
+package vm
+
+import (
+	"sync"
+	"time"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/hypersdk/chain"
+	"github.com/ava-labs/hypersdk/workers"
+	"go.uber.org/zap"
+)
+
+var (
+	t        = true
+	f        = false
+	truePtr  = &t
+	falsePtr = &f
+)
+
+type job struct {
+	chunk  *chain.Chunk
+	result *bool
+	done   chan struct{}
+}
+
+type ChunkAuthorizer struct {
+	vm          *VM
+	authWorkers workers.Workers
+
+	jobsL sync.Mutex
+	jobs  map[ids.ID]*job
+
+	required   chan ids.ID
+	optimistic chan ids.ID
+}
+
+func NewChunkAuthorizer(vm *VM) *ChunkAuthorizer {
+	return &ChunkAuthorizer{
+		vm:         vm,
+		jobs:       make(map[ids.ID]*job, 128),
+		required:   make(chan ids.ID, 128),
+		optimistic: make(chan ids.ID, 128),
+	}
+}
+
+func (c *ChunkAuthorizer) Run() {
+	c.authWorkers = workers.NewParallel(c.vm.GetAuthExecutionCores(), 4)
+	defer c.authWorkers.Stop()
+
+	for {
+		// Exit if the VM is shutting down
+		select {
+		case <-c.vm.stop:
+			return
+		default:
+		}
+
+		// Check if there are any jobs that should be authorized required
+		select {
+		case id := <-c.required:
+			c.auth(id)
+			return
+		default:
+		}
+
+		// Wait for either a priortized cert or any optimistic cert
+		select {
+		case id := <-c.required:
+			c.auth(id)
+		case id := <-c.optimistic:
+			c.auth(id)
+		case <-c.vm.stop:
+			return
+		}
+	}
+}
+
+func (c *ChunkAuthorizer) auth(id ids.ID) {
+	c.jobsL.Lock()
+	result := c.jobs[id]
+	c.jobsL.Unlock()
+	if result.result != nil {
+		// Can happen if a cert is in [required] and [optimistic]
+		return
+	}
+
+	// Record time it takes to authorize the chunk
+	start := time.Now()
+	defer func() {
+		c.vm.metrics.chunkAuth.Observe(float64(time.Since(start)))
+	}()
+
+	chunk := result.chunk
+	authJob, err := c.authWorkers.NewJob(len(chunk.Txs))
+	if err != nil {
+		panic(err)
+	}
+	batchVerifier := chain.NewAuthBatch(c.vm, authJob, chunk.AuthCounts())
+	for _, tx := range chunk.Txs {
+		// Enqueue transaction for execution
+		msg, err := tx.Digest()
+		if err != nil {
+			c.vm.Logger().Error("chunk failed auth", zap.Stringer("chunk", chunk.ID()), zap.Error(err))
+			result.result = falsePtr
+			result.chunk = nil
+			close(result.done)
+			return
+		}
+		if c.vm.IsRPCAuthorized(tx.ID()) {
+			c.vm.RecordRPCAuthorizedTx()
+			continue
+		}
+
+		// We can only pre-check transactions that would invalidate the chunk prior to verifying signatures.
+		batchVerifier.Add(msg, tx.Auth)
+	}
+	batchVerifier.Done(nil)
+	if err := authJob.Wait(); err != nil {
+		c.vm.Logger().Error("chunk failed auth", zap.Stringer("chunk", chunk.ID()), zap.Error(err))
+		result.result = falsePtr
+	} else {
+		c.vm.Logger().Debug("chunk authorized", zap.Stringer("chunk", chunk.ID()))
+		result.result = truePtr
+	}
+	result.chunk = nil
+	close(result.done)
+}
+
+// It is safe to call [Add] multiple times with the same chunk
+func (c *ChunkAuthorizer) Add(chunk *chain.Chunk, cert *chain.ChunkCertificate) {
+	// Check if already added
+	c.jobsL.Lock()
+	if _, ok := c.jobs[cert.Chunk]; ok {
+		c.jobsL.Unlock()
+		return
+	}
+	c.jobs[cert.Chunk] = &job{
+		chunk: chunk,
+		done:  make(chan struct{}),
+	}
+	c.jobsL.Unlock()
+
+	// Queue chunk for authorization
+	c.optimistic <- cert.Chunk
+}
+
+func (c *ChunkAuthorizer) Wait(id ids.ID) bool {
+	c.jobsL.Lock()
+	result, ok := c.jobs[id]
+	c.jobsL.Unlock()
+	if !ok {
+		panic("waiting on certificate that wasn't enqueued")
+	}
+
+	// If cert auth is not done yet, make sure to prioritize it
+	if result.result == nil {
+		c.required <- id
+	}
+
+	// Wait for result
+	<-result.done
+	return *result.result
+}
+
+func (c *ChunkAuthorizer) Remove(certs []ids.ID) {
+	c.jobsL.Lock()
+	defer c.jobsL.Unlock()
+
+	for _, id := range certs {
+		delete(c.jobs, id)
+	}
+}

--- a/vm/chunk_authorizer.go
+++ b/vm/chunk_authorizer.go
@@ -61,7 +61,7 @@ func (c *ChunkAuthorizer) Run() {
 		select {
 		case id := <-c.required:
 			c.auth(id)
-			return
+			continue
 		default:
 		}
 

--- a/vm/chunk_authorizer.go
+++ b/vm/chunk_authorizer.go
@@ -154,6 +154,7 @@ func (c *ChunkAuthorizer) Add(chunk *chain.Chunk) {
 func (c *ChunkAuthorizer) Wait(id ids.ID) bool {
 	result, ok := c.jobs.Get(id)
 	if !ok {
+		// This panic would also catch if a chunk was included twice
 		panic("waiting on certificate that wasn't enqueued")
 	}
 

--- a/vm/chunk_manager.go
+++ b/vm/chunk_manager.go
@@ -1180,6 +1180,7 @@ func (c *ChunkManager) PushChunkCertificate(ctx context.Context, cert *chain.Chu
 	c.appSender.SendAppGossipSpecific(ctx, validators, msg) // skips validators we aren't connected to
 }
 
+// We never want to drop a chunk with more signatures, so this isn't identical to the tx repeat case.
 func (c *ChunkManager) NextChunkCertificate(ctx context.Context) (*chain.ChunkCertificate, bool) {
 	return c.certs.Pop(ctx)
 }

--- a/vm/chunk_manager.go
+++ b/vm/chunk_manager.go
@@ -171,7 +171,6 @@ func (c *CertStore) Update(cert *chain.ChunkCertificate) {
 	}
 	elem.cert = cert
 	c.eh.Update(elem)
-	return
 }
 
 // Called when a block is accepted with valid certs.
@@ -652,7 +651,7 @@ func (c *ChunkManager) AppGossip(ctx context.Context, nodeID ids.NodeID, msg []b
 		//
 		// This operation should be cached, so it should be fast.
 		chunk, err := c.vm.GetChunk(cert.Slot, cert.Chunk)
-		if err != nil {
+		if chunk == nil {
 			c.vm.Logger().Warn("skipping optimistic chunk auth because chunk is missing", zap.Stringer("chunkID", cert.Chunk), zap.Error(err))
 			return nil
 		}
@@ -870,6 +869,7 @@ func (c *ChunkManager) Run(appSender common.AppSender) {
 					continue
 				default:
 				}
+				c.auth.Add(chunk) // this will be a no-op because we are the producer
 				c.PushChunk(context.TODO(), chunk)
 				chunkBytes := chunk.Size()
 				c.vm.metrics.chunkBuild.Observe(float64(time.Since(chunkStart)))

--- a/vm/metrics.go
+++ b/vm/metrics.go
@@ -66,6 +66,7 @@ type Metrics struct {
 	unitsExecutedRead         prometheus.Counter
 	unitsExecutedAllocate     prometheus.Counter
 	unitsExecutedWrite        prometheus.Counter
+	uselessChunkAuth          prometheus.Counter
 	engineBacklog             prometheus.Gauge
 	rpcTxBacklog              prometheus.Gauge
 	chainDataSize             prometheus.Gauge
@@ -470,6 +471,11 @@ func newMetrics() (*prometheus.Registry, *Metrics, error) {
 			Name:      "units_executed_write",
 			Help:      "number of write units executed",
 		}),
+		uselessChunkAuth: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: "chain",
+			Name:      "useless_chunk_auth",
+			Help:      "number of chunks that were authenticated but not executed",
+		}),
 		engineBacklog: prometheus.NewGauge(prometheus.GaugeOpts{
 			Namespace: "chain",
 			Name:      "engine_backlog",
@@ -594,6 +600,7 @@ func newMetrics() (*prometheus.Registry, *Metrics, error) {
 		r.Register(m.unitsExecutedRead),
 		r.Register(m.unitsExecutedAllocate),
 		r.Register(m.unitsExecutedWrite),
+		r.Register(m.uselessChunkAuth),
 	)
 	return r, m, errs.Err
 }

--- a/vm/metrics.go
+++ b/vm/metrics.go
@@ -93,6 +93,7 @@ type Metrics struct {
 	fetchMissingChunks        metric.Averager
 	collectChunkSignatures    metric.Averager
 	txTimeRemainingMempool    metric.Averager
+	chunkAuth                 metric.Averager
 
 	executorRecorder executor.Metrics
 }
@@ -248,6 +249,15 @@ func newMetrics() (*prometheus.Registry, *Metrics, error) {
 		"chain",
 		"tx_time_remaining_mempool",
 		"valid time for inclusion when a tx is included in the mempool",
+		r,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	chunkAuth, err := metric.NewAverager(
+		"chain",
+		"chunk_auth",
+		"time spent authenticating chunks",
 		r,
 	)
 	if err != nil {
@@ -527,6 +537,7 @@ func newMetrics() (*prometheus.Registry, *Metrics, error) {
 		fetchMissingChunks:     fetchMissingChunks,
 		collectChunkSignatures: collectChunkSignatures,
 		txTimeRemainingMempool: txTimeRemainingMempool,
+		chunkAuth:              chunkAuth,
 	}
 	m.executorRecorder = &executorMetrics{blocked: m.executorBlocked, executable: m.executorExecutable}
 

--- a/vm/resolutions.go
+++ b/vm/resolutions.go
@@ -192,6 +192,9 @@ func (vm *VM) processExecutedBlock(blk *chain.StatefulBlock) {
 		vm.metrics.executedBlockProcess.Observe(float64(time.Since(start)))
 	}()
 
+	// Clear authorization results
+	vm.metrics.uselessChunkAuth.Add(float64(len(vm.cm.auth.SetMin(blk.Timestamp))))
+
 	// Update timestamp in mempool
 	//
 	// We wait to update the min until here because we want to allow all execution
@@ -702,4 +705,9 @@ func (vm *VM) RecordAcceptedEpoch(e uint64) {
 
 func (vm *VM) RecordExecutedEpoch(e uint64) {
 	vm.metrics.lastExecutedEpoch.Set(float64(e))
+}
+
+func (vm *VM) GetAuthResult(chunkID ids.ID) bool {
+	// TODO: clean up this invocation
+	return vm.cm.auth.Wait(chunkID)
 }

--- a/vm/resolutions.go
+++ b/vm/resolutions.go
@@ -383,14 +383,12 @@ func (vm *VM) Accepted(ctx context.Context, b *chain.StatelessBlock, chunks []*c
 	//
 	// Transactions are added to [seen] with their [expiry], so we don't need to
 	// transform [blkTime] when calling [SetMin] here.
-	evictedTxs := vm.seenTxs.SetMin(blkTime)
-	vm.Logger().Debug("txs evicted from seen", zap.Int("len", len(evictedTxs)))
+	vm.Logger().Debug("txs evicted from seen", zap.Int("len", len(vm.seenTxs.SetMin(blkTime))))
+	vm.Logger().Debug("chunks evicted from seen", zap.Int("len", len(vm.seenChunks.SetMin(blkTime))))
 	for _, fc := range chunks {
 		// Mark all valid txs as seen
 		vm.seenTxs.Add(fc.Txs)
 	}
-	evictedChunks := vm.seenChunks.SetMin(blkTime)
-	vm.Logger().Debug("chunks evicted from seen", zap.Int("len", len(evictedChunks)))
 	vm.seenChunks.Add(b.AvailableChunks)
 
 	// Verify if emap is now sufficient (we need a consecutive run of blocks with

--- a/vm/resolutions.go
+++ b/vm/resolutions.go
@@ -601,8 +601,16 @@ func (vm *VM) GetExecutorRecorder() executor.Metrics {
 	return vm.metrics.executorRecorder
 }
 
-func (vm *VM) NextChunkCertificate(ctx context.Context) (*chain.ChunkCertificate, bool) {
-	return vm.cm.NextChunkCertificate(ctx)
+func (vm *VM) StartCertStream(context.Context) {
+	vm.cm.certs.StartStream()
+}
+
+func (vm *VM) StreamCert(ctx context.Context) (*chain.ChunkCertificate, bool) {
+	return vm.cm.certs.Stream(ctx)
+}
+
+func (vm *VM) FinishCertStream(_ context.Context, certs []*chain.ChunkCertificate) {
+	vm.cm.certs.FinishStream(certs)
 }
 
 func (vm *VM) RestoreChunkCertificates(ctx context.Context, certs []*chain.ChunkCertificate) {


### PR DESCRIPTION
- [x] remove used chunks from `ChunkAuthorizer`
- [x] fix block pruning
  - [x] we can get chunk certificates during the block build and re-add