### PR TITLE
Fix Double Wrapped Wasmtime Traps

### DIFF
--- a/x/programs/runtime/errors.go
+++ b/x/programs/runtime/errors.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package runtime
 
 import (

--- a/x/programs/runtime/errors.go
+++ b/x/programs/runtime/errors.go
@@ -1,0 +1,16 @@
+package runtime
+
+import (
+	"errors"
+	"github.com/bytecodealliance/wasmtime-go/v14"
+)
+
+func convertToTrap(err error) *wasmtime.Trap {
+	var t *wasmtime.Trap
+	switch {
+	case errors.As(err, &t):
+		return t
+	default:
+		return wasmtime.NewTrap(err.Error())
+	}
+}

--- a/x/programs/runtime/errors.go
+++ b/x/programs/runtime/errors.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"errors"
+
 	"github.com/bytecodealliance/wasmtime-go/v14"
 )
 

--- a/x/programs/runtime/imports.go
+++ b/x/programs/runtime/imports.go
@@ -102,13 +102,13 @@ func convertFunction(callInfo *CallInfo, hf HostFunction) func(*wasmtime.Caller,
 		inputBytes := memExport.Memory().UnsafeData(caller)[vals[0].I32() : vals[0].I32()+vals[1].I32()]
 
 		if err := callInfo.ConsumeFuel(hf.FuelCost); err != nil {
-			return nil, wasmtime.NewTrap(err.Error())
+			return nil, convertToTrap(err)
 		}
 		switch f := hf.Function.(type) {
 		case FunctionWithOutput:
 			results, err := f(callInfo, inputBytes)
 			if err != nil {
-				return nilResult, wasmtime.NewTrap(err.Error())
+				return nilResult, convertToTrap(err)
 			}
 			if results == nil {
 				return nilResult, nil
@@ -117,7 +117,7 @@ func convertFunction(callInfo *CallInfo, hf HostFunction) func(*wasmtime.Caller,
 			allocExport := caller.GetExport(AllocName)
 			offsetIntf, err := allocExport.Func().Call(caller, resultLength)
 			if err != nil {
-				return nilResult, wasmtime.NewTrap(err.Error())
+				return nilResult, convertToTrap(err)
 			}
 			offset := offsetIntf.(int32)
 			copy(memExport.Memory().UnsafeData(caller)[offset:], results)
@@ -125,7 +125,7 @@ func convertFunction(callInfo *CallInfo, hf HostFunction) func(*wasmtime.Caller,
 		case FunctionNoOutput:
 			err := f(callInfo, inputBytes)
 			if err != nil {
-				return []wasmtime.Val{}, wasmtime.NewTrap(err.Error())
+				return []wasmtime.Val{}, convertToTrap(err)
 			}
 
 			return []wasmtime.Val{}, nil

--- a/x/programs/runtime/program.go
+++ b/x/programs/runtime/program.go
@@ -118,7 +118,7 @@ func (p *ProgramInstance) setParams(data []byte) (int32, error) {
 	programMemory := p.inst.GetExport(p.store, MemoryName).Memory()
 	dataOffsetIntf, err := allocFn.Call(p.store, int32(len(data)))
 	if err != nil {
-		return 0, wasmtime.NewTrap(err.Error())
+		return 0, err
 	}
 	dataOffset := dataOffsetIntf.(int32)
 	linearMem := programMemory.UnsafeData(p.store)


### PR DESCRIPTION
Some wasmtime traps were being wrapped in a second wasmtime trap for no reason which was causing the error to be returned from program calls to be less predictable.  Now it only wraps the returned error in a trap if it has to.