### PR TITLE
Fix typo in sdk-macros dependency definition

### DIFF
--- a/x/programs/rust/sdk-macros/Cargo.toml
+++ b/x/programs/rust/sdk-macros/Cargo.toml
@@ -12,6 +12,6 @@ quote = "1.0.36"
 syn = { version = "2.0.63", features = ["full", "extra-traits"] }
 
 [dev-dependencies]
-borsh = { workpsace = true }
+borsh = { workspace = true }
 trybuild = "1.0.96"
 wasmlanche-sdk = { workspace = true }


### PR DESCRIPTION
I still don't understand how this was working before my change. It somehow was falling back to the workspace, I guess?

