### PR TITLE
Use workspace dependencies instead of path

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,5 +19,9 @@ panic = 'abort'
 strip = true
 
 [workspace.dependencies]
+sdk-macros = { path = "x/programs/rust/sdk-macros" }
+simulator = { path = "x/programs/cmd/simulator" }
+wasmlanche-sdk = { path = "x/programs/rust/wasmlanche-sdk" }
+
 borsh = { version = "1.5.0", features = ["derive"] }
 thiserror = "1.0.60"

--- a/x/programs/rust/examples/counter/Cargo.toml
+++ b/x/programs/rust/examples/counter/Cargo.toml
@@ -7,14 +7,14 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-wasmlanche-sdk = { path = "../../wasmlanche-sdk" }
+wasmlanche-sdk = { workspace = true }
 borsh = { workspace = true }
 
 [dev-dependencies]
-simulator = { path = "../../../cmd/simulator/" }
+simulator = { workspace = true }
 
 [build-dependencies]
-wasmlanche-sdk = { path = "../../wasmlanche-sdk", features = ["build"] }
+wasmlanche-sdk = { workspace = true, features = ["build"] }
 
 # when creating a new project, you can uncomment the following lines to enable optimizations
 # [profile.release]

--- a/x/programs/rust/examples/token/Cargo.toml
+++ b/x/programs/rust/examples/token/Cargo.toml
@@ -7,14 +7,14 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-wasmlanche-sdk = { path = "../../wasmlanche-sdk" }
+wasmlanche-sdk = { workspace = true }
 borsh = { workspace = true }
 
 [dev-dependencies]
-simulator = { path = "../../../cmd/simulator" }
+simulator = { workspace = true }
 
 [build-dependencies]
-wasmlanche-sdk = { path = "../../wasmlanche-sdk", features = ["build"] }
+wasmlanche-sdk = { workspace = true, features = ["build"] }
 
 # when creating a new project, you can uncomment the following lines to enable optimizations
 # [profile.release]

--- a/x/programs/rust/sdk-macros/Cargo.toml
+++ b/x/programs/rust/sdk-macros/Cargo.toml
@@ -14,4 +14,4 @@ syn = { version = "2.0.63", features = ["full", "extra-traits"] }
 [dev-dependencies]
 borsh = { workpsace = true }
 trybuild = "1.0.96"
-wasmlanche-sdk = { path = "../wasmlanche-sdk" }
+wasmlanche-sdk = { workspace = true }

--- a/x/programs/rust/wasmlanche-sdk/Cargo.toml
+++ b/x/programs/rust/wasmlanche-sdk/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 borsh = { workspace = true }
-sdk-macros = { path = "../sdk-macros" }
+sdk-macros = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/x/programs/rust/wasmlanche-sdk/tests/test-crate/Cargo.toml
+++ b/x/programs/rust/wasmlanche-sdk/tests/test-crate/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-wasmlanche-sdk = { path = "../../" }
+wasmlanche-sdk = { workspace = true }
 borsh = { workspace = true }

--- a/x/programs/v2/test/programs/call_program/Cargo.toml
+++ b/x/programs/v2/test/programs/call_program/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-wasmlanche-sdk = { path = "../../../../rust/wasmlanche-sdk" }
+wasmlanche-sdk = { workspace = true }
 borsh = { workspace = true }
 
 [build-dependencies]
-wasmlanche-sdk = { path = "../../../../rust/wasmlanche-sdk", features = ["build"] }
+wasmlanche-sdk = { workspace = true, features = ["build"] }

--- a/x/programs/v2/test/programs/return_complex_type/Cargo.toml
+++ b/x/programs/v2/test/programs/return_complex_type/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-wasmlanche-sdk = { path = "../../../../rust/wasmlanche-sdk" }
+wasmlanche-sdk = { workspace = true }
 borsh = { workspace = true }
 
 [build-dependencies]
-wasmlanche-sdk = { path = "../../../../rust/wasmlanche-sdk", features = ["build"] }
+wasmlanche-sdk = { workspace = true, features = ["build"] }

--- a/x/programs/v2/test/programs/simple/Cargo.toml
+++ b/x/programs/v2/test/programs/simple/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-wasmlanche-sdk = { path = "../../../../rust/wasmlanche-sdk" }
+wasmlanche-sdk = { workspace = true }
 borsh = { workspace = true }
 
 [build-dependencies]
-wasmlanche-sdk = { path = "../../../../rust/wasmlanche-sdk", features = ["build"] }
+wasmlanche-sdk = { workspace = true, features = ["build"] }


### PR DESCRIPTION
Makes it easier to move things around

