### PR TITLE
A bunch of fixes to the macro

### DIFF
--- a/x/programs/rust/sdk-macros/tests/ui/ignore-second-param.rs
+++ b/x/programs/rust/sdk-macros/tests/ui/ignore-second-param.rs
@@ -1,8 +1,0 @@
-use sdk_macros::public;
-#[allow(unused_imports)]
-use wasmlanche_sdk::Context;
-
-#[public]
-pub fn test(_: Context, _: u32) {}
-
-fn main() {}

--- a/x/programs/rust/sdk-macros/tests/ui/ignore-second-param.stderr
+++ b/x/programs/rust/sdk-macros/tests/ui/ignore-second-param.stderr
@@ -1,5 +1,0 @@
-error: Functions with the `#[public]` attribute can only ignore the first parameter.
- --> tests/ui/ignore-second-param.rs:6:25
-  |
-6 | pub fn test(_: Context, _: u32) {}
-  |                         ^

--- a/x/programs/rust/sdk-macros/tests/ui/wild.rs
+++ b/x/programs/rust/sdk-macros/tests/ui/wild.rs
@@ -1,8 +1,0 @@
-use sdk_macros::public;
-
-struct Context;
-
-#[public]
-pub fn test(_: Context, _: usize) {}
-
-fn main() {}

--- a/x/programs/rust/sdk-macros/tests/ui/wild.stderr
+++ b/x/programs/rust/sdk-macros/tests/ui/wild.stderr
@@ -1,5 +1,0 @@
-error: Functions with the `#[public]` attribute can only ignore the first parameter.
- --> tests/ui/wild.rs:6:25
-  |
-6 | pub fn test(_: Context, _: usize) {}
-  |                         ^

--- a/x/programs/rust/wasmlanche-sdk/tests/public_function.rs
+++ b/x/programs/rust/wasmlanche-sdk/tests/public_function.rs
@@ -1,3 +1,4 @@
+use borsh::BorshSerialize;
 use std::{
     path::{Path, PathBuf},
     process::Command,
@@ -47,17 +48,20 @@ fn public_functions() {
     let mut test_crate = TestCrate::new(wasm_path);
 
     let context_ptr = test_crate.write_context();
-    assert!(test_crate.always_true(context_ptr));
+    let args_ptr = test_crate.write_args([0u8; 0]);
+    assert!(test_crate.always_true((context_ptr, args_ptr)));
 
     let context_ptr = test_crate.write_context();
-    let combined_binary_digits = test_crate.combine_last_bit_of_each_id_byte(context_ptr);
+    let args_ptr = test_crate.write_args([0u8; 0]);
+    let combined_binary_digits =
+        test_crate.combine_last_bit_of_each_id_byte((context_ptr, args_ptr));
     assert_eq!(combined_binary_digits, u32::MAX);
 }
 
 type AllocParam = i32;
 type AllocReturn = u32;
 type AllocFn = TypedFunc<AllocParam, AllocReturn>;
-type UserDefinedFnParam = u32;
+type UserDefinedFnParam = (u32, u32);
 type UserDefinedFnReturn = ();
 type UserDefinedFn = TypedFunc<UserDefinedFnParam, UserDefinedFnReturn>;
 type StoreData = Option<Vec<u8>>;
@@ -130,6 +134,11 @@ impl TestCrate {
         self.allocate(serialized_context)
     }
 
+    fn write_args(&mut self, args: impl BorshSerialize) -> AllocReturn {
+        let args = borsh::to_vec(&args).expect("failed to serialize args");
+        self.allocate(args)
+    }
+
     fn allocate(&mut self, data: Vec<u8>) -> AllocReturn {
         let offset = self
             .allocate_func
@@ -147,9 +156,9 @@ impl TestCrate {
         offset
     }
 
-    fn always_true(&mut self, ptr: UserDefinedFnParam) -> bool {
+    fn always_true(&mut self, param: UserDefinedFnParam) -> bool {
         self.always_true_func
-            .call(&mut self.store, ptr)
+            .call(&mut self.store, param)
             .expect("failed to call `always_true` function");
         let result = self
             .store
@@ -160,9 +169,9 @@ impl TestCrate {
         borsh::from_slice(&result).expect("failed to deserialize result")
     }
 
-    fn combine_last_bit_of_each_id_byte(&mut self, ptr: UserDefinedFnParam) -> u32 {
+    fn combine_last_bit_of_each_id_byte(&mut self, param: UserDefinedFnParam) -> u32 {
         self.combine_last_bit_of_each_id_byte_func
-            .call(&mut self.store, ptr)
+            .call(&mut self.store, param)
             .expect("failed to call `combine_last_bit_of_each_id_byte` function");
         let result = self
             .store


### PR DESCRIPTION
Enables the usage of null-pointer as a bit of a hack to generically handle no-arg (aside from context) functions. Will work on removing this by serializing args and context into a single struct once this work in merged in main.

