### PR TITLE
Return `Option<Vec<u8>>` from `get_bytes`

### DIFF
--- a/x/programs/rust/wasmlanche-sdk/src/memory.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/memory.rs
@@ -82,7 +82,7 @@ where
 /// Reconstructs the vec from the pointer with the length given by the store
 /// `host_ptr` is encoded using Big Endian as an i64.
 #[must_use]
-fn into_bytes(ptr: HostPtr) -> Option<Vec<u8>> {
+pub fn into_bytes(ptr: HostPtr) -> Option<Vec<u8>> {
     GLOBAL_STORE
         .with_borrow_mut(|s| s.remove(&(ptr as *const u8)))
         .map(|len| unsafe { std::vec::Vec::from_raw_parts(ptr as *mut u8, len, len) })


### PR DESCRIPTION
Ditching https://github.com/ava-labs/hypersdk/pull/860 in favor of this one

Closes https://github.com/ava-labs/hypersdk/issues/848