### PR TITLE
Always run Go unit tests

### DIFF
--- a/.github/workflows/hypersdk-unit-tests.yml
+++ b/.github/workflows/hypersdk-unit-tests.yml
@@ -8,11 +8,9 @@ on:
     branches:
       - main
   pull_request:
-    types: [labeled,synchronize,reopened]
 
 jobs:
   hypersdk-unit-tests:
-    if: ${{ github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'run all ci') }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
I just ran these tests on #826 and they only took 1m30s. 

I'm still not super familiar with how Go tests work (especially in a monorepo like this), but I would argue that if you can run a tests on every commit in a PR, it's not a unit test at all and should go somehwere else. 

Time it takes on this PR:
https://github.com/ava-labs/hypersdk/actions/runs/8606340518/job/23584539436?pr=827

