### PR TITLE
Catch system errors from the host on the guest

### DIFF
--- a/x/programs/rust/wasmlanche-sdk/src/lib.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/lib.rs
@@ -22,14 +22,6 @@ use types::Address;
 
 pub type Gas = i64;
 
-#[derive(Debug, thiserror::Error)]
-pub enum Error {
-    #[error("State error: {0}")]
-    State(#[from] state::Error),
-    #[error("Param error: {0}")]
-    Param(#[from] std::io::Error),
-}
-
 #[derive(Clone, Debug)]
 pub struct Context<K = ()> {
     pub program: Program<K>,

--- a/x/programs/rust/wasmlanche-sdk/src/state.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/state.rs
@@ -36,6 +36,29 @@ pub enum Error {
 
     #[error("failed to delete from host storage")]
     Delete,
+
+    #[error("error during execution: {0:?}")]
+    Execution(ExecutionError),
+}
+
+#[derive(Debug, Clone)]
+pub enum ExecutionError {
+    Deserialization,
+    OutOfFuel,
+    Execution,
+    Invalid(u8),
+}
+
+impl From<u8> for ExecutionError {
+    fn from(value: u8) -> Self {
+        match value {
+            0 => panic!("this is not an error"),
+            1 => Self::Deserialization,
+            2 => Self::OutOfFuel,
+            3 => Self::Execution,
+            code => Self::Invalid(code),
+        }
+    }
 }
 
 pub struct State<'a, K: Key> {


### PR DESCRIPTION
Closes https://github.com/ava-labs/hypersdk/issues/666
The above issue describes a more heavy error handling trick, this one is simpler and more performant by defining a constant between 0 and 255, 0 being the `Ok` variant and anything else meaning that an error occured.
Note that this **doesn't** solve https://github.com/ava-labs/hypersdk/issues/595 as there is some ongoing discussion about it https://github.com/ava-labs/hypersdk/discussions/1020