### PR TITLE
Add `Varint` methods in the codec

### DIFF
--- a/codec/packer.go
+++ b/codec/packer.go
@@ -173,13 +173,12 @@ func (p *Packer) UnpackVarInt(required bool) int64 {
 }
 
 func ZeroOut(buf []byte) []byte {
-	for i := len(buf)-1; i >= 0; i-- {
+	for i := len(buf) - 1; i >= 0; i-- {
 		bit := buf[i]
-		if bit == 0 {
-			buf = buf[:i]
-		} else {
+		if bit > 0 {
 			break
 		}
+		buf = buf[:i]
 	}
 	return buf
 }

--- a/codec/packer_test.go
+++ b/codec/packer_test.go
@@ -135,3 +135,20 @@ func TestNewReader(t *testing.T) {
 	require.Zero(rp.UnpackUint64(true), "Reader unpacked correctly.")
 	require.ErrorIs(rp.Err(), wrappers.ErrInsufficientLength)
 }
+
+func TestVarInt(t *testing.T) {
+	require := require.New(t)
+	varUint := uint64(900)
+	wp1 := NewWriter(10, 10)
+	wp1.PackUvarInt(varUint)
+	rp1 := NewReader(wp1.Bytes(), 10)
+	require.Equal(varUint, rp1.UnpackUvarInt(true), "Reader unpacked incorrectly")
+	require.NoError(rp1.Err())
+
+	varInt := int64(-900)
+	wp2 := NewWriter(10, 10)
+	wp2.PackVarInt(varInt)
+	rp2 := NewReader(wp2.Bytes(), 10)
+	require.Equal(varInt, rp2.UnpackVarInt(true), "Reader unpacked incorrectly")
+	require.NoError(rp2.Err())
+}


### PR DESCRIPTION
Using a `VarInt` (or a `UvarInt`) in the codec will sometimes lead to a smaller impact on storage, considering that the stored number is small enough. Otherwise there may be a penalty of a maximum of 2 bytes in the case of 64 bits numbers.
- Adding packing utils to do that in the codec
- Write tests

Also closes https://github.com/ava-labs/hypersdk/issues/963