### PR TITLE
Make implementing the Key trait unsafe

### DIFF
--- a/x/programs/rust/sdk-macros/src/lib.rs
+++ b/x/programs/rust/sdk-macros/src/lib.rs
@@ -344,7 +344,7 @@ pub fn state_keys(_attr: TokenStream, item: TokenStream) -> TokenStream {
                 Ok(())
             }
         }
-        impl wasmlanche_sdk::state::Key for #name {}
+        unsafe impl wasmlanche_sdk::state::Key for #name {}
     }
     .into()
 }

--- a/x/programs/rust/wasmlanche-sdk/src/state.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/state.rs
@@ -42,7 +42,9 @@ pub struct State<'a, K: Key> {
     cache: &'a RefCell<HashMap<K, Vec<u8>>>,
 }
 
-pub trait Key: Copy + PartialEq + Eq + Hash + BorshSerialize {}
+/// # Safety
+/// This trait should only be implemented using the [`state_keys`](crate::state_keys) macro.
+pub unsafe trait Key: Copy + PartialEq + Eq + Hash + BorshSerialize {}
 
 impl<'a, K: Key> Drop for State<'a, K> {
     fn drop(&mut self) {


### PR DESCRIPTION
This discourages manual implementation

edit: Closes https://github.com/ava-labs/hypersdk/issues/839