### PR TITLE
Make `#[public]` ffi functions private and unsafe

### DIFF
--- a/x/programs/rust/sdk_macros/Cargo.toml
+++ b/x/programs/rust/sdk_macros/Cargo.toml
@@ -12,5 +12,6 @@ quote = "1.0.33"
 syn = { version = "2.0.37", features = ["full", "extra-traits"] }
 
 [dev-dependencies]
+borsh = "1.5.0"
 trybuild = "1.0.89"
 wasmlanche-sdk = { path = "../wasmlanche-sdk" }

--- a/x/programs/rust/sdk_macros/tests/ui/user-defined-context-type.rs
+++ b/x/programs/rust/sdk_macros/tests/ui/user-defined-context-type.rs
@@ -1,5 +1,7 @@
+use borsh::BorshDeserialize;
 use sdk_macros::public;
 
+#[derive(BorshDeserialize)]
 struct Context;
 
 #[public]

--- a/x/programs/rust/sdk_macros/tests/ui/user-defined-context-type.stderr
+++ b/x/programs/rust/sdk_macros/tests/ui/user-defined-context-type.stderr
@@ -1,25 +1,28 @@
 error[E0308]: mismatched types
+ --> tests/ui/user-defined-context-type.rs:7:1
+  |
+7 | #[public]
+  | ^^^^^^^^^
+  | |
+  | expected `wasmlanche_sdk::Context`, found `Context`
+  | arguments to this function are incorrect
+  |
+  = note: `Context` and `wasmlanche_sdk::Context` have similar names, but are actually distinct types
+note: `Context` is defined in the current crate
  --> tests/ui/user-defined-context-type.rs:5:1
   |
-5 | #[public]
-  | ^^^^^^^^^ expected `Context`, found `wasmlanche_sdk::Context`
-6 | pub fn test(_: Context) {}
-  |        ---- arguments to this function are incorrect
-  |
-  = note: `wasmlanche_sdk::Context` and `Context` have similar names, but are actually distinct types
+5 | struct Context;
+  | ^^^^^^^^^^^^^^
 note: `wasmlanche_sdk::Context` is defined in crate `wasmlanche_sdk`
  --> $WORKSPACE/x/programs/rust/wasmlanche-sdk/src/lib.rs
   |
   | pub struct Context {
   | ^^^^^^^^^^^^^^^^^^
-note: `Context` is defined in the current crate
- --> tests/ui/user-defined-context-type.rs:3:1
-  |
-3 | struct Context;
-  | ^^^^^^^^^^^^^^
 note: function defined here
- --> tests/ui/user-defined-context-type.rs:6:8
+ --> tests/ui/user-defined-context-type.rs:8:8
   |
-6 | pub fn test(_: Context) {}
-  |        ^^^^ ----------
+7 | #[public]
+  | ---------
+8 | pub fn test(_: Context) {}
+  |        ^^^^
   = note: this error originates in the attribute macro `public` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
Make it harder to call the `extern` functions written by the `#[public]` macro