### PR TITLE
Only run MorpheusVM and TokenVM when necessary

### DIFF
--- a/.github/workflows/hypersdk-ci.yml
+++ b/.github/workflows/hypersdk-ci.yml
@@ -74,13 +74,33 @@ jobs:
   hypersdk-tests:
     runs-on: ubuntu-latest
     needs: [mock-gen, go-mod-tidy, hypersdk-lint, hypersdk-unit-tests]
+    outputs:
+      only_programs_changed: ${{ steps.check_changes.outputs.only_programs_changed }}
     steps:
       - name: Finished HyperSDK tests
         run: echo "Finished HyperSDK tests"
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check changes
+        id: check_changes
+        run: |
+          diff=$(git diff --name-only HEAD origin/main)
+          echo "diff:\n$diff\n"
+          output=$(echo $diff | grep -v '^x/programs/' || true)
+          if [ -n "$diff" ] && [ -z "$output" ]; then
+            echo "only x/programs changed, will skip unafected tests"
+            echo "only_programs_changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "cannot skip tests"
+            echo "only_programs_changed=false" >> $GITHUB_OUTPUT
+          fi
 
   # TokenVM
   tokenvm-lint:
     needs: [hypersdk-tests]
+    if: ${{ needs.hypersdk-tests.outputs.only_programs_changed != 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -103,6 +123,7 @@ jobs:
 
   tokenvm-unit-tests:
     needs: [hypersdk-tests]
+    if: ${{ needs.hypersdk-tests.outputs.only_programs_changed != 'true' }}
     runs-on: ubuntu-20.04-32
     timeout-minutes: 10
     steps:
@@ -182,6 +203,7 @@ jobs:
   # MorpheusVM
   morpheusvm-lint:
     needs: [hypersdk-tests]
+    if: ${{ needs.hypersdk-tests.outputs.only_programs_changed != 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -204,6 +226,7 @@ jobs:
 
   morpheusvm-unit-tests:
     needs: [hypersdk-tests]
+    if: ${{ needs.hypersdk-tests.outputs.only_programs_changed != 'true' }}
     runs-on: ubuntu-20.04-32
     timeout-minutes: 10
     steps:

--- a/.github/workflows/hypersdk-ci.yml
+++ b/.github/workflows/hypersdk-ci.yml
@@ -85,11 +85,10 @@ jobs:
           fetch-depth: 0
       - name: Check changes
         id: check_changes
-        # DO NOT MERGE
         run: |
           diff=$(git diff --name-only HEAD origin/main)
           echo "diff:\n$diff\n"
-          output=$(echo $diff | grep -v '^x/programs/' | grep -v '^.github/' || true)
+          output=$(echo $diff | grep -v '^x/programs/' || true)
           if [ -n "$diff" ] && [ -z "$output" ]; then
             echo "only x/programs changed, will skip unafected tests"
             echo "only_programs_changed=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/hypersdk-ci.yml
+++ b/.github/workflows/hypersdk-ci.yml
@@ -85,10 +85,11 @@ jobs:
           fetch-depth: 0
       - name: Check changes
         id: check_changes
+        # DO NOT MERGE
         run: |
           diff=$(git diff --name-only HEAD origin/main)
           echo "diff:\n$diff\n"
-          output=$(echo $diff | grep -v '^x/programs/' || true)
+          output=$(echo $diff | grep -v '^x/programs/' | grep -v '^.github/' || true)
           if [ -n "$diff" ] && [ -z "$output" ]; then
             echo "only x/programs changed, will skip unafected tests"
             echo "only_programs_changed=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Working as expted:
 - commit to test the feature: 576c01ebed311853f79bdb38f59560a30afaa923
   run: https://github.com/ava-labs/hypersdk/actions/runs/9405379541?pr=1023
   ✅ (proper tests were skipped)
 - run with changes to CI files (should run all the extra tests)
 https://github.com/ava-labs/hypersdk/actions/runs/9405552614?pr=1023
 ✅  (everything ran)
 
 The first commit on this PR is the actual logic to implement the CI-feature. 
 The second commit is used to test the process by adding an extra `grep -v` to ignore the changes in the `.github` directory (the changes in this PR).
 The third commit is the revert of the second (test) commit. I figured that would be a little more clear if someone looks at this PR post-merge; the commit will still be there. 

   
  


