### PR TITLE
Smart Host Pointer

### DIFF
--- a/x/programs/rust/sdk-macros/src/lib.rs
+++ b/x/programs/rust/sdk-macros/src/lib.rs
@@ -156,10 +156,9 @@ pub fn public(_: TokenStream, item: TokenStream) -> TokenStream {
             }
 
             #[no_mangle]
-            unsafe extern "C" fn #name(args: *const u8) {
+            unsafe extern "C" fn #name(args: wasmlanche_sdk::HostPtr) {
                 let args: Args = unsafe {
-                    let args_bytes = wasmlanche_sdk::deref_bytes(args);
-                    borsh::from_slice(&args_bytes).expect("error fetching serialized args")
+                    borsh::from_slice(&args).expect("error fetching serialized args")
                 };
 
                 let result = super::#name(#(#converted_params),*);

--- a/x/programs/rust/wasmlanche-sdk/src/lib.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/lib.rs
@@ -9,7 +9,7 @@ mod program;
 
 pub use self::{
     logging::log,
-    memory::deref_bytes,
+    memory::HostPtr,
     program::{Program, PROGRAM_ID_LEN},
 };
 


### PR DESCRIPTION
So... I'm getting a litte fancy here allowing what is effectively a pointer to deref as `&[u8]`. I don't think this accomplishes much from an efficiency standpoint except that we don't carry around the extra `capacity` `usize` for a `Vec<u8>` when all we really need is a borrow. 

If you are okay with this change, I should probably add some documentation before we merge. The code is safe because it will panic if the `ALLOCATIONS` global detects mutliple borrows trying to convert to an owned value. 

I wanted to do this because the majority of the time we were turning a pointer returned by the host into a `Vec<u8>` we were just borrowing it right after. I'm not sure if the compiler was smart enough to drop capacity tracking, but now it's explicit. We now don't have to worry about any extra code that generated creating a `Vec<u8>`, borrowing, then dropping. 

