### PR TITLE
Make delete return the old data

### DIFF
--- a/x/programs/cmd/simulator/cmd/plan.go
+++ b/x/programs/cmd/simulator/cmd/plan.go
@@ -240,7 +240,15 @@ func runStepFunc(
 
 			return nil
 		}
-		id, _, balance, err := programExecuteFunc(ctx, log, db, params, method, maxUnits)
+		id, response, balance, err := programExecuteFunc(ctx, log, db, params, method, maxUnits)
+		if err != nil {
+			return err
+		}
+		resp.setResponse(response)
+		ok, err := validateAssertion(response[0], require)
+		if !ok {
+			return fmt.Errorf("%w", ErrResultAssertionFailed)
+		}
 		if err != nil {
 			return err
 		}

--- a/x/programs/examples/imports/pstate/pstate.go
+++ b/x/programs/examples/imports/pstate/pstate.go
@@ -217,9 +217,45 @@ func (i *Import) deleteFn(caller *program.Caller, memOffset int32, size int32) (
 	}
 
 	k := storage.ProgramPrefixKey(args.ProgramID[:], args.Key)
-	if err := i.mu.Remove(context.Background(), k); err != nil {
-		i.log.Error("failed to remove from storage", zap.Error(err))
-		return types.ValI32(-1), nil
+	bytes, err = i.mu.GetValue(context.Background(), k)
+	if err != nil {
+		if errors.Is(err, database.ErrNotFound) {
+			val, err := program.WriteBytes(memory, []byte{0})
+			if err != nil {
+				i.log.Error("failed to write to memory",
+					zap.Error(err),
+				)
+				return nil, err
+			}
+
+			return types.ValI32(int32(val)), nil
+		}
+
+		i.log.Error("failed to get value from storage",
+			zap.Error(err),
+		)
+		return nil, err
 	}
-	return types.ValI32(0), nil
+
+	// prepend 1 to val
+	bytes = append([]byte{1}, bytes...)
+
+	ptr, err := program.WriteBytes(memory, bytes)
+	if err != nil {
+		{
+			i.log.Error("failed to write to memory",
+				zap.Error(err),
+			)
+		}
+		return nil, err
+	}
+
+	if err := i.mu.Remove(context.Background(), k); err != nil {
+		i.log.Error("failed to delete value from storage",
+			zap.Error(err),
+		)
+		return nil, err
+	}
+
+	return types.ValI32(int32(ptr)), nil
 }

--- a/x/programs/examples/imports/pstate/pstate.go
+++ b/x/programs/examples/imports/pstate/pstate.go
@@ -220,6 +220,7 @@ func (i *Import) deleteFn(caller *program.Caller, memOffset int32, size int32) (
 	bytes, err = i.mu.GetValue(context.Background(), k)
 	if err != nil {
 		if errors.Is(err, database.ErrNotFound) {
+			// [0] represents `None`
 			val, err := program.WriteBytes(memory, []byte{0})
 			if err != nil {
 				i.log.Error("failed to write to memory",
@@ -237,7 +238,7 @@ func (i *Import) deleteFn(caller *program.Caller, memOffset int32, size int32) (
 		return nil, err
 	}
 
-	// prepend 1 to val
+	// 1 is the discriminant for `Some`
 	bytes = append([]byte{1}, bytes...)
 
 	ptr, err := program.WriteBytes(memory, bytes)

--- a/x/programs/rust/wasmlanche-sdk/src/lib.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/lib.rs
@@ -8,7 +8,7 @@ mod memory;
 mod program;
 
 pub use self::{
-    memory::{from_host_ptr, CPointer},
+    memory::from_host_ptr,
     params::{serialize_param, Params},
     program::Program,
 };

--- a/x/programs/rust/wasmlanche-sdk/src/memory.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/memory.rs
@@ -8,9 +8,6 @@ use crate::state::Error as StateError;
 use borsh::{from_slice, BorshDeserialize};
 use std::{alloc::Layout, cell::RefCell, collections::HashMap};
 
-#[repr(C)]
-pub struct CPointer(pub *const u8, pub usize);
-
 thread_local! {
     /// Map of pointer to the length of its content on the heap
     static GLOBAL_STORE: RefCell<HashMap<*const u8, usize>> = RefCell::new(HashMap::new());


### PR DESCRIPTION
Part 1 of a bigger fixup of the host-call signature normalization

