### PR TITLE
[executor] multi-key conflict bug

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -170,6 +170,9 @@ func (e *Executor) Run(keys state.Keys, f func() error) {
 			if v == state.Read {
 				// If we don't need exclusive access to a key, just mark
 				// that we are reading it and that we are a reader of it.
+				//
+				// We use a map for [reading] because a single task can have
+				// different keys that are all just readers of another task.
 				t.reading[lt.id] = lt
 				lt.readers[id] = t
 			} else {

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -73,7 +73,7 @@ type task struct {
 	id int
 	f  func() error
 	// reading are the tasks that this task is using non-exclusively.
-	reading []*task
+	reading map[int]*task
 
 	l        sync.Mutex
 	executed bool
@@ -147,7 +147,7 @@ func (e *Executor) Run(keys state.Keys, f func() error) {
 	t := &task{
 		id:      id,
 		f:       f,
-		reading: []*task{},
+		reading: make(map[int]*task),
 
 		blocked: make(map[int]*task),
 		readers: make(map[int]*task),
@@ -170,7 +170,9 @@ func (e *Executor) Run(keys state.Keys, f func() error) {
 			if v == state.Read {
 				// If we don't need exclusive access to a key, just mark
 				// that we are reading it and that we are a reader of it.
-				t.reading = append(t.reading, lt)
+				// TODO: currently a no-op when we add ourself multiple times
+				// but find a better way of handling [reading]
+				t.reading[lt.id] = lt
 				lt.readers[id] = t
 			} else {
 				// If we do need exclusive access to a key, we need to

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -180,6 +180,7 @@ func (e *Executor) Run(keys state.Keys, f func() error) {
 				// and can't mark itself as executed until all [shared] are
 				// cleared (which can't be done while we hold the lock for [lt]).
 				for _, rt := range lt.readers {
+					// Don't block on ourself if we just recorded us reading
 					if rt.id == id {
 						continue
 					}

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -180,6 +180,9 @@ func (e *Executor) Run(keys state.Keys, f func() error) {
 				// and can't mark itself as executed until all [shared] are
 				// cleared (which can't be done while we hold the lock for [lt]).
 				for _, rt := range lt.readers {
+					if rt.id == id {
+						continue
+					}
 					rt.l.Lock()
 					rt.blocked[id] = t
 					rt.l.Unlock()

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -72,8 +72,8 @@ func (e *Executor) work() {
 type task struct {
 	id int
 	f  func() error
-	// shared are the tasks that this task is using non-exclusively.
-	shared []*task
+	// reading are the tasks that this task is using non-exclusively.
+	reading []*task
 
 	l        sync.Mutex
 	executed bool
@@ -95,12 +95,12 @@ func (e *Executor) runTask(t *task) {
 	// to ensure we can exit.
 	defer func() {
 		// Notify other tasks that we are done reading them
-		for _, rt := range t.shared {
+		for _, rt := range t.reading {
 			rt.l.Lock()
 			delete(rt.readers, t.id)
 			rt.l.Unlock()
 		}
-		t.shared = nil
+		t.reading = nil
 
 		// Nodify blocked tasks that they can execute
 		t.l.Lock()
@@ -145,9 +145,9 @@ func (e *Executor) Run(keys state.Keys, f func() error) {
 	id := e.tasks
 	e.tasks++
 	t := &task{
-		id:     id,
-		f:      f,
-		shared: []*task{},
+		id:      id,
+		f:       f,
+		reading: []*task{},
 
 		blocked: make(map[int]*task),
 		readers: make(map[int]*task),
@@ -170,14 +170,14 @@ func (e *Executor) Run(keys state.Keys, f func() error) {
 			if v == state.Read {
 				// If we don't need exclusive access to a key, just mark
 				// that we are reading it and that we are a reader of it.
-				t.shared = append(t.shared, lt)
+				t.reading = append(t.reading, lt)
 				lt.readers[id] = t
 			} else {
 				// If we do need exclusive access to a key, we need to
 				// mark ourselves blocked on all readers ahead of us.
 				//
 				// If a task is a reader, that means it is not executed yet
-				// and can't mark itself as executed until all [shared] are
+				// and can't mark itself as executed until all [reading] are
 				// cleared (which can't be done while we hold the lock for [lt]).
 				for _, rt := range lt.readers {
 					// Don't block on ourself if we just recorded us reading

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -170,8 +170,6 @@ func (e *Executor) Run(keys state.Keys, f func() error) {
 			if v == state.Read {
 				// If we don't need exclusive access to a key, just mark
 				// that we are reading it and that we are a reader of it.
-				// TODO: currently a no-op when we add ourself multiple times
-				// but find a better way of handling [reading]
 				t.reading[lt.id] = lt
 				lt.readers[id] = t
 			} else {
@@ -182,7 +180,7 @@ func (e *Executor) Run(keys state.Keys, f func() error) {
 				// and can't mark itself as executed until all [reading] are
 				// cleared (which can't be done while we hold the lock for [lt]).
 				for _, rt := range lt.readers {
-					// Don't block on ourself if we just recorded us reading
+					// Don't block on ourself if we already marked ourself as a reader
 					if rt.id == id {
 						continue
 					}

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -502,13 +502,8 @@ func TestTwoConflictKeys(t *testing.T) {
 			for k := 0; k < i+1; k++ {
 				s.Add(ids.GenerateTestID().String(), state.Write)
 			}
-			if i == 0 || i == 1 {
-				s.Add(conflictKey1, state.Write)
-				s.Add(conflictKey2, state.Write)
-			} else {
-				s.Add(conflictKey1, state.Read)
-				s.Add(conflictKey2, state.Read)
-			}
+			s.Add(conflictKey1, state.Read)
+			s.Add(conflictKey2, state.Write)
 			ti := i
 			e.Run(s, func() error {
 				if ti == 10 {
@@ -843,7 +838,7 @@ func TestLargeRandomReadsAndWrites(t *testing.T) {
 	var (
 		require   = require.New(t)
 		numKeys   = 10
-		numTxs    = 100000
+		numTxs    = 100_000
 		completed = make([]int, 0, numTxs)
 		e         = New(numTxs, 4, nil)
 

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -877,8 +877,7 @@ func TestLargeRandomReadsAndWrites(t *testing.T) {
 		// add the random keys to tx
 		for k := range randomConflictingKeys {
 			// randomly pick if conflict key is Read/Write
-			conflictMode := rand.Intn(2) //nolint:gosec
-			switch conflictMode {
+			switch rand.Intn(2) { //nolint:gosec
 			case 0:
 				s.Add(conflictKeys[k], state.Read)
 			case 1:
@@ -890,8 +889,7 @@ func TestLargeRandomReadsAndWrites(t *testing.T) {
 		remaining := numKeys - setSize
 		for j := 0; j < remaining; j++ {
 			// randomly pick the permission for unique keys
-			uniqueMode := rand.Intn(2) //nolint:gosec
-			switch uniqueMode {
+			switch rand.Intn(2) { //nolint:gosec
 			case 0:
 				s.Add(ids.GenerateTestID().String(), state.Read)
 			case 1:

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -843,7 +843,7 @@ func TestLargeRandomReadsAndWrites(t *testing.T) {
 	var (
 		require   = require.New(t)
 		numKeys   = 10
-		numTxs    = 100_000
+		numTxs    = 100000
 		completed = make([]int, 0, numTxs)
 		e         = New(numTxs, 4, nil)
 
@@ -879,12 +879,10 @@ func TestLargeRandomReadsAndWrites(t *testing.T) {
 			randomConflictingKeys.Add(rand.Intn(conflictSize)) //nolint:gosec
 		}
 
-		// randomly pick if these conflict keys are
-		// going to be Read/Write
-		conflictMode := rand.Intn(2) //nolint:gosec
-
 		// add the random keys to tx
 		for k := range randomConflictingKeys {
+			// randomly pick if conflict key is Read/Write
+			conflictMode := rand.Intn(2) //nolint:gosec
 			switch conflictMode {
 			case 0:
 				s.Add(conflictKeys[k], state.Read)


### PR DESCRIPTION
Consider two transactions, T1 and T2 both accessing key A and B. Suppose in the slow path, T1 and T2 have not executed.

T1 requests: A read, B write

T2 requests: A read, B write

In T1, these keys don't exist in e.nodes so we'll just add it

In T2, when we encounter A, lt is T1

We add ourselves, T2 to lt.readers for key A, and note that T1 hasn't executed so T1 is blocking T2.

For key B in T2, we go through the lt.readers now since we're a Write, and one of the rt is us, T2. So we're saying T2 is blocked on ourself