### PR TITLE
Centralize gas-type

### DIFF
--- a/x/programs/rust/examples/counter/src/lib.rs
+++ b/x/programs/rust/examples/counter/src/lib.rs
@@ -1,4 +1,4 @@
-use wasmlanche_sdk::{public, state_keys, types::Address, Context, Program};
+use wasmlanche_sdk::{public, state_keys, types::Address, Context, Gas, Program};
 
 #[state_keys]
 pub enum StateKeys {
@@ -27,7 +27,7 @@ pub fn inc(context: Context<StateKeys>, to: Address, amount: Count) -> bool {
 pub fn inc_external(
     _: Context,
     target: Program,
-    max_units: i64,
+    max_units: Gas,
     of: Address,
     amount: Count,
 ) -> bool {
@@ -53,7 +53,7 @@ fn get_value_internal(context: &Context<StateKeys>, of: Address) -> Count {
 
 /// Gets the count at the address for an external program.
 #[public]
-pub fn get_value_external(_: Context, target: Program, max_units: i64, of: Address) -> Count {
+pub fn get_value_external(_: Context, target: Program, max_units: Gas, of: Address) -> Count {
     target.call_function("get_value", of, max_units).unwrap()
 }
 

--- a/x/programs/rust/examples/token/src/lib.rs
+++ b/x/programs/rust/examples/token/src/lib.rs
@@ -1,6 +1,5 @@
 use borsh::{BorshDeserialize, BorshSerialize};
-use wasmlanche_sdk::Context;
-use wasmlanche_sdk::{public, state_keys, types::Address};
+use wasmlanche_sdk::{public, state_keys, types::Address, Context};
 
 const INITIAL_SUPPLY: u64 = 123456789;
 

--- a/x/programs/rust/wasmlanche-sdk/src/lib.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/lib.rs
@@ -20,6 +20,8 @@ use borsh::{BorshDeserialize, BorshSerialize};
 pub use sdk_macros::{public, state_keys};
 use types::Address;
 
+pub type Gas = i64;
+
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("State error: {0}")]

--- a/x/programs/rust/wasmlanche-sdk/src/program.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/program.rs
@@ -1,6 +1,7 @@
 use crate::{
     memory::HostPtr,
     state::{Error as StateError, Key, State},
+    Gas,
 };
 use borsh::{BorshDeserialize, BorshSerialize};
 use std::{cell::RefCell, collections::HashMap};
@@ -49,7 +50,7 @@ impl<K> Program<K> {
         &self,
         function_name: &str,
         args: ArgType,
-        max_units: i64,
+        max_units: Gas,
     ) -> Result<T, StateError> {
         #[link(wasm_import_module = "program")]
         extern "C" {
@@ -102,7 +103,7 @@ struct CallProgramArgs<'a, K> {
     target_id: &'a Program<K>,
     function: &'a [u8],
     args_ptr: &'a [u8],
-    max_units: i64,
+    max_units: Gas,
 }
 
 impl<K> BorshSerialize for CallProgramArgs<'_, K> {

--- a/x/programs/test/programs/call_program/src/lib.rs
+++ b/x/programs/test/programs/call_program/src/lib.rs
@@ -1,4 +1,4 @@
-use wasmlanche_sdk::{public, Context, Program};
+use wasmlanche_sdk::{public, Context, Gas, Program};
 
 #[public]
 pub fn simple_call(_: Context) -> i64 {
@@ -6,7 +6,7 @@ pub fn simple_call(_: Context) -> i64 {
 }
 
 #[public]
-pub fn simple_call_external(_: Context, target: Program, max_units: i64) -> i64 {
+pub fn simple_call_external(_: Context, target: Program, max_units: Gas) -> i64 {
     target.call_function("simple_call", (), max_units).unwrap()
 }
 
@@ -16,7 +16,7 @@ pub fn call_with_param(_: Context, value: i64) -> i64 {
 }
 
 #[public]
-pub fn call_with_param_external(_: Context, target: Program, max_units: i64, value: i64) -> i64 {
+pub fn call_with_param_external(_: Context, target: Program, max_units: Gas, value: i64) -> i64 {
     target
         .call_function("call_with_param", value, max_units)
         .unwrap()
@@ -31,7 +31,7 @@ pub fn call_with_two_params(_: Context, value1: i64, value2: i64) -> i64 {
 pub fn call_with_two_params_external(
     _: Context,
     target: Program,
-    max_units: i64,
+    max_units: Gas,
     value1: i64,
     value2: i64,
 ) -> i64 {

--- a/x/programs/test/programs/return_complex_type/src/lib.rs
+++ b/x/programs/test/programs/return_complex_type/src/lib.rs
@@ -1,10 +1,10 @@
 use borsh::BorshSerialize;
-use wasmlanche_sdk::{public, Context, Program};
+use wasmlanche_sdk::{public, Context, Gas, Program};
 
 #[derive(BorshSerialize)]
 pub struct ComplexReturn {
     program: Program,
-    max_units: i64,
+    max_units: Gas,
 }
 
 #[public]


### PR DESCRIPTION
This makes it easier to change the type to a u64 if desired (or any other type)

