### PR TITLE
State::get should return an option

### DIFF
--- a/x/programs/cmd/simulator/src/lib.rs
+++ b/x/programs/cmd/simulator/src/lib.rs
@@ -378,7 +378,7 @@ mod tests {
 
         assert_eq!(output_json, expected_json);
 
-        let output_param: Param = serde_json::from_value(dbg!(expected_json)).unwrap();
+        let output_param: Param = serde_json::from_value(expected_json).unwrap();
 
         assert_eq!(output_param, expected_param);
     }

--- a/x/programs/runtime/import_state.go
+++ b/x/programs/runtime/import_state.go
@@ -57,14 +57,14 @@ func NewStateAccessModule() *ImportModule {
 				}
 				return val, nil
 			})},
-			"put": {FuelCost: writeCost, Function: FunctionWithOutput(func(callInfo *CallInfo, input []byte) ([]byte, error) {
+			"put": {FuelCost: writeCost, Function: FunctionNoOutput(func(callInfo *CallInfo, input []byte) error {
 				parsedInput := &keyValueInput{}
 				if err := borsh.Deserialize(parsedInput, input); err != nil {
-					return nil, err
+					return err
 				}
 				ctx, cancel := context.WithCancel(context.Background())
 				defer cancel()
-				return nil, callInfo.State.Insert(ctx, prependAccountToKey(callInfo.Account, parsedInput.Key), parsedInput.Value)
+				return callInfo.State.Insert(ctx, prependAccountToKey(callInfo.Account, parsedInput.Key), parsedInput.Value)
 			})},
 			"delete": {FuelCost: deleteCost, Function: FunctionWithOutput(func(callInfo *CallInfo, input []byte) ([]byte, error) {
 				parsedInput := &keyInput{}

--- a/x/programs/rust/examples/counter/src/lib.rs
+++ b/x/programs/rust/examples/counter/src/lib.rs
@@ -6,9 +6,11 @@ pub enum StateKeys {
     Counter(Address),
 }
 
+type Count = u64;
+
 /// Increments the count at the address by the amount.
 #[public]
-pub fn inc(context: Context<StateKeys>, to: Address, amount: i64) -> bool {
+pub fn inc(context: Context<StateKeys>, to: Address, amount: Count) -> bool {
     let counter = amount + get_value_internal(&context, to);
     let Context { program, .. } = context;
 
@@ -22,7 +24,13 @@ pub fn inc(context: Context<StateKeys>, to: Address, amount: i64) -> bool {
 
 /// Increments the count at the address by the amount for an external program.
 #[public]
-pub fn inc_external(_: Context, target: Program, max_units: i64, of: Address, amount: i64) -> bool {
+pub fn inc_external(
+    _: Context,
+    target: Program,
+    max_units: i64,
+    of: Address,
+    amount: Count,
+) -> bool {
     target
         .call_function("inc", (of, amount), max_units)
         .unwrap()
@@ -30,11 +38,11 @@ pub fn inc_external(_: Context, target: Program, max_units: i64, of: Address, am
 
 /// Gets the count at the address.
 #[public]
-pub fn get_value(context: Context<StateKeys>, of: Address) -> i64 {
+pub fn get_value(context: Context<StateKeys>, of: Address) -> Count {
     get_value_internal(&context, of)
 }
 
-fn get_value_internal(context: &Context<StateKeys>, of: Address) -> i64 {
+fn get_value_internal(context: &Context<StateKeys>, of: Address) -> Count {
     context
         .program
         .state()
@@ -45,7 +53,7 @@ fn get_value_internal(context: &Context<StateKeys>, of: Address) -> i64 {
 
 /// Gets the count at the address for an external program.
 #[public]
-pub fn get_value_external(_: Context, target: Program, max_units: i64, of: Address) -> i64 {
+pub fn get_value_external(_: Context, target: Program, max_units: i64, of: Address) -> Count {
     target.call_function("get_value", of, max_units).unwrap()
 }
 

--- a/x/programs/rust/examples/token/src/lib.rs
+++ b/x/programs/rust/examples/token/src/lib.rs
@@ -45,10 +45,12 @@ pub fn init(context: Context<StateKeys>) {
 #[public]
 pub fn get_total_supply(context: Context<StateKeys>) -> i64 {
     let Context { program, .. } = context;
+
     program
         .state()
         .get(StateKeys::TotalSupply)
         .expect("failed to get total supply")
+        .unwrap_or_default()
 }
 
 /// Transfers balance from the token owner to the recipient.
@@ -68,6 +70,7 @@ fn mint_to_internal(
     let balance = program
         .state()
         .get::<i64>(StateKeys::Balance(recipient))
+        .expect("balance should deserialize")
         .unwrap_or_default();
 
     program
@@ -104,13 +107,15 @@ pub fn transfer(
     let sender_balance = program
         .state()
         .get::<i64>(StateKeys::Balance(sender))
-        .expect("failed to update balance");
+        .expect("failed to deserialize balance")
+        .unwrap_or_default();
 
     assert!(amount >= 0 && sender_balance >= amount, "invalid input");
 
     let recipient_balance = program
         .state()
         .get::<i64>(StateKeys::Balance(recipient))
+        .expect("failed to deserialize balance")
         .unwrap_or_default();
 
     // update balances
@@ -149,6 +154,7 @@ pub fn get_balance(context: Context<StateKeys>, recipient: Address) -> i64 {
     program
         .state()
         .get(StateKeys::Balance(recipient))
+        .expect("state corrupt")
         .unwrap_or_default()
 }
 

--- a/x/programs/rust/examples/token/src/lib.rs
+++ b/x/programs/rust/examples/token/src/lib.rs
@@ -2,7 +2,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use wasmlanche_sdk::Context;
 use wasmlanche_sdk::{public, state_keys, types::Address};
 
-const INITIAL_SUPPLY: i64 = 123456789;
+const INITIAL_SUPPLY: u64 = 123456789;
 
 /// The program state keys.
 #[state_keys]
@@ -43,7 +43,7 @@ pub fn init(context: Context<StateKeys>) {
 
 /// Returns the total supply of the token.
 #[public]
-pub fn get_total_supply(context: Context<StateKeys>) -> i64 {
+pub fn get_total_supply(context: Context<StateKeys>) -> u64 {
     let Context { program, .. } = context;
 
     program
@@ -55,7 +55,7 @@ pub fn get_total_supply(context: Context<StateKeys>) -> i64 {
 
 /// Transfers balance from the token owner to the recipient.
 #[public]
-pub fn mint_to(context: Context<StateKeys>, recipient: Address, amount: i64) -> bool {
+pub fn mint_to(context: Context<StateKeys>, recipient: Address, amount: u64) -> bool {
     mint_to_internal(context, recipient, amount);
     true
 }
@@ -63,14 +63,14 @@ pub fn mint_to(context: Context<StateKeys>, recipient: Address, amount: i64) -> 
 fn mint_to_internal(
     context: Context<StateKeys>,
     recipient: Address,
-    amount: i64,
+    amount: u64,
 ) -> Context<StateKeys> {
     let program = &context.program;
 
     let balance = program
         .state()
-        .get::<i64>(StateKeys::Balance(recipient))
-        .expect("balance should deserialize")
+        .get::<u64>(StateKeys::Balance(recipient))
+        .expect("state corrupt")
         .unwrap_or_default();
 
     program
@@ -83,11 +83,11 @@ fn mint_to_internal(
 
 /// Burn the token from the recipient.
 #[public]
-pub fn burn_from(context: Context<StateKeys>, recipient: Address) -> i64 {
+pub fn burn_from(context: Context<StateKeys>, recipient: Address) -> u64 {
     let Context { program, .. } = context;
     program
         .state()
-        .delete::<i64>(StateKeys::Balance(recipient))
+        .delete::<u64>(StateKeys::Balance(recipient))
         .expect("failed to burn recipient tokens")
         .expect("recipient balance not found")
 }
@@ -98,7 +98,7 @@ pub fn transfer(
     context: Context<StateKeys>,
     sender: Address,
     recipient: Address,
-    amount: i64,
+    amount: u64,
 ) -> bool {
     let Context { program, .. } = context;
     assert_ne!(sender, recipient, "sender and recipient must be different");
@@ -106,16 +106,16 @@ pub fn transfer(
     // ensure the sender has adequate balance
     let sender_balance = program
         .state()
-        .get::<i64>(StateKeys::Balance(sender))
-        .expect("failed to deserialize balance")
+        .get::<u64>(StateKeys::Balance(sender))
+        .expect("state corrupt")
         .unwrap_or_default();
 
-    assert!(amount >= 0 && sender_balance >= amount, "invalid input");
+    assert!(sender_balance >= amount, "invalid input");
 
     let recipient_balance = program
         .state()
-        .get::<i64>(StateKeys::Balance(recipient))
-        .expect("failed to deserialize balance")
+        .get::<u64>(StateKeys::Balance(recipient))
+        .expect("state corrupt")
         .unwrap_or_default();
 
     // update balances
@@ -135,14 +135,14 @@ pub fn transfer(
 #[derive(BorshDeserialize, BorshSerialize)]
 pub struct Minter {
     to: Address,
-    amount: i32,
+    amount: u64,
 }
 
 /// Mints tokens to multiple recipients.
 #[public]
 pub fn mint_to_many(context: Context<StateKeys>, minters: Vec<Minter>) -> bool {
     minters.into_iter().fold(context, |context, minter| {
-        mint_to_internal(context, minter.to, minter.amount as i64)
+        mint_to_internal(context, minter.to, minter.amount)
     });
     true
 }
@@ -223,7 +223,7 @@ mod tests {
             max_units: 0,
             params: vec![program_id.into()],
             require: Some(Require {
-                result: ResultAssertion::NumericEq(INITIAL_SUPPLY as u64),
+                result: ResultAssertion::NumericEq(INITIAL_SUPPLY),
             }),
         });
 
@@ -392,7 +392,7 @@ mod tests {
             max_units: 0,
             params: vec![program_id.into()],
             require: Some(Require {
-                result: ResultAssertion::NumericEq(INITIAL_SUPPLY as u64),
+                result: ResultAssertion::NumericEq(INITIAL_SUPPLY),
             }),
         });
 

--- a/x/programs/rust/sdk-macros/src/lib.rs
+++ b/x/programs/rust/sdk-macros/src/lib.rs
@@ -158,7 +158,8 @@ pub fn public(_: TokenStream, item: TokenStream) -> TokenStream {
             #[no_mangle]
             unsafe extern "C" fn #name(args: *const u8) {
                 let args: Args = unsafe {
-                    wasmlanche_sdk::from_host_ptr(args).expect("error fetching serialized args")
+                    let args_bytes = wasmlanche_sdk::deref_bytes(args);
+                    borsh::from_slice(&args_bytes).expect("error fetching serialized args")
                 };
 
                 let result = super::#name(#(#converted_params),*);

--- a/x/programs/rust/wasmlanche-sdk/src/lib.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/lib.rs
@@ -9,7 +9,7 @@ mod program;
 
 pub use self::{
     logging::log,
-    memory::from_host_ptr,
+    memory::deref_bytes,
     program::{Program, PROGRAM_ID_LEN},
 };
 

--- a/x/programs/rust/wasmlanche-sdk/src/memory.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/memory.rs
@@ -11,10 +11,10 @@ thread_local! {
     static GLOBAL_STORE: RefCell<HashMap<*const u8, usize>> = RefCell::new(HashMap::new());
 }
 
-/// Reconstructs the vec that was created using the [alloc] function.
+/// Reconstructs the vec that was created using the module's `alloc` function.
 /// # Panics
 /// If you are trying to dereference data that has already been dereferenced
-/// or the pointer is invalid (wasn't created with [alloc])
+/// or the pointer is invalid (wasn't created with the module's `alloc` function).
 #[must_use]
 pub fn deref_bytes(ptr: *const u8) -> Vec<u8> {
     GLOBAL_STORE

--- a/x/programs/rust/wasmlanche-sdk/src/memory.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/memory.rs
@@ -4,8 +4,6 @@
 //! the program. These methods are unsafe as should be used
 //! with caution.
 
-use crate::state::Error as StateError;
-use borsh::{from_slice, BorshDeserialize};
 use std::{alloc::Layout, cell::RefCell, collections::HashMap};
 
 thread_local! {
@@ -13,32 +11,19 @@ thread_local! {
     static GLOBAL_STORE: RefCell<HashMap<*const u8, usize>> = RefCell::new(HashMap::new());
 }
 
-/// Converts a raw pointer to a deserialized value.
-/// Expects the first 4 bytes of the pointer to represent the `length` of the serialized value,
-/// with the subsequent `length` bytes comprising the serialized data.
-/// # Panics
-/// Panics if the bytes cannot be deserialized.
-/// # Safety
-/// This function is unsafe because it dereferences raw pointers.
-/// # Errors
-/// Returns an [`StateError`] if the bytes cannot be deserialized.
-pub fn from_host_ptr<V>(ptr: *const u8) -> Result<V, StateError>
-where
-    V: BorshDeserialize,
-{
-    match into_bytes(ptr) {
-        Some(bytes) => from_slice::<V>(&bytes).map_err(|_| StateError::Deserialization),
-        None => Err(StateError::InvalidPointer),
-    }
-}
-
 /// Reconstructs the vec from the pointer with the length given by the store
 /// `host_ptr` is encoded using Big Endian as an i64.
+/// # Panics
+/// If you are trying to dereference data that has already been dereferenced
+/// or the pointer is invalid
 #[must_use]
-pub fn into_bytes(ptr: *const u8) -> Option<Vec<u8>> {
+pub fn deref_bytes(ptr: *const u8) -> Vec<u8> {
     GLOBAL_STORE
         .with_borrow_mut(|s| s.remove(&ptr))
+        // SAFETY:
+        // the space is reserved by the `alloc` function
         .map(|len| unsafe { std::vec::Vec::from_raw_parts(ptr.cast_mut(), len, len) })
+        .expect("value missing or taken")
 }
 
 /* memory functions ------------------------------------------- */
@@ -51,32 +36,32 @@ pub extern "C" fn alloc(len: usize) -> *mut u8 {
     assert!(len > 0, "cannot allocate 0 sized data");
     // can only fail if `len > isize::MAX` for u8
     let layout = Layout::array::<u8>(len).expect("capacity overflow");
-    // take a mutable pointer to the layout
+
     let ptr = unsafe { std::alloc::alloc(layout) };
+
     if ptr.is_null() {
         std::alloc::handle_alloc_error(layout);
     }
-    // keep track of the pointer and the length of the allocated data
+
     GLOBAL_STORE.with_borrow_mut(|s| s.insert(ptr, len));
-    // return the pointer so the runtime
-    // can write data at this offset
+
     ptr
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{alloc, into_bytes};
-    use crate::memory::GLOBAL_STORE;
+    use super::*;
 
     #[test]
     fn data_allocation() {
         let len = 1024;
         let ptr = alloc(len);
-        let vec = vec![1; len];
+        let vec: Vec<_> = (u8::MIN..=u8::MAX).cycle().take(len).collect();
         unsafe { std::ptr::copy(vec.as_ptr(), ptr, vec.len()) }
-        let val = into_bytes(ptr).unwrap();
+        let val = deref_bytes(ptr);
         assert_eq!(val, vec);
-        assert!(GLOBAL_STORE.with_borrow(|s| s.get(&(ptr.cast_const())).is_none()));
+
+        GLOBAL_STORE.with_borrow(|map| assert!(!map.contains_key(&ptr.cast_const())));
     }
 
     #[test]

--- a/x/programs/rust/wasmlanche-sdk/src/memory.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/memory.rs
@@ -11,11 +11,10 @@ thread_local! {
     static GLOBAL_STORE: RefCell<HashMap<*const u8, usize>> = RefCell::new(HashMap::new());
 }
 
-/// Reconstructs the vec from the pointer with the length given by the store
-/// `host_ptr` is encoded using Big Endian as an i64.
+/// Reconstructs the vec that was created using the [alloc] function.
 /// # Panics
 /// If you are trying to dereference data that has already been dereferenced
-/// or the pointer is invalid
+/// or the pointer is invalid (wasn't created with [alloc])
 #[must_use]
 pub fn deref_bytes(ptr: *const u8) -> Vec<u8> {
     GLOBAL_STORE

--- a/x/programs/rust/wasmlanche-sdk/src/program.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/program.rs
@@ -1,5 +1,5 @@
 use crate::{
-    memory::into_bytes,
+    memory::deref_bytes,
     state::{Error as StateError, Key, State},
 };
 use borsh::{BorshDeserialize, BorshSerialize};
@@ -70,7 +70,7 @@ impl<K> Program<K> {
 
         let ptr = unsafe { ffi(args_bytes.as_ptr(), args_bytes.len()) };
 
-        let bytes = into_bytes(ptr).unwrap_or_default();
+        let bytes = deref_bytes(ptr);
 
         borsh::from_slice(&bytes).map_err(|_| StateError::Deserialization)
     }


### PR DESCRIPTION
It should always be valid to check to see if anything has been stored at a specific key without erroring.

Scope increased, I cleaned up the whole of state accesses and inlined a bunch of code to simplify things. 

