### PR TITLE
[executor] Introduce on-the-fly scheduling for Read/Allocate/Write keys

### DIFF
--- a/chain/builder.go
+++ b/chain/builder.go
@@ -161,7 +161,7 @@ func BuildBlock(
 			break
 		}
 
-		e := executor.New(streamBatch, vm.GetTransactionExecutionCores(), vm.GetExecutorBuildRecorder())
+		e := executor.New(streamBatch, vm.GetTransactionExecutionCores(), MaxKeyDependencies, vm.GetExecutorBuildRecorder())
 		pending := make(map[ids.ID]*Transaction, streamBatch)
 		var pendingLock sync.Mutex
 		for li, ltx := range txs {

--- a/chain/consts.go
+++ b/chain/consts.go
@@ -35,6 +35,10 @@ const (
 	HeightKeyChunks       = 1
 	TimestampKeyChunks    = 1
 	FeeKeyChunks          = 8 // 96 (per dimension) * 5 (num dimensions)
+
+	// MaxKeyDependencies must be greater than the maximum number of key dependencies
+	// any single task could have when executing a task.
+	MaxKeyDependencies = 100_000_000
 )
 
 func HeightKey(prefix []byte) []byte {

--- a/chain/processor.go
+++ b/chain/processor.go
@@ -39,7 +39,7 @@ func (b *StatelessBlock) Execute(
 		t      = b.GetTimestamp()
 
 		f       = fetcher.New(im, numTxs, b.vm.GetStateFetchConcurrency())
-		e       = executor.New(numTxs, b.vm.GetTransactionExecutionCores(), b.vm.GetExecutorVerifyRecorder())
+		e       = executor.New(numTxs, b.vm.GetTransactionExecutionCores(), MaxKeyDependencies, b.vm.GetExecutorVerifyRecorder())
 		ts      = tstate.New(numTxs * 2) // TODO: tune this heuristic
 		results = make([]*Result, numTxs)
 	)

--- a/examples/morpheusvm/go.mod
+++ b/examples/morpheusvm/go.mod
@@ -125,6 +125,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.11.2 // indirect
 	go.opentelemetry.io/otel/trace v1.11.2 // indirect
 	go.opentelemetry.io/proto/otlp v0.19.0 // indirect
+	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/mock v0.4.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.17.0 // indirect

--- a/examples/morpheusvm/go.sum
+++ b/examples/morpheusvm/go.sum
@@ -636,6 +636,8 @@ go.opentelemetry.io/otel/trace v1.11.2/go.mod h1:4N+yC7QEz7TTsG9BSRLNAa63eg5E06O
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
 go.opentelemetry.io/proto/otlp v0.19.0 h1:IVN6GR+mhC4s5yfcTbmzHYODqvWAp3ZedA2SJPI1Nnw=
 go.opentelemetry.io/proto/otlp v0.19.0/go.mod h1:H7XAot3MsfNsj7EXtrA2q5xSNQ10UqI405h3+duxN4U=
+go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
+go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 go.uber.org/goleak v1.2.1 h1:NBol2c7O1ZokfZ0LEU9K6Whx/KnwvepVetCUhtKja4A=
 go.uber.org/goleak v1.2.1/go.mod h1:qlT2yGI9QafXHhZZLxlSuNsMw3FFLxBr+tBRlmO1xH4=
 go.uber.org/mock v0.4.0 h1:VcM4ZOtdbR4f6VXfiOpwpVJDL6lCReaZ6mw31wqh7KU=

--- a/examples/tokenvm/go.mod
+++ b/examples/tokenvm/go.mod
@@ -140,6 +140,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.11.2 // indirect
 	go.opentelemetry.io/otel/trace v1.11.2 // indirect
 	go.opentelemetry.io/proto/otlp v0.19.0 // indirect
+	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/mock v0.4.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.17.0 // indirect

--- a/examples/tokenvm/go.sum
+++ b/examples/tokenvm/go.sum
@@ -670,6 +670,8 @@ go.opentelemetry.io/otel/trace v1.11.2/go.mod h1:4N+yC7QEz7TTsG9BSRLNAa63eg5E06O
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
 go.opentelemetry.io/proto/otlp v0.19.0 h1:IVN6GR+mhC4s5yfcTbmzHYODqvWAp3ZedA2SJPI1Nnw=
 go.opentelemetry.io/proto/otlp v0.19.0/go.mod h1:H7XAot3MsfNsj7EXtrA2q5xSNQ10UqI405h3+duxN4U=
+go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
+go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 go.uber.org/goleak v1.2.1 h1:NBol2c7O1ZokfZ0LEU9K6Whx/KnwvepVetCUhtKja4A=
 go.uber.org/goleak v1.2.1/go.mod h1:qlT2yGI9QafXHhZZLxlSuNsMw3FFLxBr+tBRlmO1xH4=
 go.uber.org/mock v0.4.0 h1:VcM4ZOtdbR4f6VXfiOpwpVJDL6lCReaZ6mw31wqh7KU=

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -120,13 +120,15 @@ func (e *Executor) Run(keys state.Keys, f func() error) {
 
 	// Record dependencies
 	previousDependencies := set.NewSet[int](len(keys))
-	for k := range keys {
+	for k, v := range keys {
 		latest, ok := e.nodes[k]
 		if ok {
 			lt := e.tasks[latest]
 			if !lt.executed {
 				previousDependencies.Add(latest) // we may depend on the same task multiple times
-				lt.blocking[id] = t
+				if v.Has(state.Allocate) || v.Has(state.Write) {
+					lt.blocking[id] = t
+				}
 			}
 		}
 		e.nodes[k] = id

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -117,7 +117,7 @@ func (e *Executor) Run(keys state.Keys, f func() error) {
 	t := &task{
 		id:       id,
 		f:        f,
-		blocking: map[int]*task{},
+		blocking: make(map[int]*task),
 	}
 	e.tasks[id] = t
 

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -150,9 +150,16 @@ func (e *Executor) Run(keys state.Keys, f func() error) {
 					lt.blocking[id] = t
 					lt.l.Unlock()
 					continue
-				/*case (v.Has(state.Allocate) || v.Has(state.Write)) && !n.isAllocateWrite:
+				case (v.Has(state.Allocate) || v.Has(state.Write)) && !n.isAllocateWrite:
 					// blocked by all reads
-					t.dependencies.Add(int64(len(lt.blocking)))*/
+					t.dependencies.Add(int64(len(lt.blocking) + 1))
+					for b := range lt.blocking {
+						bt := e.tasks[b]
+						bt.l.Lock()
+						bt.blocking[id] = t
+						bt.l.Unlock()
+					}
+					lt.blocking[id] = t
 				case (v.Has(state.Allocate) || v.Has(state.Write)) && n.isAllocateWrite:
 					t.dependencies.Add(int64(1))
 					lt.blocking[id] = t					

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -151,6 +151,9 @@ func (e *Executor) Run(keys state.Keys, f func() error) {
 				case (v.Has(state.Allocate) || v.Has(state.Write)) && !n.isAllocateWrite:
 					// blocked by all reads
 					t.dependencies.Add(int64(len(lt.blocking)))*/
+				case (v.Has(state.Allocate) || v.Has(state.Write)) && n.isAllocateWrite:
+					t.dependencies.Add(int64(1))
+					lt.blocking[id] = t					
 				}
 			}
 			lt.l.Unlock()

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -145,10 +145,12 @@ func (e *Executor) Run(keys state.Keys, f func() error) {
 					lt.blocking[id] = t
 					lt.l.Unlock()
 					continue
-				/*case v == state.Read && n.isAllocateWrite:
+				case v == state.Read && n.isAllocateWrite:
 					t.dependencies.Add(int64(1))
 					lt.blocking[id] = t
-				case (v.Has(state.Allocate) || v.Has(state.Write)) && !n.isAllocateWrite:
+					lt.l.Unlock()
+					continue
+				/*case (v.Has(state.Allocate) || v.Has(state.Write)) && !n.isAllocateWrite:
 					// blocked by all reads
 					t.dependencies.Add(int64(len(lt.blocking)))*/
 				case (v.Has(state.Allocate) || v.Has(state.Write)) && n.isAllocateWrite:

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -6,6 +6,7 @@ package executor
 import (
 	"sync"
 	"sync/atomic"
+	"fmt"
 
 	// "github.com/ava-labs/avalanchego/utils/set"
 
@@ -31,7 +32,12 @@ type Executor struct {
 	done      bool
 	completed int
 	tasks     map[int]*task
-	nodes     map[string]int
+	nodes     map[string]*node
+}
+
+type node struct {
+	id int 
+	isAllocateWrite bool
 }
 
 // New creates a new [Executor].
@@ -40,7 +46,7 @@ func New(items, concurrency int, metrics Metrics) *Executor {
 		metrics:    metrics,
 		stop:       make(chan struct{}),
 		tasks:      make(map[int]*task, items),
-		nodes:      make(map[string]int, items*2), // TODO: tune this
+		nodes:      make(map[string]*node, items*2), // TODO: tune this
 		executable: make(chan *task, items),       // ensure we don't block while holding lock
 	}
 	e.wg.Add(concurrency)
@@ -69,6 +75,7 @@ func (e *Executor) runWorker() {
 			if !ok {
 				return
 			}
+			fmt.Printf("a tid %v\n", t.id)
 			if err := t.f(); err != nil {
 				e.stopOnce.Do(func() {
 					e.err = err
@@ -77,22 +84,30 @@ func (e *Executor) runWorker() {
 				return
 			}
 
+			fmt.Printf("b tid %v\n", t.id)
+			//fmt.Printf("tid %v | t.blocking %v\n", t.id, len(t.blocking))
 			e.l.Lock()
 			for _, bt := range t.blocking {
-				if bt.dependencies.Add(-1) > 0 {
+				//fmt.Printf("tid %v | id %v | executed %v | dep %v | b %v\n", t.id, bt.id, bt.executed, bt.dependencies.Load(), bt.blocking)
+				if bt.dependencies.Load() > 0 && bt.dependencies.Add(-1) > 0 {
 					continue
 				}
-				e.executable <- bt
+				if !bt.executed {
+					//fmt.Printf("len %v\n", len(e.executable))
+					e.executable <- bt	
+				}
 			}
 			t.blocking = nil // free memory
 			t.executed = true
 			e.completed++
 			if e.done && e.completed == len(e.tasks) {
+				fmt.Printf("this sholdn't print\n")
 				// We will close here if there are unexecuted tasks
 				// when we call [Wait].
 				close(e.executable)
 			}
 			e.l.Unlock()
+			fmt.Printf("c tid %v\n", t.id)
 		case <-e.stop:
 			return
 		}
@@ -115,19 +130,29 @@ func (e *Executor) Run(keys state.Keys, f func() error) {
 	e.tasks[id] = t
 
 	// Record dependencies
-	//previousDependencies := set.NewSet[int](len(keys))
 	for k, v := range keys {
-		latest, ok := e.nodes[k]
+		n, ok := e.nodes[k]
 		if ok {
-			lt := e.tasks[latest]
+			lt := e.tasks[n.id]
 			if !lt.executed {
-				if v.Has(state.Allocate) || v.Has(state.Write) {
+				switch {
+				case v == state.Read && !n.isAllocateWrite:
+					lt.blocking[id] = t
+					continue
+				/*case v == state.Read && n.isAllocateWrite:
 					t.dependencies.Add(int64(1))
+					lt.blocking[id] = t
+				case (v.Has(state.Allocate) || v.Has(state.Write)) && !n.isAllocateWrite:
+					// blocked by all reads
+					t.dependencies.Add(int64(len(lt.blocking)))
+					lt.blocking[id] = t
+				case (v.Has(state.Allocate) || v.Has(state.Write)) && n.isAllocateWrite:
+					t.dependencies.Add(int64(1))
+					lt.blocking[id] = t*/			
 				}
-				lt.blocking[id] = t
 			}
 		}
-		e.nodes[k] = id
+		e.nodes[k] = &node{id: id, isAllocateWrite: v.Has(state.Allocate) || v.Has(state.Write)}
 	}
 
 	if t.dependencies.Load() > 0 {

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -121,15 +121,10 @@ func (e *Executor) Run(keys state.Keys, f func() error) {
 		if ok {
 			lt := e.tasks[latest]
 			if !lt.executed {
-				if v == state.Read {
-					lt.dependencies.Add(int64(1))
-					continue
-				}
-				//previousDependencies.Add(latest) // we may depend on the same task multiple times
 				if v.Has(state.Allocate) || v.Has(state.Write) {
 					t.dependencies.Add(int64(1))
-					lt.blocking[id] = t
 				}
+				lt.blocking[id] = t
 			}
 		}
 		e.nodes[k] = id

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -156,10 +156,12 @@ func (e *Executor) Run(keys state.Keys, f func() error) {
 						continue
 					}
 					// blocked by all Reads plus an Allocate/Write or the first Read
-					// example: w->r->r...w->r->r OR r->r->w...
-					for b := range lt.blocking {
-						bt := e.tasks[b]
-						previousDependencies.Add(b)
+					// case 1: w->r->r...w->r->r, the length of [blocking] on the
+					// second [w] is the number of reads from the first [w].
+					// case 2: r->r->w..., the length of [blocking] is the number of
+					// reads called before the first [w]
+					for bid, bt := range lt.blocking {
+						previousDependencies.Add(bid)
 						bt.l.Lock()
 						bt.blocking[id] = t
 						bt.l.Unlock()

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -157,15 +157,15 @@ func (e *Executor) Run(keys state.Keys, f func() error) {
 					// case 2: r->r->w..., the length of [blocking] is the number of
 					// reads called before the first [w]
 					for bid, bt := range lt.blocking {
+						// this may happen in multi-key conflicts, where the id already
+						// exists in blocking, so we don't want to record that we're
+						// blocked on ourself
 						if bid == id {
 							continue
 						}
 						bt.l.Lock()
 						if !bt.executed {
 							previousDependencies.Add(bid) // may depend on the same task
-							if bt.blocking == nil {
-								bt.blocking = make(map[int]*task)
-							}
 							bt.blocking[id] = t
 						}
 						bt.l.Unlock()

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -67,8 +67,7 @@ func (e *Executor) work() {
 }
 
 type task struct {
-	id int
-	f  func() error
+	f func() error
 
 	l        sync.Mutex
 	blocking map[int]*task
@@ -117,7 +116,6 @@ func (e *Executor) Run(keys state.Keys, f func() error) {
 	// Add task to map
 	id := len(e.tasks)
 	t := &task{
-		id:       id,
 		f:        f,
 		blocking: make(map[int]*task),
 	}

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -20,11 +20,6 @@ import (
 // Executor ensures that conflicting tasks
 // are executed in the order they were queued.
 // Tasks with no conflicts are executed immediately.
-//
-// It is assumed that no single task has more than [maxDependencies].
-// This is used to ensure a dependent task does not begin executing a
-// task until all dependencies have been enqueued. If this invariant is
-// violated, some tasks will never execute and this code could deadlock.
 type Executor struct {
 	metrics Metrics
 
@@ -41,6 +36,11 @@ type Executor struct {
 }
 
 // New creates a new [Executor].
+//
+// It is assumed that no single task has more than [maxDependencies].
+// This is used to ensure a dependent task does not begin executing a
+// task until all dependencies have been enqueued. If this invariant is
+// violated, some tasks will never execute and this code could deadlock.
 func New(items, concurrency int, maxDependencies int64, metrics Metrics) *Executor {
 	e := &Executor{
 		metrics:         metrics,

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -4,7 +4,7 @@
 package executor
 
 import (
-	_ "errors"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -16,7 +16,7 @@ import (
 	"github.com/ava-labs/hypersdk/state"
 )
 
-/*func TestExecutorNoConflicts(t *testing.T) {
+func TestExecutorNoConflicts(t *testing.T) {
 	var (
 		require   = require.New(t)
 		l         sync.Mutex
@@ -197,10 +197,10 @@ func TestStop(t *testing.T) {
 	}
 	require.Less(len(completed), 500)
 	require.ErrorIs(e.Wait(), ErrStopped) // no task running
-}*/
+}
 
 // W->W->W->...
-func TestManyWrites(t *testing.T) {
+/*func TestManyWrites(t *testing.T) {
 	var (
 		require     = require.New(t)
 		conflictKey = ids.GenerateTestID().String()
@@ -379,3 +379,45 @@ func TestWriteThenReadRepeated(t *testing.T) {
 	// 50..99 are ran in parallel, so non-deterministic
 	require.Len(completed, 100)
 }
+
+// R->R->W->R->W->R->R...
+func TestReadThenWriteRepeated(t *testing.T) {
+	var (
+		require     = require.New(t)
+		conflictKey = ids.GenerateTestID().String()
+		l           sync.Mutex
+		completed   = make([]int, 0, 100)
+		e           = New(100, 4, nil)
+	)
+	for i := 0; i < 100; i++ {
+		s := make(state.Keys, (i + 1))
+		for k := 0; k < i+1; k++ {
+			s.Add(ids.GenerateTestID().String(), state.Write)
+		}
+		if i == 10 || i == 12 {
+			s.Add(conflictKey, state.Write)
+		} else {
+			s.Add(conflictKey, state.Read)
+		}
+		ti := i
+		e.Run(s, func() error {
+			if ti == 10 {
+				time.Sleep(1 * time.Second)
+			}
+
+			l.Lock()
+			completed = append(completed, ti)
+			l.Unlock()
+			return nil
+		})
+	}
+	require.NoError(e.Wait())
+	fmt.Printf("completed %v\n", completed)
+	// 0..9 are ran in parallel, so non-deterministic
+	require.Equal(10, completed[10])
+	require.Equal(11, completed[11])
+	require.Equal(12, completed[12])
+	// 13..99 are ran in parallel, so non-deterministic
+	require.Len(completed, 100)
+}
+*/

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -197,7 +197,7 @@ func TestStop(t *testing.T) {
 	}
 	require.Less(len(completed), 500)
 	require.ErrorIs(e.Wait(), ErrStopped) // no task running
-}
+}*/
 
 // W->W->W->...
 func TestManyWrites(t *testing.T) {
@@ -230,7 +230,7 @@ func TestManyWrites(t *testing.T) {
 	}
 	require.NoError(e.Wait())
 	require.Equal(answer, completed)
-}*/
+}
 
 // R->R->R->...
 func TestManyReads(t *testing.T) {

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -168,8 +168,8 @@ func TestEarlyExit(t *testing.T) {
 			return nil
 		})
 	}
-	require.Less(len(completed), 500)
-	require.ErrorIs(e.Wait(), terr) // no task running
+	require.ErrorIs(e.Wait(), terr) // no task running	
+	require.True(len(completed) < 500)
 }
 
 func TestStop(t *testing.T) {
@@ -195,12 +195,12 @@ func TestStop(t *testing.T) {
 			return nil
 		})
 	}
-	require.Less(len(completed), 500)
 	require.ErrorIs(e.Wait(), ErrStopped) // no task running
+	require.Less(len(completed), 500)
 }
 
 // W->W->W->...
-/*func TestManyWrites(t *testing.T) {
+func TestManyWrites(t *testing.T) {
 	var (
 		require     = require.New(t)
 		conflictKey = ids.GenerateTestID().String()
@@ -420,4 +420,3 @@ func TestReadThenWriteRepeated(t *testing.T) {
 	// 13..99 are ran in parallel, so non-deterministic
 	require.Len(completed, 100)
 }
-*/

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"testing"
 	"time"
-	_ "fmt"
+	"fmt"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/stretchr/testify/require"
@@ -197,7 +197,7 @@ func TestStop(t *testing.T) {
 	}
 	require.Less(len(completed), 500)
 	require.ErrorIs(e.Wait(), ErrStopped) // no task running
-}*/
+}
 
 // W->W->W->...
 func TestManyWrites(t *testing.T) {
@@ -261,10 +261,10 @@ func TestManyReads(t *testing.T) {
 	require.NoError(e.Wait())
 	// 0..99 are ran in parallel, so non-deterministic
 	require.Len(completed, 100)
-}
+}*/
 
 // W->R->R->...
-/*func TestWriteThenRead(t *testing.T) {
+func TestWriteThenRead(t *testing.T) {
 	var (
 		require     = require.New(t)
 		conflictKey = ids.GenerateTestID().String()
@@ -299,4 +299,4 @@ func TestManyReads(t *testing.T) {
 	require.Equal(0, completed[0]) // Write first to execute
 	// 1..99 are ran in parallel, so non-deterministic
 	require.Len(completed, 100)
-}*/
+}

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"testing"
 	"time"
-	"fmt"
+	_ "fmt"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/stretchr/testify/require"
@@ -230,7 +230,7 @@ func TestManyWrites(t *testing.T) {
 	}
 	require.NoError(e.Wait())
 	require.Equal(answer, completed)
-}
+}*/
 
 // R->R->R->...
 func TestManyReads(t *testing.T) {
@@ -261,10 +261,10 @@ func TestManyReads(t *testing.T) {
 	require.NoError(e.Wait())
 	// 0..99 are ran in parallel, so non-deterministic
 	require.Len(completed, 100)
-}*/
+}
 
 // W->R->R->...
-func TestWriteThenRead(t *testing.T) {
+/*func TestWriteThenRead(t *testing.T) {
 	var (
 		require     = require.New(t)
 		conflictKey = ids.GenerateTestID().String()
@@ -299,4 +299,4 @@ func TestWriteThenRead(t *testing.T) {
 	require.Equal(0, completed[0]) // Write first to execute
 	// 1..99 are ran in parallel, so non-deterministic
 	require.Len(completed, 100)
-}
+}*/

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -311,10 +311,7 @@ func TestReadThenWrite(t *testing.T) {
 		e           = New(100, 4, nil)
 	)
 	for i := 0; i < 100; i++ {
-		s := make(state.Keys, (i + 1))
-		for k := 0; k < i+1; k++ {
-			s.Add(ids.GenerateTestID().String(), state.Write)
-		}
+		s := make(state.Keys, 1)
 		if i == 10 {
 			s.Add(conflictKey, state.Write)
 		} else {
@@ -322,7 +319,7 @@ func TestReadThenWrite(t *testing.T) {
 		}
 		ti := i
 		e.Run(s, func() error {
-			if ti == 10 {
+			if ti == 9 {
 				time.Sleep(1 * time.Second)
 			}
 

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -5,10 +5,10 @@ package executor
 
 import (
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
-	"fmt"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/stretchr/testify/require"
@@ -168,7 +168,7 @@ func TestEarlyExit(t *testing.T) {
 			return nil
 		})
 	}
-	require.ErrorIs(e.Wait(), terr) // no task running	
+	require.ErrorIs(e.Wait(), terr) // no task running
 	require.True(len(completed) < 500)
 }
 

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -197,7 +197,7 @@ func TestStop(t *testing.T) {
 	}
 	require.Less(len(completed), 500)
 	require.ErrorIs(e.Wait(), ErrStopped) // no task running
-}
+}*/
 
 // W->W->W->...
 func TestManyWrites(t *testing.T) {
@@ -299,7 +299,7 @@ func TestWriteThenRead(t *testing.T) {
 	require.Equal(0, completed[0]) // Write first to execute
 	// 1..99 are ran in parallel, so non-deterministic
 	require.Len(completed, 100)
-}*/
+}
 
 // R->R->W...
 func TestReadThenWrite(t *testing.T) {
@@ -337,5 +337,45 @@ func TestReadThenWrite(t *testing.T) {
 	// 0..9 are ran in parallel, so non-deterministic
 	require.Equal(10, completed[10]) // First write to execute
 	// 11..99 are ran in parallel, so non-deterministic
+	require.Len(completed, 100)
+}
+
+// W->R->R->...W->R->R->...
+func TestWriteThenReadRepeated(t *testing.T) {
+	var (
+		require     = require.New(t)
+		conflictKey = ids.GenerateTestID().String()
+		l           sync.Mutex
+		completed   = make([]int, 0, 100)
+		e           = New(100, 4, nil)
+	)
+	for i := 0; i < 100; i++ {
+		s := make(state.Keys, (i + 1))
+		for k := 0; k < i+1; k++ {
+			s.Add(ids.GenerateTestID().String(), state.Write)
+		}
+		if i == 0 || i == 49 {
+			s.Add(conflictKey, state.Write)
+		} else {
+			s.Add(conflictKey, state.Read)
+		}
+		ti := i
+		e.Run(s, func() error {
+			if ti == 0 {
+				time.Sleep(1 * time.Second)
+			}
+
+			l.Lock()
+			completed = append(completed, ti)
+			l.Unlock()
+			return nil
+		})
+	}
+	require.NoError(e.Wait())
+	fmt.Printf("completed %v\n", completed)
+	require.Equal(0, completed[0]) // First write to execute
+	// 1..48 are ran in parallel, so non-deterministic
+	require.Equal(49, completed[49]) // Second write to execute
+	// 50..99 are ran in parallel, so non-deterministic
 	require.Len(completed, 100)
 }

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -5,7 +5,6 @@ package executor
 
 import (
 	"errors"
-	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -169,7 +168,7 @@ func TestEarlyExit(t *testing.T) {
 		})
 	}
 	require.ErrorIs(e.Wait(), terr) // no task running
-	require.True(len(completed) < 500)
+	require.Less(len(completed), 500)
 }
 
 func TestStop(t *testing.T) {
@@ -295,7 +294,6 @@ func TestWriteThenRead(t *testing.T) {
 		})
 	}
 	require.NoError(e.Wait())
-	fmt.Printf("completed %v\n", completed)
 	require.Equal(0, completed[0]) // Write first to execute
 	// 1..99 are ran in parallel, so non-deterministic
 	require.Len(completed, 100)
@@ -330,7 +328,6 @@ func TestReadThenWrite(t *testing.T) {
 		})
 	}
 	require.NoError(e.Wait())
-	fmt.Printf("completed %v\n", completed)
 	// 0..9 are ran in parallel, so non-deterministic
 	require.Equal(10, completed[10]) // First write to execute
 	// 11..99 are ran in parallel, so non-deterministic
@@ -369,7 +366,6 @@ func TestWriteThenReadRepeated(t *testing.T) {
 		})
 	}
 	require.NoError(e.Wait())
-	fmt.Printf("completed %v\n", completed)
 	require.Equal(0, completed[0]) // First write to execute
 	// 1..48 are ran in parallel, so non-deterministic
 	require.Equal(49, completed[49]) // Second write to execute
@@ -409,7 +405,6 @@ func TestReadThenWriteRepeated(t *testing.T) {
 		})
 	}
 	require.NoError(e.Wait())
-	fmt.Printf("completed %v\n", completed)
 	// 0..9 are ran in parallel, so non-deterministic
 	require.Equal(10, completed[10])
 	require.Equal(11, completed[11])

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -880,14 +880,12 @@ func TestLargeRandomReadsAndWrites(t *testing.T) {
 			}
 		}
 
-		// randomly pick what the key access should be
-		// for unique keys
-		uniqueMode := rand.Intn(2) //nolint:gosec
-
 		// fill in rest with unique keys
 		// invariant: [remaining] > 0
 		remaining := numKeys - setSize
 		for j := 0; j < remaining; j++ {
+			// randomly pick the permission for unique keys
+			uniqueMode := rand.Intn(2) //nolint:gosec
 			switch uniqueMode {
 			case 0:
 				s.Add(ids.GenerateTestID().String(), state.Read)

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -502,13 +502,8 @@ func TestTwoConflictKeys(t *testing.T) {
 			for k := 0; k < i+1; k++ {
 				s.Add(ids.GenerateTestID().String(), state.Write)
 			}
-			if i == 0 || i == 1 {
-				s.Add(conflictKey1, state.Write)
-				s.Add(conflictKey2, state.Write)
-			} else {
-				s.Add(conflictKey1, state.Read)
-				s.Add(conflictKey2, state.Read)
-			}
+			s.Add(conflictKey1, state.Read)
+			s.Add(conflictKey2, state.Write)
 			ti := i
 			e.Run(s, func() error {
 				if ti == 10 {
@@ -879,13 +874,10 @@ func TestLargeRandomReadsAndWrites(t *testing.T) {
 			randomConflictingKeys.Add(rand.Intn(conflictSize)) //nolint:gosec
 		}
 
-		// randomly pick if these conflict keys are
-		// going to be Read/Write
-		conflictMode := rand.Intn(2) //nolint:gosec
-
 		// add the random keys to tx
 		for k := range randomConflictingKeys {
-			switch conflictMode {
+			// randomly pick if conflict key is Read/Write
+			switch rand.Intn(2) { //nolint:gosec
 			case 0:
 				s.Add(conflictKeys[k], state.Read)
 			case 1:
@@ -897,8 +889,7 @@ func TestLargeRandomReadsAndWrites(t *testing.T) {
 		remaining := numKeys - setSize
 		for j := 0; j < remaining; j++ {
 			// randomly pick the permission for unique keys
-			uniqueMode := rand.Intn(2) //nolint:gosec
-			switch uniqueMode {
+			switch rand.Intn(2) { //nolint:gosec
 			case 0:
 				s.Add(ids.GenerateTestID().String(), state.Read)
 			case 1:

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -838,7 +838,7 @@ func TestLargeRandomReadsAndWrites(t *testing.T) {
 	var (
 		require   = require.New(t)
 		numKeys   = 10
-		numTxs    = 100_000
+		numTxs    = 100000
 		completed = make([]int, 0, numTxs)
 		e         = New(numTxs, 4, nil)
 

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -888,9 +888,7 @@ func TestLargeRandomReadsAndWrites(t *testing.T) {
 		s := make(state.Keys, (numKeys + 1))
 
 		// random size of conflict keys to add
-		min := 1
-		max := 6
-		setSize := rand.Intn(max-min+1) + min             //nolint:gosec
+		setSize := max(1, rand.Intn(6))                   //nolint:gosec
 		randomConflictingKeys := set.NewSet[int](setSize) // indices of [conflictKeys]
 		for randomConflictingKeys.Len() < setSize {
 			randomConflictingKeys.Add(rand.Intn(numKeys)) //nolint:gosec

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -16,456 +16,498 @@ import (
 	"github.com/ava-labs/hypersdk/state"
 )
 
+const numIterations = 10
+
 func TestExecutorNoConflicts(t *testing.T) {
-	var (
-		require   = require.New(t)
-		l         sync.Mutex
-		completed = make([]int, 0, 100)
-		e         = New(100, 4, nil)
-		canWait   = make(chan struct{})
-	)
-	for i := 0; i < 100; i++ {
-		s := make(state.Keys, (i + 1))
-		for k := 0; k < i+1; k++ {
-			s.Add(ids.GenerateTestID().String(), state.Read|state.Write)
-		}
-		ti := i
-		e.Run(s, func() error {
-			l.Lock()
-			completed = append(completed, ti)
-			if len(completed) == 100 {
-				close(canWait)
+	fmt.Printf("TestExecutorNoConflicts starting... ")
+	for j := 0; j < numIterations; j++ {
+		var (
+			require   = require.New(t)
+			l         sync.Mutex
+			completed = make([]int, 0, 100)
+			e         = New(100, 4, nil)
+			canWait   = make(chan struct{})
+		)
+
+		for i := 0; i < 100; i++ {
+			s := make(state.Keys, (i + 1))
+			for k := 0; k < i+1; k++ {
+				s.Add(ids.GenerateTestID().String(), state.Read|state.Write)
 			}
-			l.Unlock()
-			return nil
-		})
+			ti := i
+			e.Run(s, func() error {
+				l.Lock()
+				completed = append(completed, ti)
+				if len(completed) == 100 {
+					close(canWait)
+				}
+				l.Unlock()
+				return nil
+			})
+		}
+		<-canWait
+		require.NoError(e.Wait()) // no task running
+		require.Len(completed, 100)
 	}
-	<-canWait
-	require.NoError(e.Wait()) // no task running
-	require.Len(completed, 100)
-	fmt.Printf("TestExecutorNoConflicts done\n")
+	fmt.Printf("done\n")
 }
 
 func TestExecutorNoConflictsSlow(t *testing.T) {
-	var (
-		require   = require.New(t)
-		l         sync.Mutex
-		completed = make([]int, 0, 100)
-		e         = New(100, 4, nil)
-	)
-	for i := 0; i < 100; i++ {
-		s := make(state.Keys, (i + 1))
-		for k := 0; k < i+1; k++ {
-			s.Add(ids.GenerateTestID().String(), state.Read|state.Write)
-		}
-		ti := i
-		e.Run(s, func() error {
-			if ti == 0 {
-				time.Sleep(3 * time.Second)
+	fmt.Printf("TestExecutorNoConflictsSlow starting... ")
+	for j := 0; j < numIterations; j++ {
+		var (
+			require   = require.New(t)
+			l         sync.Mutex
+			completed = make([]int, 0, 100)
+			e         = New(100, 4, nil)
+		)
+		for i := 0; i < 100; i++ {
+			s := make(state.Keys, (i + 1))
+			for k := 0; k < i+1; k++ {
+				s.Add(ids.GenerateTestID().String(), state.Read|state.Write)
 			}
-			l.Lock()
-			completed = append(completed, ti)
-			l.Unlock()
-			return nil
-		})
+			ti := i
+			e.Run(s, func() error {
+				if ti == 0 {
+					time.Sleep(3 * time.Second)
+				}
+				l.Lock()
+				completed = append(completed, ti)
+				l.Unlock()
+				return nil
+			})
+		}
+		require.NoError(e.Wait()) // existing task is running
+		require.Len(completed, 100)
+		require.Equal(0, completed[99])
 	}
-	require.NoError(e.Wait()) // existing task is running
-	require.Len(completed, 100)
-	require.Equal(0, completed[99])
-	fmt.Printf("TestExecutorNoConflictsSlow done\n")
+	fmt.Printf("done\n")
 }
 
 func TestExecutorSimpleConflict(t *testing.T) {
-	var (
-		require     = require.New(t)
-		conflictKey = ids.GenerateTestID().String()
-		l           sync.Mutex
-		completed   = make([]int, 0, 100)
-		e           = New(100, 4, nil)
-	)
-	for i := 0; i < 100; i++ {
-		s := make(state.Keys, (i + 1))
-		for k := 0; k < i+1; k++ {
-			s.Add(ids.GenerateTestID().String(), state.Read|state.Write)
-		}
-		if i%10 == 0 {
-			s.Add(conflictKey, state.Read|state.Write)
-		}
-		ti := i
-		e.Run(s, func() error {
-			if ti == 0 {
-				time.Sleep(3 * time.Second)
+	fmt.Printf("TestExecutorSimpleConflict starting... ")
+	for j := 0; j < numIterations; j++ {
+		var (
+			require     = require.New(t)
+			conflictKey = ids.GenerateTestID().String()
+			l           sync.Mutex
+			completed   = make([]int, 0, 100)
+			e           = New(100, 4, nil)
+		)
+		for i := 0; i < 100; i++ {
+			s := make(state.Keys, (i + 1))
+			for k := 0; k < i+1; k++ {
+				s.Add(ids.GenerateTestID().String(), state.Read|state.Write)
 			}
+			if i%10 == 0 {
+				s.Add(conflictKey, state.Read|state.Write)
+			}
+			ti := i
+			e.Run(s, func() error {
+				if ti == 0 {
+					time.Sleep(3 * time.Second)
+				}
 
-			l.Lock()
-			completed = append(completed, ti)
-			l.Unlock()
-			return nil
-		})
+				l.Lock()
+				completed = append(completed, ti)
+				l.Unlock()
+				return nil
+			})
+		}
+		require.NoError(e.Wait())
+		require.Equal([]int{0, 10, 20, 30, 40, 50, 60, 70, 80, 90}, completed[90:])
 	}
-	require.NoError(e.Wait())
-	require.Equal([]int{0, 10, 20, 30, 40, 50, 60, 70, 80, 90}, completed[90:])
-	fmt.Printf("TestExecutorSimpleConflict done\n")
+	fmt.Printf("done\n")
 }
 
 func TestExecutorMultiConflict(t *testing.T) {
-	var (
-		require      = require.New(t)
-		conflictKey  = ids.GenerateTestID().String()
-		conflictKey2 = ids.GenerateTestID().String()
-		l            sync.Mutex
-		completed    = make([]int, 0, 100)
-		e            = New(100, 4, nil)
-	)
-	for i := 0; i < 100; i++ {
-		s := make(state.Keys, (i + 1))
-		for k := 0; k < i+1; k++ {
-			s.Add(ids.GenerateTestID().String(), state.Read|state.Write)
-		}
-		if i%10 == 0 {
-			s.Add(conflictKey, state.Read|state.Write)
-		}
-		if i == 15 || i == 20 {
-			s.Add(conflictKey2, state.Read|state.Write)
-		}
-		ti := i
-		e.Run(s, func() error {
-			if ti == 0 {
-				time.Sleep(3 * time.Second)
+	fmt.Printf("TestExecutorMultiConflict starting... ")
+	for j := 0; j < numIterations; j++ {
+		var (
+			require      = require.New(t)
+			conflictKey  = ids.GenerateTestID().String()
+			conflictKey2 = ids.GenerateTestID().String()
+			l            sync.Mutex
+			completed    = make([]int, 0, 100)
+			e            = New(100, 4, nil)
+		)
+		for i := 0; i < 100; i++ {
+			s := make(state.Keys, (i + 1))
+			for k := 0; k < i+1; k++ {
+				s.Add(ids.GenerateTestID().String(), state.Read|state.Write)
 			}
-			if ti == 15 {
-				time.Sleep(5 * time.Second)
+			if i%10 == 0 {
+				s.Add(conflictKey, state.Read|state.Write)
 			}
+			if i == 15 || i == 20 {
+				s.Add(conflictKey2, state.Read|state.Write)
+			}
+			ti := i
+			e.Run(s, func() error {
+				if ti == 0 {
+					time.Sleep(3 * time.Second)
+				}
+				if ti == 15 {
+					time.Sleep(5 * time.Second)
+				}
 
-			l.Lock()
-			completed = append(completed, ti)
-			l.Unlock()
-			return nil
-		})
+				l.Lock()
+				completed = append(completed, ti)
+				l.Unlock()
+				return nil
+			})
+		}
+		require.NoError(e.Wait())
+		require.Equal([]int{0, 10, 15, 20, 30, 40, 50, 60, 70, 80, 90}, completed[89:])
 	}
-	require.NoError(e.Wait())
-	require.Equal([]int{0, 10, 15, 20, 30, 40, 50, 60, 70, 80, 90}, completed[89:])
-	fmt.Printf("TestExecutorMultiConflict done\n")
+	fmt.Printf("done\n")
 }
 
 func TestEarlyExit(t *testing.T) {
-	var (
-		require   = require.New(t)
-		l         sync.Mutex
-		completed = make([]int, 0, 500)
-		e         = New(500, 4, nil)
-		terr      = errors.New("uh oh")
-	)
-	for i := 0; i < 500; i++ {
-		s := make(state.Keys, (i + 1))
-		for k := 0; k < i+1; k++ {
-			s.Add(ids.GenerateTestID().String(), state.Read|state.Write)
-		}
-		ti := i
-		e.Run(s, func() error {
-			l.Lock()
-			completed = append(completed, ti)
-			l.Unlock()
-			if ti == 200 {
-				return terr
+	fmt.Printf("TestEarlyExit starting... ")
+	for j := 0; j < numIterations; j++ {
+		var (
+			require   = require.New(t)
+			l         sync.Mutex
+			completed = make([]int, 0, 500)
+			e         = New(500, 4, nil)
+			terr      = errors.New("uh oh")
+		)
+		for i := 0; i < 500; i++ {
+			s := make(state.Keys, (i + 1))
+			for k := 0; k < i+1; k++ {
+				s.Add(ids.GenerateTestID().String(), state.Read|state.Write)
 			}
-			return nil
-		})
+			ti := i
+			e.Run(s, func() error {
+				l.Lock()
+				completed = append(completed, ti)
+				l.Unlock()
+				if ti == 200 {
+					return terr
+				}
+				return nil
+			})
+		}
+		require.ErrorIs(e.Wait(), terr) // no task running
+		require.Less(len(completed), 500)
 	}
-	require.ErrorIs(e.Wait(), terr) // no task running
-	require.Less(len(completed), 500)
-	fmt.Printf("TestEarlyExit done\n")
+	fmt.Printf("done\n")
 }
 
 func TestStop(t *testing.T) {
-	var (
-		require   = require.New(t)
-		l         sync.Mutex
-		completed = make([]int, 0, 500)
-		e         = New(500, 4, nil)
-	)
-	for i := 0; i < 500; i++ {
-		s := make(state.Keys, (i + 1))
-		for k := 0; k < i+1; k++ {
-			s.Add(ids.GenerateTestID().String(), state.Read|state.Write)
-		}
-		ti := i
-		e.Run(s, func() error {
-			l.Lock()
-			completed = append(completed, ti)
-			l.Unlock()
-			if ti == 200 {
-				e.Stop()
+	fmt.Printf("TestStop starting... ")
+	for j := 0; j < numIterations; j++ {
+		var (
+			require   = require.New(t)
+			l         sync.Mutex
+			completed = make([]int, 0, 500)
+			e         = New(500, 4, nil)
+		)
+		for i := 0; i < 500; i++ {
+			s := make(state.Keys, (i + 1))
+			for k := 0; k < i+1; k++ {
+				s.Add(ids.GenerateTestID().String(), state.Read|state.Write)
 			}
-			return nil
-		})
+			ti := i
+			e.Run(s, func() error {
+				l.Lock()
+				completed = append(completed, ti)
+				l.Unlock()
+				if ti == 200 {
+					e.Stop()
+				}
+				return nil
+			})
+		}
+		require.ErrorIs(e.Wait(), ErrStopped) // no task running
+		require.Less(len(completed), 500)
 	}
-	require.ErrorIs(e.Wait(), ErrStopped) // no task running
-	require.Less(len(completed), 500)
-	fmt.Printf("TestStop done\n")
+	fmt.Printf("done\n")
 }
 
 // W->W->W->...
 func TestManyWrites(t *testing.T) {
-	var (
-		require     = require.New(t)
-		conflictKey = ids.GenerateTestID().String()
-		l           sync.Mutex
-		completed   = make([]int, 0, 100)
-		answer      = make([]int, 0, 100)
-		e           = New(100, 4, nil)
-	)
-	for i := 0; i < 100; i++ {
-		answer = append(answer, i)
-		s := make(state.Keys, (i + 1))
-		for k := 0; k < i+1; k++ {
-			s.Add(ids.GenerateTestID().String(), state.Write)
-		}
-		s.Add(conflictKey, state.Write)
-		ti := i
-		e.Run(s, func() error {
-			if ti == 0 {
-				time.Sleep(3 * time.Second)
+	fmt.Printf("TestManyWrites starting... ")
+	for j := 0; j < numIterations; j++ {
+		var (
+			require     = require.New(t)
+			conflictKey = ids.GenerateTestID().String()
+			l           sync.Mutex
+			completed   = make([]int, 0, 100)
+			answer      = make([]int, 0, 100)
+			e           = New(100, 4, nil)
+		)
+		for i := 0; i < 100; i++ {
+			answer = append(answer, i)
+			s := make(state.Keys, (i + 1))
+			for k := 0; k < i+1; k++ {
+				s.Add(ids.GenerateTestID().String(), state.Write)
 			}
+			s.Add(conflictKey, state.Write)
+			ti := i
+			e.Run(s, func() error {
+				if ti == 0 {
+					time.Sleep(3 * time.Second)
+				}
 
-			l.Lock()
-			completed = append(completed, ti)
-			l.Unlock()
-			return nil
-		})
+				l.Lock()
+				completed = append(completed, ti)
+				l.Unlock()
+				return nil
+			})
+		}
+		require.NoError(e.Wait())
+		require.Equal(answer, completed)
 	}
-	require.NoError(e.Wait())
-	require.Equal(answer, completed)
-	fmt.Printf("TestManyWrites done\n")
+	fmt.Printf("done\n")
 }
 
 // R->R->R->...
 func TestManyReads(t *testing.T) {
-	var (
-		require     = require.New(t)
-		conflictKey = ids.GenerateTestID().String()
-		l           sync.Mutex
-		completed   = make([]int, 0, 100)
-		e           = New(100, 4, nil)
-	)
-	for i := 0; i < 100; i++ {
-		s := make(state.Keys, (i + 1))
-		for k := 0; k < i+1; k++ {
-			s.Add(ids.GenerateTestID().String(), state.Write)
-		}
-		s.Add(conflictKey, state.Read)
-		ti := i
-		e.Run(s, func() error {
-			if ti%2 == 0 {
-				time.Sleep(1 * time.Second)
+	fmt.Printf("TestManyReads starting... ")
+	for j := 0; j < numIterations; j++ {
+		var (
+			require     = require.New(t)
+			conflictKey = ids.GenerateTestID().String()
+			l           sync.Mutex
+			completed   = make([]int, 0, 100)
+			e           = New(100, 4, nil)
+		)
+		for i := 0; i < 100; i++ {
+			s := make(state.Keys, (i + 1))
+			for k := 0; k < i+1; k++ {
+				s.Add(ids.GenerateTestID().String(), state.Write)
 			}
-			l.Lock()
-			completed = append(completed, ti)
-			l.Unlock()
-			return nil
-		})
+			s.Add(conflictKey, state.Read)
+			ti := i
+			e.Run(s, func() error {
+				if ti%2 == 0 {
+					time.Sleep(1 * time.Second)
+				}
+				l.Lock()
+				completed = append(completed, ti)
+				l.Unlock()
+				return nil
+			})
+		}
+		require.NoError(e.Wait())
+		// 0..99 are ran in parallel, so non-deterministic
+		require.Len(completed, 100)
 	}
-	require.NoError(e.Wait())
-	// 0..99 are ran in parallel, so non-deterministic
-	require.Len(completed, 100)
-	fmt.Printf("TestManyReads done\n")
+	fmt.Printf("done\n")
 }
 
 // W->R->R->...
 func TestWriteThenRead(t *testing.T) {
-	var (
-		require     = require.New(t)
-		conflictKey = ids.GenerateTestID().String()
-		l           sync.Mutex
-		completed   = make([]int, 0, 100)
-		e           = New(100, 4, nil)
-	)
-	for i := 0; i < 100; i++ {
-		s := make(state.Keys, (i + 1))
-		for k := 0; k < i+1; k++ {
-			s.Add(ids.GenerateTestID().String(), state.Write)
-		}
-		if i == 0 {
-			s.Add(conflictKey, state.Write)
-		} else {
-			s.Add(conflictKey, state.Read)
-		}
-		ti := i
-		e.Run(s, func() error {
-			if ti == 0 {
-				time.Sleep(1 * time.Second)
+	fmt.Printf("TestWriteThenRead starting... ")
+	for j := 0; j < numIterations; j++ {
+		var (
+			require     = require.New(t)
+			conflictKey = ids.GenerateTestID().String()
+			l           sync.Mutex
+			completed   = make([]int, 0, 100)
+			e           = New(100, 4, nil)
+		)
+		for i := 0; i < 100; i++ {
+			s := make(state.Keys, (i + 1))
+			for k := 0; k < i+1; k++ {
+				s.Add(ids.GenerateTestID().String(), state.Write)
 			}
+			if i == 0 {
+				s.Add(conflictKey, state.Write)
+			} else {
+				s.Add(conflictKey, state.Read)
+			}
+			ti := i
+			e.Run(s, func() error {
+				if ti == 0 {
+					time.Sleep(1 * time.Second)
+				}
 
-			l.Lock()
-			completed = append(completed, ti)
-			l.Unlock()
-			return nil
-		})
+				l.Lock()
+				completed = append(completed, ti)
+				l.Unlock()
+				return nil
+			})
+		}
+		require.NoError(e.Wait())
+		require.Equal(0, completed[0]) // Write first to execute
+		// 1..99 are ran in parallel, so non-deterministic
+		require.Len(completed, 100)
 	}
-	require.NoError(e.Wait())
-	require.Equal(0, completed[0]) // Write first to execute
-	// 1..99 are ran in parallel, so non-deterministic
-	require.Len(completed, 100)
-	fmt.Printf("TestWriteThenRead done\n")
+	fmt.Printf("done\n")
 }
 
 // R->R->W...
 func TestReadThenWrite(t *testing.T) {
-	var (
-		require     = require.New(t)
-		conflictKey = ids.GenerateTestID().String()
-		l           sync.Mutex
-		completed   = make([]int, 0, 100)
-		e           = New(100, 4, nil)
-	)
-	for i := 0; i < 100; i++ {
-		s := make(state.Keys, (i + 1))
-		for k := 0; k < i+1; k++ {
-			s.Add(ids.GenerateTestID().String(), state.Write)
-		}
-		if i == 10 {
-			s.Add(conflictKey, state.Write)
-		} else {
-			s.Add(conflictKey, state.Read)
-		}
-		ti := i
-		e.Run(s, func() error {
-			if ti == 9 {
-				time.Sleep(1 * time.Second)
+	fmt.Printf("TestReadThenWrite starting... ")
+	for j := 0; j < numIterations; j++ {
+		var (
+			require     = require.New(t)
+			conflictKey = ids.GenerateTestID().String()
+			l           sync.Mutex
+			completed   = make([]int, 0, 100)
+			e           = New(100, 4, nil)
+		)
+		for i := 0; i < 100; i++ {
+			s := make(state.Keys, (i + 1))
+			for k := 0; k < i+1; k++ {
+				s.Add(ids.GenerateTestID().String(), state.Write)
 			}
+			if i == 10 {
+				s.Add(conflictKey, state.Write)
+			} else {
+				s.Add(conflictKey, state.Read)
+			}
+			ti := i
+			e.Run(s, func() error {
+				if ti == 9 {
+					time.Sleep(1 * time.Second)
+				}
 
-			l.Lock()
-			completed = append(completed, ti)
-			l.Unlock()
-			return nil
-		})
+				l.Lock()
+				completed = append(completed, ti)
+				l.Unlock()
+				return nil
+			})
+		}
+		require.NoError(e.Wait())
+		// 0..9 are ran in parallel, so non-deterministic
+		require.Equal(10, completed[10]) // First write to execute
+		// 11..99 are ran in parallel, so non-deterministic
+		require.Len(completed, 100)
 	}
-	require.NoError(e.Wait())
-	// 0..9 are ran in parallel, so non-deterministic
-	require.Equal(10, completed[10]) // First write to execute
-	// 11..99 are ran in parallel, so non-deterministic
-	require.Len(completed, 100)
-	fmt.Printf("TestReadThenWrite done\n")
+	fmt.Printf("done\n")
 }
 
 // W->R->R->...W->R->R->...
 func TestWriteThenReadRepeated(t *testing.T) {
-	var (
-		require     = require.New(t)
-		conflictKey = ids.GenerateTestID().String()
-		l           sync.Mutex
-		completed   = make([]int, 0, 100)
-		e           = New(100, 4, nil)
-	)
-	for i := 0; i < 100; i++ {
-		s := make(state.Keys, (i + 1))
-		for k := 0; k < i+1; k++ {
-			s.Add(ids.GenerateTestID().String(), state.Write)
-		}
-		if i == 0 || i == 49 {
-			s.Add(conflictKey, state.Write)
-		} else {
-			s.Add(conflictKey, state.Read)
-		}
-		ti := i
-		e.Run(s, func() error {
-			if ti == 0 {
-				time.Sleep(1 * time.Second)
+	fmt.Printf("TestWriteThenReadRepeated starting... ")
+	for j := 0; j < numIterations; j++ {
+		var (
+			require     = require.New(t)
+			conflictKey = ids.GenerateTestID().String()
+			l           sync.Mutex
+			completed   = make([]int, 0, 100)
+			e           = New(100, 4, nil)
+		)
+		for i := 0; i < 100; i++ {
+			s := make(state.Keys, (i + 1))
+			for k := 0; k < i+1; k++ {
+				s.Add(ids.GenerateTestID().String(), state.Write)
 			}
+			if i == 0 || i == 49 {
+				s.Add(conflictKey, state.Write)
+			} else {
+				s.Add(conflictKey, state.Read)
+			}
+			ti := i
+			e.Run(s, func() error {
+				if ti == 0 {
+					time.Sleep(1 * time.Second)
+				}
 
-			l.Lock()
-			completed = append(completed, ti)
-			l.Unlock()
-			return nil
-		})
+				l.Lock()
+				completed = append(completed, ti)
+				l.Unlock()
+				return nil
+			})
+		}
+		require.NoError(e.Wait())
+		require.Equal(0, completed[0]) // First write to execute
+		// 1..48 are ran in parallel, so non-deterministic
+		require.Equal(49, completed[49]) // Second write to execute
+		// 50..99 are ran in parallel, so non-deterministic
+		require.Len(completed, 100)
 	}
-	require.NoError(e.Wait())
-	require.Equal(0, completed[0]) // First write to execute
-	// 1..48 are ran in parallel, so non-deterministic
-	require.Equal(49, completed[49]) // Second write to execute
-	// 50..99 are ran in parallel, so non-deterministic
-	require.Len(completed, 100)
-	fmt.Printf("TestWriteThenReadRepeated done\n")
+	fmt.Printf("done\n")
 }
 
 // R->R->W->R->W->R->R...
 func TestReadThenWriteRepeated(t *testing.T) {
-	var (
-		require     = require.New(t)
-		conflictKey = ids.GenerateTestID().String()
-		l           sync.Mutex
-		completed   = make([]int, 0, 100)
-		e           = New(100, 4, nil)
-	)
-	for i := 0; i < 100; i++ {
-		s := make(state.Keys, (i + 1))
-		for k := 0; k < i+1; k++ {
-			s.Add(ids.GenerateTestID().String(), state.Write)
-		}
-		if i == 10 || i == 12 {
-			s.Add(conflictKey, state.Write)
-		} else {
-			s.Add(conflictKey, state.Read)
-		}
-		ti := i
-		e.Run(s, func() error {
-			if ti == 10 {
-				time.Sleep(1 * time.Second)
+	fmt.Printf("TestReadThenWriteRepeated starting... ")
+	for j := 0; j < numIterations; j++ {
+		var (
+			require     = require.New(t)
+			conflictKey = ids.GenerateTestID().String()
+			l           sync.Mutex
+			completed   = make([]int, 0, 100)
+			e           = New(100, 4, nil)
+		)
+		for i := 0; i < 100; i++ {
+			s := make(state.Keys, (i + 1))
+			for k := 0; k < i+1; k++ {
+				s.Add(ids.GenerateTestID().String(), state.Write)
 			}
+			if i == 10 || i == 12 {
+				s.Add(conflictKey, state.Write)
+			} else {
+				s.Add(conflictKey, state.Read)
+			}
+			ti := i
+			e.Run(s, func() error {
+				if ti == 10 {
+					time.Sleep(1 * time.Second)
+				}
 
-			l.Lock()
-			completed = append(completed, ti)
-			l.Unlock()
-			return nil
-		})
+				l.Lock()
+				completed = append(completed, ti)
+				l.Unlock()
+				return nil
+			})
+		}
+		require.NoError(e.Wait())
+		// 0..9 are ran in parallel, so non-deterministic
+		require.Equal(10, completed[10])
+		require.Equal(11, completed[11])
+		require.Equal(12, completed[12])
+		// 13..99 are ran in parallel, so non-deterministic
+		require.Len(completed, 100)
 	}
-	require.NoError(e.Wait())
-	// 0..9 are ran in parallel, so non-deterministic
-	require.Equal(10, completed[10])
-	require.Equal(11, completed[11])
-	require.Equal(12, completed[12])
-	// 13..99 are ran in parallel, so non-deterministic
-	require.Len(completed, 100)
-	fmt.Printf("TestReadThenWriteRepeated done\n")
+	fmt.Printf("done\n")
 }
 
 func TestTwoConflictKeys(t *testing.T) {
-	var (
-		require      = require.New(t)
-		conflictKey1 = ids.GenerateTestID().String()
-		conflictKey2 = ids.GenerateTestID().String()
-		l            sync.Mutex
-		completed    = make([]int, 0, 100)
-		e            = New(100, 4, nil)
-	)
-	for i := 0; i < 100; i++ {
-		s := make(state.Keys, (i + 1))
-		for k := 0; k < i+1; k++ {
-			s.Add(ids.GenerateTestID().String(), state.Write)
-		}
-		if i == 0 || i == 1 {
-			s.Add(conflictKey1, state.Write)
-			s.Add(conflictKey2, state.Write)
-		} else {
-			s.Add(conflictKey1, state.Read)
-			s.Add(conflictKey2, state.Read)
-		}
-		ti := i
-		e.Run(s, func() error {
-			if ti == 10 {
-				time.Sleep(1 * time.Second)
+	fmt.Printf("TestTwoConflictKeys starting... ")
+	for j := 0; j < numIterations; j++ {
+		var (
+			require      = require.New(t)
+			conflictKey1 = ids.GenerateTestID().String()
+			conflictKey2 = ids.GenerateTestID().String()
+			l            sync.Mutex
+			completed    = make([]int, 0, 100)
+			e            = New(100, 4, nil)
+		)
+		for i := 0; i < 100; i++ {
+			s := make(state.Keys, (i + 1))
+			for k := 0; k < i+1; k++ {
+				s.Add(ids.GenerateTestID().String(), state.Write)
 			}
+			if i == 0 || i == 1 {
+				s.Add(conflictKey1, state.Write)
+				s.Add(conflictKey2, state.Write)
+			} else {
+				s.Add(conflictKey1, state.Read)
+				s.Add(conflictKey2, state.Read)
+			}
+			ti := i
+			e.Run(s, func() error {
+				if ti == 10 {
+					time.Sleep(1 * time.Second)
+				}
 
-			l.Lock()
-			completed = append(completed, ti)
-			l.Unlock()
-			return nil
-		})
+				l.Lock()
+				completed = append(completed, ti)
+				l.Unlock()
+				return nil
+			})
+		}
+		require.NoError(e.Wait())
+		require.Equal(0, completed[0])
+		require.Equal(1, completed[1])
+		// 2..99 are ran in parallel, so non-deterministic
+		require.Len(completed, 100)
 	}
-	require.NoError(e.Wait())
-	require.Equal(0, completed[0])
-	require.Equal(1, completed[1])
-	// 2..99 are ran in parallel, so non-deterministic
-	require.Len(completed, 100)
-	fmt.Printf("TestTwoConflictKeys done\n")
+	fmt.Printf("done\n")
 }

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -550,7 +550,7 @@ func TestLargeConcurrentRead(t *testing.T) {
 
 	// randomly wait on certain txs
 	for blocking.Len() < numBlocking {
-		blocking.Add(rand.Intn(100_000)) //nolint:gosec
+		blocking.Add(rand.Intn(numTxs)) //nolint:gosec
 	}
 
 	// make the conflict keys
@@ -624,7 +624,7 @@ func TestLargeSequentialWrites(t *testing.T) {
 
 	// randomly wait on certain txs
 	for blocking.Len() < numBlocking {
-		blocking.Add(rand.Intn(100_000)) //nolint:gosec
+		blocking.Add(rand.Intn(numTxs)) //nolint:gosec
 	}
 
 	// make the conflict keys
@@ -708,7 +708,7 @@ func TestLargeReadsThenWrites(t *testing.T) {
 
 	// randomly wait on certain txs
 	for blocking.Len() < numBlocking {
-		blocking.Add(rand.Intn(100_000)) //nolint:gosec
+		blocking.Add(rand.Intn(numTxs)) //nolint:gosec
 	}
 
 	// make the conflict keys
@@ -786,7 +786,7 @@ func TestLargeWritesThenReads(t *testing.T) {
 
 	// randomly wait on certain txs
 	for blocking.Len() < numBlocking {
-		blocking.Add(rand.Intn(100_000)) //nolint:gosec
+		blocking.Add(rand.Intn(numTxs)) //nolint:gosec
 	}
 
 	// make the conflict keys
@@ -857,7 +857,7 @@ func TestLargeRandomReadsAndWrites(t *testing.T) {
 
 	// randomly wait on certain txs
 	for blocking.Len() < numBlocking {
-		blocking.Add(rand.Intn(100_000)) //nolint:gosec
+		blocking.Add(rand.Intn(numTxs)) //nolint:gosec
 	}
 
 	// make the conflict keys

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -253,7 +253,6 @@ func TestManyReads(t *testing.T) {
 		for k := 0; k < i+1; k++ {
 			s.Add(ids.GenerateTestID().String(), state.Write)
 		}
-		//s := make(state.Keys, 1)
 		s.Add(conflictKey, state.Read)
 		ti := i
 		e.Run(s, func() error {

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ava-labs/hypersdk/state"
 )
 
+// Run several times to catch non-determinism
 const numIterations = 10
 
 func TestExecutorNoConflicts(t *testing.T) {
@@ -276,7 +277,7 @@ func TestManyReads(t *testing.T) {
 		for i := 0; i < 100; i++ {
 			s := make(state.Keys, (i + 1))
 			for k := 0; k < i+1; k++ {
-				s.Add(ids.GenerateTestID().String(), state.Write)
+				s.Add(ids.GenerateTestID().String(), state.Read)
 			}
 			// mimic concurrent reading for all txns
 			s.Add(conflictKey, state.Read)

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -16,8 +16,10 @@ import (
 	"github.com/ava-labs/hypersdk/state"
 )
 
-// Run several times to catch non-determinism
-const numIterations = 10
+const (
+	numIterations   = 10 // Run several times to catch non-determinism
+	maxDependencies = 100_000_000
+)
 
 func generateNumbers(start int) []int {
 	array := make([]int, 9999)
@@ -32,7 +34,7 @@ func TestExecutorNoConflicts(t *testing.T) {
 		require   = require.New(t)
 		l         sync.Mutex
 		completed = make([]int, 0, 100)
-		e         = New(100, 4, nil)
+		e         = New(100, 4, maxDependencies, nil)
 		canWait   = make(chan struct{})
 	)
 
@@ -63,7 +65,7 @@ func TestExecutorNoConflictsSlow(t *testing.T) {
 			require   = require.New(t)
 			l         sync.Mutex
 			completed = make([]int, 0, 100)
-			e         = New(100, 4, nil)
+			e         = New(100, 4, maxDependencies, nil)
 			slow      = make(chan struct{})
 		)
 		for i := 0; i < 100; i++ {
@@ -97,7 +99,7 @@ func TestExecutorSimpleConflict(t *testing.T) {
 		conflictKey = ids.GenerateTestID().String()
 		l           sync.Mutex
 		completed   = make([]int, 0, 100)
-		e           = New(100, 4, nil)
+		e           = New(100, 4, maxDependencies, nil)
 		slow        = make(chan struct{})
 	)
 	for i := 0; i < 100; i++ {
@@ -134,7 +136,7 @@ func TestExecutorMultiConflict(t *testing.T) {
 		conflictKey2 = ids.GenerateTestID().String()
 		l            sync.Mutex
 		completed    = make([]int, 0, 100)
-		e            = New(100, 4, nil)
+		e            = New(100, 4, maxDependencies, nil)
 		slow1        = make(chan struct{})
 		slow2        = make(chan struct{})
 	)
@@ -179,7 +181,7 @@ func TestEarlyExit(t *testing.T) {
 		require   = require.New(t)
 		l         sync.Mutex
 		completed = make([]int, 0, 500)
-		e         = New(500, 4, nil)
+		e         = New(500, 4, maxDependencies, nil)
 		terr      = errors.New("uh oh")
 	)
 	for i := 0; i < 500; i++ {
@@ -207,7 +209,7 @@ func TestStop(t *testing.T) {
 		require   = require.New(t)
 		l         sync.Mutex
 		completed = make([]int, 0, 500)
-		e         = New(500, 4, nil)
+		e         = New(500, 4, maxDependencies, nil)
 	)
 	for i := 0; i < 500; i++ {
 		s := make(state.Keys, (i + 1))
@@ -238,7 +240,7 @@ func TestManyWrites(t *testing.T) {
 			l           sync.Mutex
 			completed   = make([]int, 0, 100)
 			answer      = make([]int, 0, 100)
-			e           = New(100, 4, nil)
+			e           = New(100, 4, maxDependencies, nil)
 			slow        = make(chan struct{})
 		)
 		for i := 0; i < 100; i++ {
@@ -277,7 +279,7 @@ func TestManyReads(t *testing.T) {
 			conflictKey = ids.GenerateTestID().String()
 			l           sync.Mutex
 			completed   = make([]int, 0, 100)
-			e           = New(100, 4, nil)
+			e           = New(100, 4, maxDependencies, nil)
 			slow        = make(chan struct{})
 		)
 		for i := 0; i < 100; i++ {
@@ -317,7 +319,7 @@ func TestWriteThenRead(t *testing.T) {
 			conflictKey = ids.GenerateTestID().String()
 			l           sync.Mutex
 			completed   = make([]int, 0, 100)
-			e           = New(100, 4, nil)
+			e           = New(100, 4, maxDependencies, nil)
 			slow        = make(chan struct{})
 		)
 		for i := 0; i < 100; i++ {
@@ -361,7 +363,7 @@ func TestReadThenWrite(t *testing.T) {
 			conflictKey = ids.GenerateTestID().String()
 			l           sync.Mutex
 			completed   = make([]int, 0, 100)
-			e           = New(100, 4, nil)
+			e           = New(100, 4, maxDependencies, nil)
 			slow        = make(chan struct{})
 		)
 		for i := 0; i < 100; i++ {
@@ -407,7 +409,7 @@ func TestWriteThenReadRepeated(t *testing.T) {
 			conflictKey = ids.GenerateTestID().String()
 			l           sync.Mutex
 			completed   = make([]int, 0, 100)
-			e           = New(100, 4, nil)
+			e           = New(100, 4, maxDependencies, nil)
 			slow        = make(chan struct{})
 		)
 		for i := 0; i < 100; i++ {
@@ -450,7 +452,7 @@ func TestReadThenWriteRepeated(t *testing.T) {
 			conflictKey = ids.GenerateTestID().String()
 			l           sync.Mutex
 			completed   = make([]int, 0, 100)
-			e           = New(100, 4, nil)
+			e           = New(100, 4, maxDependencies, nil)
 			slow        = make(chan struct{})
 		)
 		for i := 0; i < 100; i++ {
@@ -494,7 +496,7 @@ func TestTwoConflictKeys(t *testing.T) {
 			conflictKey2 = ids.GenerateTestID().String()
 			l            sync.Mutex
 			completed    = make([]int, 0, 100)
-			e            = New(100, 4, nil)
+			e            = New(100, 4, maxDependencies, nil)
 			slow         = make(chan struct{})
 		)
 		for i := 0; i < 100; i++ {
@@ -533,7 +535,7 @@ func TestLargeConcurrentRead(t *testing.T) {
 		numKeys   = 10
 		numTxs    = 100_000
 		completed = make([]int, 0, numTxs)
-		e         = New(numTxs, 4, nil)
+		e         = New(numTxs, 4, maxDependencies, nil)
 
 		numBlocking = 1000
 		blocking    = set.Set[int]{}
@@ -608,7 +610,7 @@ func TestLargeSequentialWrites(t *testing.T) {
 		numKeys   = 10
 		numTxs    = 100_000
 		completed = make([]int, 0, numTxs)
-		e         = New(numTxs, 4, nil)
+		e         = New(numTxs, 4, maxDependencies, nil)
 
 		numBlocking = 1000
 		blocking    = set.Set[int]{}
@@ -686,7 +688,7 @@ func TestLargeReadsThenWrites(t *testing.T) {
 		numTxs    = 100_000
 		completed = make([]int, 0, numTxs)
 		answers   = make([][]int, 5)
-		e         = New(numTxs, 4, nil)
+		e         = New(numTxs, 4, maxDependencies, nil)
 
 		numBlocking  = 10000
 		blocking     = set.Set[int]{}
@@ -764,7 +766,7 @@ func TestLargeWritesThenReads(t *testing.T) {
 		numTxs    = 100_000
 		completed = make([]int, 0, numTxs)
 		answers   = make([][]int, 5)
-		e         = New(numTxs, 4, nil)
+		e         = New(numTxs, 4, maxDependencies, nil)
 
 		numBlocking  = 10000
 		blocking     = set.Set[int]{}
@@ -840,7 +842,7 @@ func TestLargeRandomReadsAndWrites(t *testing.T) {
 		numKeys   = 10
 		numTxs    = 100000
 		completed = make([]int, 0, numTxs)
-		e         = New(numTxs, 4, nil)
+		e         = New(numTxs, 4, maxDependencies, nil)
 
 		conflictSize = 100
 		conflictKeys = make([]string, 0, conflictSize)

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -546,10 +546,7 @@ func TestLargeConcurrentRead(t *testing.T) {
 	)
 
 	// randomly wait on certain txs
-	for {
-		if blocking.Len() == 1000 {
-			break
-		}
+	for blocking.Len() < 1000 {
 		blocking.Add(rand.Intn(100_000)) //nolint:gosec
 	}
 
@@ -630,10 +627,7 @@ func TestLargeSequentialWrites(t *testing.T) {
 	)
 
 	// randomly wait on certain txs
-	for {
-		if blocking.Len() == 1000 {
-			break
-		}
+	for blocking.Len() < 1000 {
 		blocking.Add(rand.Intn(100_000)) //nolint:gosec
 	}
 
@@ -724,10 +718,7 @@ func TestLargeReadsThenWrites(t *testing.T) {
 	answers[4] = generateNumbers(90000)
 
 	// randomly wait on certain txs
-	for {
-		if blocking.Len() == 10000 {
-			break
-		}
+	for blocking.Len() < 10000 {
 		blocking.Add(rand.Intn(100_000)) //nolint:gosec
 	}
 
@@ -809,10 +800,7 @@ func TestLargeWritesThenReads(t *testing.T) {
 	answers[4] = generateNumbers(80000)
 
 	// randomly wait on certain txs
-	for {
-		if blocking.Len() == 10000 {
-			break
-		}
+	for blocking.Len() < 10000 {
 		blocking.Add(rand.Intn(100_000)) //nolint:gosec
 	}
 
@@ -885,10 +873,7 @@ func TestLargeRandomReadsAndWrites(t *testing.T) {
 	)
 
 	// randomly wait on certain txs
-	for {
-		if blocking.Len() == 10000 {
-			break
-		}
+	for blocking.Len() < 10000 {
 		blocking.Add(rand.Intn(100_000)) //nolint:gosec
 	}
 
@@ -907,10 +892,7 @@ func TestLargeRandomReadsAndWrites(t *testing.T) {
 		max := 6
 		setSize := rand.Intn(max-min+1) + min             //nolint:gosec
 		randomConflictingKeys := set.NewSet[int](setSize) // indices of [conflictKeys]
-		for {
-			if randomConflictingKeys.Len() == setSize {
-				break
-			}
+		for randomConflictingKeys.Len() < setSize {
 			randomConflictingKeys.Add(rand.Intn(numKeys)) //nolint:gosec
 		}
 

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -537,6 +537,7 @@ func TestLargeConcurrentRead(t *testing.T) {
 		require      = require.New(t)
 		numKeys      = 10
 		numTxs       = 100_000
+		numBlocking  = 1000
 		conflictKeys = make([]string, 0, numKeys)
 		blocking     = set.Set[int]{}
 		l            sync.Mutex
@@ -546,7 +547,7 @@ func TestLargeConcurrentRead(t *testing.T) {
 	)
 
 	// randomly wait on certain txs
-	for blocking.Len() < 1000 {
+	for blocking.Len() < numBlocking {
 		blocking.Add(rand.Intn(100_000)) //nolint:gosec
 	}
 
@@ -602,7 +603,7 @@ func TestLargeConcurrentRead(t *testing.T) {
 			return nil
 		})
 	}
-	for i := 0; i < 1000; i++ {
+	for i := 0; i < numBlocking; i++ {
 		slow <- struct{}{}
 	}
 	close(slow)
@@ -618,6 +619,7 @@ func TestLargeSequentialWrites(t *testing.T) {
 		require      = require.New(t)
 		numKeys      = 5
 		numTxs       = 100_000
+		numBlocking  = 1000
 		conflictKeys = make([]string, 0, numKeys)
 		blocking     = set.Set[int]{}
 		l            sync.Mutex
@@ -627,7 +629,7 @@ func TestLargeSequentialWrites(t *testing.T) {
 	)
 
 	// randomly wait on certain txs
-	for blocking.Len() < 1000 {
+	for blocking.Len() < numBlocking {
 		blocking.Add(rand.Intn(100_000)) //nolint:gosec
 	}
 
@@ -683,7 +685,7 @@ func TestLargeSequentialWrites(t *testing.T) {
 			return nil
 		})
 	}
-	for i := 0; i < 1000; i++ {
+	for i := 0; i < numBlocking; i++ {
 		slow <- struct{}{}
 	}
 	close(slow)
@@ -701,6 +703,7 @@ func TestLargeReadsThenWrites(t *testing.T) {
 		require      = require.New(t)
 		numKeys      = 5
 		numTxs       = 100_000
+		numBlocking  = 10000
 		conflictKeys = make([]string, 0, numKeys)
 		blocking     = set.Set[int]{}
 		l            sync.Mutex
@@ -718,7 +721,7 @@ func TestLargeReadsThenWrites(t *testing.T) {
 	answers[4] = generateNumbers(90000)
 
 	// randomly wait on certain txs
-	for blocking.Len() < 10000 {
+	for blocking.Len() < numBlocking {
 		blocking.Add(rand.Intn(100_000)) //nolint:gosec
 	}
 
@@ -760,7 +763,7 @@ func TestLargeReadsThenWrites(t *testing.T) {
 			return nil
 		})
 	}
-	for i := 0; i < 1000; i++ {
+	for i := 0; i < numBlocking; i++ {
 		slow <- struct{}{}
 	}
 	close(slow)
@@ -783,6 +786,7 @@ func TestLargeWritesThenReads(t *testing.T) {
 		require      = require.New(t)
 		numKeys      = 5
 		numTxs       = 100_000
+		numBlocking  = 10000
 		conflictKeys = make([]string, 0, numKeys)
 		blocking     = set.Set[int]{}
 		l            sync.Mutex
@@ -800,7 +804,7 @@ func TestLargeWritesThenReads(t *testing.T) {
 	answers[4] = generateNumbers(80000)
 
 	// randomly wait on certain txs
-	for blocking.Len() < 10000 {
+	for blocking.Len() < numBlocking {
 		blocking.Add(rand.Intn(100_000)) //nolint:gosec
 	}
 
@@ -842,7 +846,7 @@ func TestLargeWritesThenReads(t *testing.T) {
 			return nil
 		})
 	}
-	for i := 0; i < 1000; i++ {
+	for i := 0; i < numBlocking; i++ {
 		slow <- struct{}{}
 	}
 	close(slow)
@@ -864,6 +868,7 @@ func TestLargeRandomReadsAndWrites(t *testing.T) {
 		require      = require.New(t)
 		numKeys      = 10
 		numTxs       = 100_000
+		numBlocking  = 10000
 		conflictSize = 100
 		conflictKeys = make([]string, 0, conflictSize)
 		blocking     = set.Set[int]{}
@@ -874,7 +879,7 @@ func TestLargeRandomReadsAndWrites(t *testing.T) {
 	)
 
 	// randomly wait on certain txs
-	for blocking.Len() < 10000 {
+	for blocking.Len() < numBlocking {
 		blocking.Add(rand.Intn(100_000)) //nolint:gosec
 	}
 
@@ -945,7 +950,7 @@ func TestLargeRandomReadsAndWrites(t *testing.T) {
 			return nil
 		})
 	}
-	for i := 0; i < 1000; i++ {
+	for i := 0; i < numBlocking; i++ {
 		slow <- struct{}{}
 	}
 	close(slow)

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -550,7 +550,7 @@ func TestLargeNumConcurrentReadTxs(t *testing.T) {
 		if blocking.Len() == 1000 {
 			break
 		}
-		blocking.Add(rand.Intn(100_000))
+		blocking.Add(rand.Intn(100_000)) //nolint:gosec
 	}
 
 	// make the conflict keys
@@ -617,7 +617,7 @@ func TestLargeNumSequentialWritesTxs(t *testing.T) {
 		if blocking.Len() == 1000 {
 			break
 		}
-		blocking.Add(rand.Intn(100_000))
+		blocking.Add(rand.Intn(100_000)) //nolint:gosec
 	}
 
 	// make the conflict keys
@@ -694,7 +694,7 @@ func TestLargeNumReadsThenWritesTxs(t *testing.T) {
 		if blocking.Len() == 10000 {
 			break
 		}
-		blocking.Add(rand.Intn(100_000))
+		blocking.Add(rand.Intn(100_000)) //nolint:gosec
 	}
 
 	// make the conflict keys
@@ -777,7 +777,7 @@ func TestLargeNumWritesThenReadsTxs(t *testing.T) {
 		if blocking.Len() == 10000 {
 			break
 		}
-		blocking.Add(rand.Intn(100_000))
+		blocking.Add(rand.Intn(100_000)) //nolint:gosec
 	}
 
 	// make the conflict keys

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -534,16 +534,18 @@ func TestLargeConcurrentRead(t *testing.T) {
 	rand.Seed(1)
 
 	var (
-		require      = require.New(t)
-		numKeys      = 10
-		numTxs       = 100_000
+		require   = require.New(t)
+		numKeys   = 10
+		numTxs    = 100_000
+		completed = make([]int, 0, numTxs)
+		e         = New(numTxs, 4, nil)
+
 		numBlocking  = 1000
-		conflictKeys = make([]string, 0, numKeys)
 		blocking     = set.Set[int]{}
-		l            sync.Mutex
-		completed    = make([]int, 0, numTxs)
-		e            = New(numTxs, 4, nil)
-		slow         = make(chan struct{})
+		conflictKeys = make([]string, 0, numKeys)
+
+		l    sync.Mutex
+		slow = make(chan struct{})
 	)
 
 	// randomly wait on certain txs
@@ -606,16 +608,18 @@ func TestLargeSequentialWrites(t *testing.T) {
 	rand.Seed(2)
 
 	var (
-		require      = require.New(t)
-		numKeys      = 5
-		numTxs       = 100_000
+		require   = require.New(t)
+		numKeys   = 5
+		numTxs    = 100_000
+		completed = make([]int, 0, numTxs)
+		e         = New(numTxs, 4, nil)
+
 		numBlocking  = 1000
-		conflictKeys = make([]string, 0, numKeys)
 		blocking     = set.Set[int]{}
-		l            sync.Mutex
-		completed    = make([]int, 0, numTxs)
-		e            = New(numTxs, 4, nil)
-		slow         = make(chan struct{})
+		conflictKeys = make([]string, 0, numKeys)
+
+		l    sync.Mutex
+		slow = make(chan struct{})
 	)
 
 	// randomly wait on certain txs
@@ -680,17 +684,19 @@ func TestLargeReadsThenWrites(t *testing.T) {
 	rand.Seed(3)
 
 	var (
-		require      = require.New(t)
-		numKeys      = 5
-		numTxs       = 100_000
+		require   = require.New(t)
+		numKeys   = 5
+		numTxs    = 100_000
+		completed = make([]int, 0, numTxs)
+		answers   = make([][]int, 5)
+		e         = New(numTxs, 4, nil)
+
 		numBlocking  = 10000
-		conflictKeys = make([]string, 0, numKeys)
 		blocking     = set.Set[int]{}
-		l            sync.Mutex
-		completed    = make([]int, 0, numTxs)
-		answers      = make([][]int, 5)
-		e            = New(numTxs, 4, nil)
-		slow         = make(chan struct{})
+		conflictKeys = make([]string, 0, numKeys)
+
+		l    sync.Mutex
+		slow = make(chan struct{})
 	)
 
 	// make [answers] matrix
@@ -756,17 +762,19 @@ func TestLargeWritesThenReads(t *testing.T) {
 	rand.Seed(4)
 
 	var (
-		require      = require.New(t)
-		numKeys      = 5
-		numTxs       = 100_000
+		require   = require.New(t)
+		numKeys   = 5
+		numTxs    = 100_000
+		completed = make([]int, 0, numTxs)
+		answers   = make([][]int, 5)
+		e         = New(numTxs, 4, nil)
+
 		numBlocking  = 10000
-		conflictKeys = make([]string, 0, numKeys)
 		blocking     = set.Set[int]{}
-		l            sync.Mutex
-		completed    = make([]int, 0, numTxs)
-		answers      = make([][]int, 5)
-		e            = New(numTxs, 4, nil)
-		slow         = make(chan struct{})
+		conflictKeys = make([]string, 0, numKeys)
+
+		l    sync.Mutex
+		slow = make(chan struct{})
 	)
 
 	// make [answers] matrix
@@ -831,17 +839,20 @@ func TestLargeRandomReadsAndWrites(t *testing.T) {
 	rand.Seed(5)
 
 	var (
-		require      = require.New(t)
-		numKeys      = 10
-		numTxs       = 100_000
-		numBlocking  = 10000
+		require   = require.New(t)
+		numKeys   = 10
+		numTxs    = 100_000
+		completed = make([]int, 0, numTxs)
+		e         = New(numTxs, 4, nil)
+
 		conflictSize = 100
 		conflictKeys = make([]string, 0, conflictSize)
-		blocking     = set.Set[int]{}
-		l            sync.Mutex
-		completed    = make([]int, 0, numTxs)
-		e            = New(numTxs, 4, nil)
-		slow         = make(chan struct{})
+
+		numBlocking = 10000
+		blocking    = set.Set[int]{}
+
+		l    sync.Mutex
+		slow = make(chan struct{})
 	)
 
 	// randomly wait on certain txs

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -864,7 +864,8 @@ func TestLargeRandomReadsAndWrites(t *testing.T) {
 		require      = require.New(t)
 		numKeys      = 10
 		numTxs       = 100_000
-		conflictKeys = make([]string, 0, numKeys)
+		conflictSize = 100
+		conflictKeys = make([]string, 0, conflictSize)
 		blocking     = set.Set[int]{}
 		l            sync.Mutex
 		completed    = make([]int, 0, numTxs)
@@ -878,7 +879,7 @@ func TestLargeRandomReadsAndWrites(t *testing.T) {
 	}
 
 	// make the conflict keys
-	for k := 0; k < numKeys; k++ {
+	for k := 0; k < conflictSize; k++ {
 		conflictKeys = append(conflictKeys, ids.GenerateTestID().String())
 	}
 
@@ -891,7 +892,7 @@ func TestLargeRandomReadsAndWrites(t *testing.T) {
 		setSize := max(1, rand.Intn(6))                   //nolint:gosec
 		randomConflictingKeys := set.NewSet[int](setSize) // indices of [conflictKeys]
 		for randomConflictingKeys.Len() < setSize {
-			randomConflictingKeys.Add(rand.Intn(numKeys)) //nolint:gosec
+			randomConflictingKeys.Add(rand.Intn(conflictSize)) //nolint:gosec
 		}
 
 		// randomly pick if these conflict keys are

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -330,7 +330,7 @@ func TestReadThenWrite(t *testing.T) {
 		}
 		ti := i
 		e.Run(s, func() error {
-			if ti < 10 {
+			if ti == 9 {
 				time.Sleep(1 * time.Second)
 			}
 

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -564,10 +564,7 @@ func TestLargeConcurrentRead(t *testing.T) {
 		// random size of conflict keys to add
 		setSize := rand.Intn(numKeys + 1)                 //nolint:gosec
 		randomConflictingKeys := set.NewSet[int](setSize) // indices of [conflictKeys]
-		for {
-			if randomConflictingKeys.Len() == setSize {
-				break
-			}
+		for randomConflictingKeys.Len() < setSize {
 			randomConflictingKeys.Add(rand.Intn(numKeys)) //nolint:gosec
 		}
 
@@ -586,14 +583,7 @@ func TestLargeConcurrentRead(t *testing.T) {
 		// pass into executor
 		ti := i
 		e.Run(s, func() error {
-			shouldWait := false
-			for num := range blocking {
-				if num == ti {
-					shouldWait = true
-					break
-				}
-			}
-			if shouldWait {
+			if blocking.Contains(ti) {
 				<-slow
 			}
 
@@ -646,10 +636,7 @@ func TestLargeSequentialWrites(t *testing.T) {
 		// random size of conflict keys to add
 		setSize := rand.Intn(numKeys + 1)                 //nolint:gosec
 		randomConflictingKeys := set.NewSet[int](setSize) // indices of [conflictKeys]
-		for {
-			if randomConflictingKeys.Len() == setSize {
-				break
-			}
+		for randomConflictingKeys.Len() < setSize {
 			randomConflictingKeys.Add(rand.Intn(numKeys)) //nolint:gosec
 		}
 
@@ -668,14 +655,7 @@ func TestLargeSequentialWrites(t *testing.T) {
 		// pass into executor
 		ti := i
 		e.Run(s, func() error {
-			shouldWait := false
-			for num := range blocking {
-				if num == ti {
-					shouldWait = true
-					break
-				}
-			}
-			if shouldWait {
+			if blocking.Contains(ti) {
 				<-slow
 			}
 
@@ -746,14 +726,7 @@ func TestLargeReadsThenWrites(t *testing.T) {
 		// pass into executor
 		ti := i
 		e.Run(s, func() error {
-			shouldWait := false
-			for num := range blocking {
-				if num == ti {
-					shouldWait = true
-					break
-				}
-			}
-			if shouldWait {
+			if blocking.Contains(ti) {
 				<-slow
 			}
 
@@ -829,14 +802,7 @@ func TestLargeWritesThenReads(t *testing.T) {
 		// pass into executor
 		ti := i
 		e.Run(s, func() error {
-			shouldWait := false
-			for num := range blocking {
-				if num == ti {
-					shouldWait = true
-					break
-				}
-			}
-			if shouldWait {
+			if blocking.Contains(ti) {
 				<-slow
 			}
 
@@ -933,14 +899,7 @@ func TestLargeRandomReadsAndWrites(t *testing.T) {
 		// pass into executor
 		ti := i
 		e.Run(s, func() error {
-			shouldWait := false
-			for num := range blocking {
-				if num == ti {
-					shouldWait = true
-					break
-				}
-			}
-			if shouldWait {
+			if blocking.Contains(ti) {
 				<-slow
 			}
 

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	go.opentelemetry.io/otel/exporters/zipkin v1.11.2
 	go.opentelemetry.io/otel/sdk v1.11.2
 	go.opentelemetry.io/otel/trace v1.11.2
+	go.uber.org/atomic v1.11.0
 	go.uber.org/mock v0.4.0
 	go.uber.org/zap v1.26.0
 	golang.org/x/crypto v0.17.0
@@ -74,7 +75,6 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.11.2 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.11.2 // indirect
 	go.opentelemetry.io/proto/otlp v0.19.0 // indirect
-	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/net v0.19.0 // indirect
 	golang.org/x/sys v0.15.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -74,6 +74,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.11.2 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.11.2 // indirect
 	go.opentelemetry.io/proto/otlp v0.19.0 // indirect
+	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/net v0.19.0 // indirect
 	golang.org/x/sys v0.15.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -465,6 +465,8 @@ go.opentelemetry.io/otel/trace v1.11.2/go.mod h1:4N+yC7QEz7TTsG9BSRLNAa63eg5E06O
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
 go.opentelemetry.io/proto/otlp v0.19.0 h1:IVN6GR+mhC4s5yfcTbmzHYODqvWAp3ZedA2SJPI1Nnw=
 go.opentelemetry.io/proto/otlp v0.19.0/go.mod h1:H7XAot3MsfNsj7EXtrA2q5xSNQ10UqI405h3+duxN4U=
+go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
+go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 go.uber.org/goleak v1.2.1 h1:NBol2c7O1ZokfZ0LEU9K6Whx/KnwvepVetCUhtKja4A=
 go.uber.org/goleak v1.2.1/go.mod h1:qlT2yGI9QafXHhZZLxlSuNsMw3FFLxBr+tBRlmO1xH4=
 go.uber.org/mock v0.4.0 h1:VcM4ZOtdbR4f6VXfiOpwpVJDL6lCReaZ6mw31wqh7KU=

--- a/x/programs/cmd/simulator/go.mod
+++ b/x/programs/cmd/simulator/go.mod
@@ -65,6 +65,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.11.2 // indirect
 	go.opentelemetry.io/otel/trace v1.11.2 // indirect
 	go.opentelemetry.io/proto/otlp v0.19.0 // indirect
+	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/mock v0.4.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.17.0 // indirect

--- a/x/programs/cmd/simulator/go.sum
+++ b/x/programs/cmd/simulator/go.sum
@@ -455,6 +455,8 @@ go.opentelemetry.io/otel/trace v1.11.2/go.mod h1:4N+yC7QEz7TTsG9BSRLNAa63eg5E06O
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
 go.opentelemetry.io/proto/otlp v0.19.0 h1:IVN6GR+mhC4s5yfcTbmzHYODqvWAp3ZedA2SJPI1Nnw=
 go.opentelemetry.io/proto/otlp v0.19.0/go.mod h1:H7XAot3MsfNsj7EXtrA2q5xSNQ10UqI405h3+duxN4U=
+go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
+go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 go.uber.org/goleak v1.2.1 h1:NBol2c7O1ZokfZ0LEU9K6Whx/KnwvepVetCUhtKja4A=
 go.uber.org/goleak v1.2.1/go.mod h1:qlT2yGI9QafXHhZZLxlSuNsMw3FFLxBr+tBRlmO1xH4=
 go.uber.org/mock v0.4.0 h1:VcM4ZOtdbR4f6VXfiOpwpVJDL6lCReaZ6mw31wqh7KU=


### PR DESCRIPTION
Closes #701, #709 . 

### Overview

The executor keeps track of a dependency graph to determine if a `task` is executable or not. 


Properties of the dependency graph: 

- There is a graph for every key. 
- The nodes in the graph represent the `task` and the type of access its requesting for that key (Read/Allocate/Write).
- Generally, nodes in the graph are Write keys. Unless, if, it's the first node in the graph (i.e., the graph was empty), and it is a Read access, then it is also a node.
- An edge is formed between Write-Write, Read-Write, or Write-Read nodes.
- An edge is formed to the same node (self-edge) every time a Read is requested

### Test Plan

- Added unit tests in `executor_test.go`, coverage is ~97.5%
- Existing unit tests in `executor_test.go` pass
- Integration tests pass
- CI (with load & sync testing)