### PR TITLE
[Heap] Make map index generic

### DIFF
--- a/eheap/eheap.go
+++ b/eheap/eheap.go
@@ -22,7 +22,7 @@ type Item interface {
 // instead of grouping by expiry to support this feature, which makes it
 // less efficient).
 type ExpiryHeap[T Item] struct {
-	minHeap *heap.Heap[T, int64]
+	minHeap *heap.Heap[ids.ID, T, int64]
 }
 
 // New returns an instance of ExpiryHeap with minHeap and maxHeap
@@ -37,7 +37,7 @@ func New[T Item](items int) *ExpiryHeap[T] {
 func (eh *ExpiryHeap[T]) Add(item T) {
 	itemID := item.ID()
 	poolLen := eh.minHeap.Len()
-	eh.minHeap.Push(&heap.Entry[T, int64]{
+	eh.minHeap.Push(&heap.Entry[ids.ID, T, int64]{
 		ID:    itemID,
 		Val:   item.Expiry(),
 		Item:  item,

--- a/eheap/eheap.go
+++ b/eheap/eheap.go
@@ -29,7 +29,7 @@ type ExpiryHeap[T Item] struct {
 // containing [items].
 func New[T Item](items int) *ExpiryHeap[T] {
 	return &ExpiryHeap[T]{
-		minHeap: heap.New[T, int64](items, true),
+		minHeap: heap.New[ids.ID, T, int64](items, true),
 	}
 }
 

--- a/emap/emap.go
+++ b/emap/emap.go
@@ -29,7 +29,7 @@ type Item interface {
 type EMap[T Item] struct {
 	mu sync.RWMutex
 
-	bh    *heap.Heap[*bucket, int64]
+	bh    *heap.Heap[ids.ID, *bucket, int64]
 	seen  set.Set[ids.ID]   // Stores a set of unique tx ids
 	times map[int64]*bucket // Uses timestamp as keys to map to buckets of ids.
 }
@@ -39,7 +39,7 @@ func NewEMap[T Item]() *EMap[T] {
 	return &EMap[T]{
 		seen:  set.Set[ids.ID]{},
 		times: make(map[int64]*bucket),
-		bh:    heap.New[*bucket, int64](120, true),
+		bh:    heap.New[ids.ID, *bucket, int64](120, true),
 	}
 }
 
@@ -81,7 +81,7 @@ func (e *EMap[T]) add(id ids.ID, t int64) {
 		items: []ids.ID{id},
 	}
 	e.times[t] = b
-	e.bh.Push(&heap.Entry[*bucket, int64]{
+	e.bh.Push(&heap.Entry[ids.ID, *bucket, int64]{
 		ID:    id,
 		Val:   t,
 		Item:  b,

--- a/emap/emap_test.go
+++ b/emap/emap_test.go
@@ -27,7 +27,7 @@ func TestEmapNew(t *testing.T) {
 	emptyE := &EMap[*TestTx]{
 		seen:  set.Set[ids.ID]{},
 		times: make(map[int64]*bucket),
-		bh:    heap.New[*bucket, int64](0, true),
+		bh:    heap.New[ids.ID, *bucket, int64](0, true),
 	}
 	require.Equal(emptyE.seen, e.seen, "Emap did not return an empty emap struct.")
 	require.Equal(emptyE.times, e.times, "Emap did not return an empty emap struct.")

--- a/heap/heap.go
+++ b/heap/heap.go
@@ -6,74 +6,72 @@ package heap
 import (
 	"cmp"
 	"container/heap"
-
-	"github.com/ava-labs/avalanchego/ids"
 )
 
 // Heap[I,V] is used to track objects of [I] by [Val].
 //
 // This data structure does not perform any synchronization and is not
 // safe to use concurrently without external locking.
-type Heap[I any, V cmp.Ordered] struct {
-	ih *innerHeap[I, V]
+type Heap[T comparable, I any, V cmp.Ordered] struct {
+	ih *innerHeap[T, I, V]
 }
 
 // New returns an instance of Heap[I,V]
-func New[I any, V cmp.Ordered](items int, isMinHeap bool) *Heap[I, V] {
-	return &Heap[I, V]{newInnerHeap[I, V](items, isMinHeap)}
+func New[T comparable, I any, V cmp.Ordered](items int, isMinHeap bool) *Heap[T, I, V] {
+	return &Heap[T, I, V]{newInnerHeap[T, I, V](items, isMinHeap)}
 }
 
 // Len returns the number of items in ih.
-func (h *Heap[I, V]) Len() int { return h.ih.Len() }
+func (h *Heap[T, I, V]) Len() int { return h.ih.Len() }
 
 // Get returns the entry in th associated with [id], and a bool if [id] was
 // found in th.
-func (h *Heap[I, V]) Get(id ids.ID) (*Entry[I, V], bool) {
+func (h *Heap[T, I, V]) Get(id T) (*Entry[T, I, V], bool) {
 	return h.ih.Get(id)
 }
 
 // Has returns whether [id] is found in th.
-func (h *Heap[I, V]) Has(id ids.ID) bool {
+func (h *Heap[T, I, V]) Has(id T) bool {
 	return h.ih.Has(id)
 }
 
 // Items returns all items in the heap in sorted order. You should not modify
 // the response.
-func (h *Heap[I, V]) Items() []*Entry[I, V] {
+func (h *Heap[T, I, V]) Items() []*Entry[T, I, V] {
 	return h.ih.items
 }
 
 // Push can be called by external users instead of using `containers.heap`,
 // which makes using this heap less error-prone.
-func (h *Heap[I, V]) Push(e *Entry[I, V]) {
+func (h *Heap[T, I, V]) Push(e *Entry[T, I, V]) {
 	heap.Push(h.ih, e)
 }
 
 // Pop can be called by external users to remove an object from the heap at
 // a specific index instead of using `containers.heap`,
 // which makes using this heap less error-prone.
-func (h *Heap[I, V]) Pop() *Entry[I, V] {
+func (h *Heap[T, I, V]) Pop() *Entry[T, I, V] {
 	if len(h.ih.items) == 0 {
 		return nil
 	}
-	return heap.Pop(h.ih).(*Entry[I, V])
+	return heap.Pop(h.ih).(*Entry[T, I, V])
 }
 
 // Remove can be called by external users to remove an object from the heap at
 // a specific index instead of using `containers.heap`,
 // which makes using this heap less error-prone.
-func (h *Heap[I, V]) Remove(index int) *Entry[I, V] {
+func (h *Heap[T, I, V]) Remove(index int) *Entry[T, I, V] {
 	if index >= len(h.ih.items) {
 		return nil
 	}
-	return heap.Remove(h.ih, index).(*Entry[I, V])
+	return heap.Remove(h.ih, index).(*Entry[T, I, V])
 }
 
 // First returns the first item in the heap. This is the smallest item in
 // a minHeap and the largest item in a maxHeap.
 //
 // If no items are in the heap, it will return nil.
-func (h *Heap[I, V]) First() *Entry[I, V] {
+func (h *Heap[T, I, V]) First() *Entry[T, I, V] {
 	if len(h.ih.items) == 0 {
 		return nil
 	}

--- a/heap/heap_test.go
+++ b/heap/heap_test.go
@@ -17,28 +17,28 @@ type testItem struct {
 
 func TestUnit64HeapPushPopMin(t *testing.T) {
 	require := require.New(t)
-	minHeap := New[*testItem, uint64](0, true)
+	minHeap := New[ids.ID, *testItem, uint64](0, true)
 	require.Zero(minHeap.Len(), "heap not initialized properly.")
 	mempoolItem1 := &testItem{ids.GenerateTestID(), 10}
 	mempoolItem2 := &testItem{ids.GenerateTestID(), 7}
 	mempoolItem3 := &testItem{ids.GenerateTestID(), 15}
 
 	// Middle UnitPrice
-	med := &Entry[*testItem, uint64]{
+	med := &Entry[ids.ID, *testItem, uint64]{
 		ID:    mempoolItem1.id,
 		Item:  mempoolItem1,
 		Val:   mempoolItem1.value,
 		Index: minHeap.Len(),
 	}
 	// Lesser UnitPrice
-	low := &Entry[*testItem, uint64]{
+	low := &Entry[ids.ID, *testItem, uint64]{
 		ID:    mempoolItem2.id,
 		Item:  mempoolItem2,
 		Val:   mempoolItem2.value,
 		Index: minHeap.Len(),
 	}
 	// Greatest UnitPrice
-	high := &Entry[*testItem, uint64]{
+	high := &Entry[ids.ID, *testItem, uint64]{
 		ID:    mempoolItem3.id,
 		Item:  mempoolItem3,
 		Val:   mempoolItem3.value,
@@ -67,7 +67,7 @@ func TestUnit64HeapPushPopMin(t *testing.T) {
 
 func TestUnit64HeapPushPopMax(t *testing.T) {
 	require := require.New(t)
-	maxHeap := New[*testItem, uint64](0, false)
+	maxHeap := New[ids.ID, *testItem, uint64](0, false)
 	require.Zero(maxHeap.Len(), "heap not initialized properly.")
 
 	mempoolItem1 := &testItem{ids.GenerateTestID(), 10}
@@ -75,21 +75,21 @@ func TestUnit64HeapPushPopMax(t *testing.T) {
 	mempoolItem3 := &testItem{ids.GenerateTestID(), 15}
 
 	// Middle UnitPrice
-	med := &Entry[*testItem, uint64]{
+	med := &Entry[ids.ID, *testItem, uint64]{
 		ID:    mempoolItem1.id,
 		Item:  mempoolItem1,
 		Val:   mempoolItem1.value,
 		Index: maxHeap.Len(),
 	}
 	// Lesser UnitPrice
-	low := &Entry[*testItem, uint64]{
+	low := &Entry[ids.ID, *testItem, uint64]{
 		ID:    mempoolItem2.id,
 		Item:  mempoolItem2,
 		Val:   mempoolItem2.value,
 		Index: maxHeap.Len(),
 	}
 	// Greatest UnitPrice
-	high := &Entry[*testItem, uint64]{
+	high := &Entry[ids.ID, *testItem, uint64]{
 		ID:    mempoolItem3.id,
 		Item:  mempoolItem3,
 		Val:   mempoolItem3.value,
@@ -119,10 +119,10 @@ func TestUnit64HeapPushPopMax(t *testing.T) {
 func TestUnit64HeapPushExists(t *testing.T) {
 	// Push an item already in heap
 	require := require.New(t)
-	minHeap := New[*testItem, uint64](0, true)
+	minHeap := New[ids.ID, *testItem, uint64](0, true)
 	require.Zero(minHeap.Len(), "heap not initialized properly.")
 	mempoolItem := &testItem{ids.GenerateTestID(), 10}
-	entry := &Entry[*testItem, uint64]{
+	entry := &Entry[ids.ID, *testItem, uint64]{
 		ID:    mempoolItem.id,
 		Item:  mempoolItem,
 		Val:   mempoolItem.value,
@@ -142,11 +142,11 @@ func TestUnit64HeapPushExists(t *testing.T) {
 func TestUnit64HeapGetID(t *testing.T) {
 	// Push an item and grab its ID
 	require := require.New(t)
-	minHeap := New[*testItem, uint64](0, true)
+	minHeap := New[ids.ID, *testItem, uint64](0, true)
 	require.Zero(minHeap.Len(), "heap not initialized properly.")
 
 	mempoolItem := &testItem{ids.GenerateTestID(), 10}
-	entry := &Entry[*testItem, uint64]{
+	entry := &Entry[ids.ID, *testItem, uint64]{
 		ID:    mempoolItem.id,
 		Item:  mempoolItem,
 		Val:   mempoolItem.value,
@@ -164,10 +164,10 @@ func TestUnit64HeapGetID(t *testing.T) {
 
 func TestUnit64HeapHasID(t *testing.T) {
 	require := require.New(t)
-	minHeap := New[*testItem, uint64](0, true)
+	minHeap := New[ids.ID, *testItem, uint64](0, true)
 	require.Zero(minHeap.Len(), "heap not initialized properly.")
 	mempoolItem := &testItem{ids.GenerateTestID(), 10}
-	entry := &Entry[*testItem, uint64]{
+	entry := &Entry[ids.ID, *testItem, uint64]{
 		ID:    mempoolItem.id,
 		Item:  mempoolItem,
 		Val:   mempoolItem.value,

--- a/heap/inner_heap.go
+++ b/heap/inner_heap.go
@@ -7,43 +7,41 @@ import (
 	"cmp"
 	"container/heap"
 	"fmt"
-
-	"github.com/ava-labs/avalanchego/ids"
 )
 
-var _ heap.Interface = (*innerHeap[any, uint64])(nil)
+var _ heap.Interface = (*innerHeap[any, any, uint64])(nil)
 
-type Entry[I any, V cmp.Ordered] struct {
-	ID   ids.ID // id of entry
-	Item I      // associated item
-	Val  V      // Value to be prioritized
+type Entry[T comparable, I any, V cmp.Ordered] struct {
+	ID   T // id of entry
+	Item I // associated item
+	Val  V // Value to be prioritized
 
 	Index int // Index of the entry in heap
 }
 
-type innerHeap[I any, V cmp.Ordered] struct {
-	isMinHeap bool                    // true for Min-Heap, false for Max-Heap
-	items     []*Entry[I, V]          // items in this heap
-	lookup    map[ids.ID]*Entry[I, V] // ids in the heap mapping to an entry
+type innerHeap[T comparable, I any, V cmp.Ordered] struct {
+	isMinHeap bool                  // true for Min-Heap, false for Max-Heap
+	items     []*Entry[T, I, V]     // items in this heap
+	lookup    map[T]*Entry[T, I, V] // ids in the heap mapping to an entry
 }
 
-func newInnerHeap[I any, V cmp.Ordered](items int, isMinHeap bool) *innerHeap[I, V] {
-	return &innerHeap[I, V]{
+func newInnerHeap[T comparable, I any, V cmp.Ordered](items int, isMinHeap bool) *innerHeap[T, I, V] {
+	return &innerHeap[T, I, V]{
 		isMinHeap: isMinHeap,
 
-		items:  make([]*Entry[I, V], 0, items),
-		lookup: make(map[ids.ID]*Entry[I, V], items),
+		items:  make([]*Entry[T, I, V], 0, items),
+		lookup: make(map[T]*Entry[T, I, V], items),
 	}
 }
 
 // Len returns the number of items in ih.
-func (ih *innerHeap[I, V]) Len() int { return len(ih.items) }
+func (ih *innerHeap[T, I, V]) Len() int { return len(ih.items) }
 
 // Less compares the priority of [i] and [j] based on th.isMinHeap.
 //
 // This should never be called by an external caller and is required to
 // confirm to `heap.Interface`.
-func (ih *innerHeap[I, V]) Less(i, j int) bool {
+func (ih *innerHeap[T, I, V]) Less(i, j int) bool {
 	if ih.isMinHeap {
 		return ih.items[i].Val < ih.items[j].Val
 	}
@@ -54,7 +52,7 @@ func (ih *innerHeap[I, V]) Less(i, j int) bool {
 //
 // This should never be called by an external caller and is required to
 // confirm to `heap.Interface`.
-func (ih *innerHeap[I, V]) Swap(i, j int) {
+func (ih *innerHeap[T, I, V]) Swap(i, j int) {
 	ih.items[i], ih.items[j] = ih.items[j], ih.items[i]
 	ih.items[i].Index = i
 	ih.items[j].Index = j
@@ -65,8 +63,8 @@ func (ih *innerHeap[I, V]) Swap(i, j int) {
 //
 // This should never be called by an external caller and is required to
 // confirm to `heap.Interface`.
-func (ih *innerHeap[I, V]) Push(x any) {
-	entry, ok := x.(*Entry[I, V])
+func (ih *innerHeap[T, I, V]) Push(x any) {
+	entry, ok := x.(*Entry[T, I, V])
 	if !ok {
 		panic(fmt.Errorf("unexpected %T, expected *Entry", x))
 	}
@@ -82,7 +80,7 @@ func (ih *innerHeap[I, V]) Push(x any) {
 //
 // This should never be called by an external caller and is required to
 // confirm to `heap.Interface`.
-func (ih *innerHeap[I, V]) Pop() any {
+func (ih *innerHeap[T, I, V]) Pop() any {
 	n := len(ih.items)
 	item := ih.items[n-1]
 	ih.items[n-1] = nil // avoid memory leak
@@ -93,13 +91,13 @@ func (ih *innerHeap[I, V]) Pop() any {
 
 // Get returns the entry in th associated with [id], and a bool if [id] was
 // found in th.
-func (ih *innerHeap[I, V]) Get(id ids.ID) (*Entry[I, V], bool) {
+func (ih *innerHeap[T, I, V]) Get(id T) (*Entry[T, I, V], bool) {
 	entry, ok := ih.lookup[id]
 	return entry, ok
 }
 
 // Has returns whether [id] is found in th.
-func (ih *innerHeap[I, V]) Has(id ids.ID) bool {
+func (ih *innerHeap[T, I, V]) Has(id T) bool {
 	_, has := ih.Get(id)
 	return has
 }


### PR DESCRIPTION
Instead of `ids.ID` we make this a generic. This will unblock #858 and let us use `ActionID` as a comparable type.