### PR TITLE
add benchmark for pebble

### DIFF
--- a/pebble/pebble_test.go
+++ b/pebble/pebble_test.go
@@ -1,0 +1,63 @@
+package pebble
+
+import (
+	"crypto/rand"
+	"fmt"
+	"os"
+	"testing"
+)
+
+const batchSize = 1_500_000
+
+func randBytes() []byte {
+	b := make([]byte, 32)
+	_, err := rand.Read(b)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
+func BenchmarkBatchInsertion(b *testing.B) {
+	for _, sync := range []bool{false, true} {
+		b.Run(fmt.Sprintf("sync=%t", sync), func(b *testing.B) {
+			// Setup DB
+			b.StopTimer()
+			tdir := b.TempDir()
+			cfg := NewDefaultConfig()
+			cfg.Sync = sync
+			db, _, err := New(tdir, cfg)
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			// Setup keys
+			keys := make([][]byte, batchSize)
+			for i := 0; i < batchSize; i++ {
+				keys[i] = randBytes()
+			}
+
+			b.StartTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				batch := db.NewBatch()
+				for j := 0; j < batchSize; j++ {
+					if err := batch.Put(keys[j], randBytes()); err != nil {
+						b.Fatal(err)
+					}
+				}
+				if err := batch.Write(); err != nil {
+					b.Fatal(err)
+				}
+			}
+			b.StopTimer()
+
+			if err := db.Close(); err != nil {
+				b.Fatal(err)
+			}
+			if err := os.RemoveAll(tdir); err != nil {
+				b.Fatal(err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
`go test -timeout 999999s -bench=. -benchtime=100x`

```
goos: darwin
goarch: arm64
pkg: github.com/ava-labs/hypersdk/pebble
BenchmarkBatchInsertion/sync=false-12         	     100	1221987962 ns/op	347194269 B/op	 1512420 allocs/op
BenchmarkBatchInsertion/sync=true-12          	     100	1244107152 ns/op	347131379 B/op	 1512449 allocs/op
PASS
ok  	github.com/ava-labs/hypersdk/pebble	255.915s
```

At no point did the CPU time spike to 100% across all cores.