### PR TITLE
[x/programs] program recursion test

### DIFF
--- a/x/programs/cmd/simulator/cmd/config.go
+++ b/x/programs/cmd/simulator/cmd/config.go
@@ -164,7 +164,10 @@ func validateAssertion(bytes []byte, require *Require) (bool, error) {
 	}
 
 	actual := int64(0)
-	borsh.Deserialize(&actual, bytes)
+	err := borsh.Deserialize(&actual, bytes)
+	if err != nil {
+		return false, err
+	}
 	assertion := require.Result
 	// convert the assertion value(string) to uint64
 	value, err := strconv.ParseInt(assertion.Value, 10, 64)

--- a/x/programs/rust/wasmlanche-sdk/Cargo.toml
+++ b/x/programs/rust/wasmlanche-sdk/Cargo.toml
@@ -19,3 +19,4 @@ build = ["serde_json"]
 
 [dev-dependencies]
 wasmtime = "14"
+simulator = { path = "../../cmd/simulator" }

--- a/x/programs/rust/wasmlanche-sdk/src/params.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/params.rs
@@ -5,7 +5,7 @@ use std::ops::Deref;
 #[macro_export]
 macro_rules! params {
     ($first:expr $(,$rest:expr)* $(,)*) => {
-        std::iter::once($crate::params::serialize_param($first))
+        core::iter::once($crate::params::serialize_param($first))
             $(
                 .chain(Some($crate::params::serialize_param($rest)))
             )*
@@ -17,6 +17,7 @@ macro_rules! params {
 pub struct Param(Vec<u8>);
 
 /// A collection of [borsh] serialized parameters.
+#[derive(Default)]
 pub struct Params(Vec<u8>);
 
 impl Deref for Params {

--- a/x/programs/rust/wasmlanche-sdk/tests/public_function.rs
+++ b/x/programs/rust/wasmlanche-sdk/tests/public_function.rs
@@ -68,6 +68,7 @@ struct TestCrate {
     allocate_func: AllocFn,
     always_true_func: UserDefinedFn,
     combine_last_bit_of_each_id_byte_func: UserDefinedFn,
+    recursive: UserDefinedFn,
 }
 
 impl TestCrate {
@@ -109,6 +110,9 @@ impl TestCrate {
         let combine_last_bit_of_each_id_byte_func = instance
             .get_typed_func(&mut store, "combine_last_bit_of_each_id_byte_guest")
             .expect("combine_last_bit_of_each_id_byte should be a function");
+        let recursive = instance
+            .get_typed_func(&mut store, "recursive_guest")
+            .expect("recursive should be a function");
 
         Self {
             store,
@@ -116,6 +120,7 @@ impl TestCrate {
             allocate_func,
             always_true_func,
             combine_last_bit_of_each_id_byte_func,
+            recursive,
         }
     }
 
@@ -170,5 +175,11 @@ impl TestCrate {
             .take()
             .expect("combine_last_bit_of_each_id_byte should always return something");
         borsh::from_slice(&result).expect("failed to deserialize result")
+    }
+
+    fn recursive(&mut self, ptr: UserDefinedFnParam) {
+        self.recursive
+            .call(&mut self.store, ptr)
+            .expect("failed to call `recursive` function");
     }
 }

--- a/x/programs/rust/wasmlanche-sdk/tests/recursive.rs
+++ b/x/programs/rust/wasmlanche-sdk/tests/recursive.rs
@@ -1,0 +1,81 @@
+use simulator::{Endpoint, Key, Plan, Step};
+use std::{path::PathBuf, process::Command};
+
+const WASM_TARGET: &str = "wasm32-unknown-unknown";
+const TEST_PKG: &str = "test-crate";
+const PROFILE: &str = "release"; // "dev";
+
+#[test]
+fn recursive() {
+    let wasm_path = {
+        let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+        let manifest_dir = std::path::Path::new(&manifest_dir);
+        let test_crate_dir = manifest_dir.join("tests").join(TEST_PKG);
+        let target_dir = std::env::var("CARGO_TARGET_DIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| manifest_dir.join("target"));
+
+        let status = Command::new("cargo")
+            .arg("build")
+            .arg("--package")
+            .arg(TEST_PKG)
+            .arg("--target")
+            .arg(WASM_TARGET)
+            .arg("--profile")
+            .arg(PROFILE)
+            .arg("--target-dir")
+            .arg(&target_dir)
+            .current_dir(&test_crate_dir)
+            .status()
+            .expect("cargo build failed");
+
+        if !status.success() {
+            panic!("cargo build failed");
+        }
+
+        let profile_location: &str = match PROFILE {
+            "dev" => "debug",
+            "release" => "release",
+            _ => panic!("unrecognized profile {}", PROFILE),
+        };
+
+        target_dir
+            .join(WASM_TARGET)
+            .join(profile_location)
+            .join(TEST_PKG.replace('-', "_"))
+            .with_extension("wasm")
+    };
+
+    let simulator = simulator::Client::new();
+
+    let owner_key = String::from("owner");
+    let alice_key = Key::Ed25519(String::from("alice"));
+
+    let mut plan = Plan::new(owner_key.clone());
+
+    plan.add_step(Step::create_key(Key::Ed25519(owner_key)));
+    plan.add_step(Step::create_key(alice_key));
+
+    let program_id = plan.add_step(Step::create_program(wasm_path.to_str().unwrap().to_owned()));
+    let max_units = 10000000;
+
+    plan.add_step(Step {
+        endpoint: Endpoint::Execute,
+        method: "recursive".into(),
+        max_units,
+        params: vec![program_id.into(), max_units.into()],
+        require: None,
+    });
+
+    // run plan
+    let plan_responses = simulator.run_plan(plan).unwrap();
+
+    assert!(
+        plan_responses.iter().all(|resp| resp.error.is_none()),
+        "error: {:?}",
+        plan_responses
+            .iter()
+            .filter_map(|resp| resp.error.as_ref())
+            .next()
+    );
+}

--- a/x/programs/rust/wasmlanche-sdk/tests/test-crate/src/lib.rs
+++ b/x/programs/rust/wasmlanche-sdk/tests/test-crate/src/lib.rs
@@ -1,6 +1,4 @@
-#![no_std]
-
-use wasmlanche_sdk::{public, Context};
+use wasmlanche_sdk::{params, public, Context};
 
 #[public]
 pub fn always_true(_: Context) -> bool {
@@ -15,4 +13,17 @@ pub fn combine_last_bit_of_each_id_byte(context: Context) -> u32 {
         .iter()
         .map(|byte| *byte as u32)
         .fold(0, |acc, byte| (acc << 1) + (byte & 1))
+}
+
+// TODO move me to the actual test
+#[public]
+pub fn recursive(Context { program }: Context, units_left: i64) -> bool {
+    let units = 100000;
+    program
+        .call_function(
+            "recursive",
+            &params!(&(units_left - units)).unwrap(),
+            units_left - units,
+        )
+        .is_ok_and(|res| res)
 }


### PR DESCRIPTION
By curiosity, I wanted to write a recursion test just to make sure that unwinding works as expected and that the execution will run out of units.
This is still a WIP because although this property is verified, there is no way to assert that an execution failed. Additionally, there is an error log message from the simulator saying that the execution ran out of units which is annoying to have on the terminal.
I think that it is blocked by https://github.com/ava-labs/hypersdk/issues/865, https://github.com/ava-labs/hypersdk/issues/595, and the fact that the logging is printed on stderr because of the communication pattern.

Closes https://github.com/ava-labs/hypersdk/issues/899

edit: there is also this deserialization error which was not caught. I'm wondering if we could tune the static analysis to detect those blunders.