### PR TITLE
[chain] fix result size

### DIFF
--- a/chain/result.go
+++ b/chain/result.go
@@ -31,19 +31,13 @@ func (r *Result) Size() int {
 
 func (r *Result) Marshal(p *codec.Packer) error {
 	p.PackBool(r.Success)
-
-	numOutputs := 0
-	for _, action := range r.Outputs {
-		numOutputs += len(action)
-	}
 	p.PackInt(len(r.Outputs))
-	p.PackInt(numOutputs)
 	for _, action := range r.Outputs {
+		p.PackInt(len(action))
 		for _, output := range action {
 			p.PackBytes(output)
 		}
 	}
-
 	p.PackFixedBytes(r.Consumed.Bytes())
 	p.PackUint64(r.Fee)
 	return nil
@@ -65,11 +59,10 @@ func UnmarshalResult(p *codec.Packer) (*Result, error) {
 	result := &Result{
 		Success: p.UnpackBool(),
 	}
-
 	totalOutputs := [][][]byte{}
 	numActions := p.UnpackInt(false)
-	numOutputs := p.UnpackInt(false)
 	for i := 0; i < numActions; i++ {
+		numOutputs := p.UnpackInt(false)
 		outputs := [][]byte{}
 		for j := 0; j < numOutputs; j++ {
 			var output []byte

--- a/chain/result.go
+++ b/chain/result.go
@@ -20,10 +20,10 @@ type Result struct {
 }
 
 func (r *Result) Size() int {
-	outputSize := consts.IntLen
+	outputSize := len(r.Outputs)
 	for _, action := range r.Outputs {
 		for _, output := range action {
-			outputSize += codec.BytesLen(output)
+			outputSize += codec.BytesLen(output) + 1 // for each output
 		}
 	}
 	return consts.BoolLen + outputSize + fees.DimensionsLen + consts.Uint64Len


### PR DESCRIPTION
Fixes the following:

- Packs the number of Actions in result.Outputs
- Packs the number of Outputs in each Action. This fixes the problem when unmarshaling we know where the outputs should be nested