### PR TITLE
Implement cache deletes

### DIFF
--- a/x/programs/runtime/import_state.go
+++ b/x/programs/runtime/import_state.go
@@ -26,6 +26,10 @@ type keyValueInput struct {
 	Value []byte
 }
 
+type keyInput struct {
+	Key []byte
+}
+
 func NewStateAccessModule() *ImportModule {
 	return &ImportModule{
 		Name: "state",
@@ -98,9 +102,7 @@ func NewStateAccessModule() *ImportModule {
 				return bytes, nil
 			})},
 			"delete_many": {FuelCost: putManyCost, Function: FunctionNoOutput(func(callInfo *CallInfo, input []byte) error {
-				// fmt.Fprintln(os.Stderr, "OK")
-				// return nil
-				var parsedInput [][]byte
+				var parsedInput []keyInput
 				if err := borsh.Deserialize(&parsedInput, input); err != nil {
 					fmt.Fprintln(os.Stderr, err)
 					return err
@@ -111,7 +113,7 @@ func NewStateAccessModule() *ImportModule {
 				defer cancel()
 
 				for _, entry := range parsedInput {
-					if err := callInfo.State.GetProgramState(callInfo.Program).Remove(ctx, entry); err != nil {
+					if err := callInfo.State.GetProgramState(callInfo.Program).Remove(ctx, entry.Key); err != nil {
 						fmt.Fprintln(os.Stderr, err)
 						return err
 					}

--- a/x/programs/runtime/import_state.go
+++ b/x/programs/runtime/import_state.go
@@ -6,8 +6,6 @@ package runtime
 import (
 	"context"
 	"errors"
-	"fmt"
-	"os"
 
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/near/borsh-go"
@@ -104,17 +102,14 @@ func NewStateAccessModule() *ImportModule {
 			"delete_many": {FuelCost: putManyCost, Function: FunctionNoOutput(func(callInfo *CallInfo, input []byte) error {
 				var parsedInput []keyInput
 				if err := borsh.Deserialize(&parsedInput, input); err != nil {
-					fmt.Fprintln(os.Stderr, err)
 					return err
 				}
-				fmt.Fprintln(os.Stderr, "OK")
 
 				ctx, cancel := context.WithCancel(context.Background())
 				defer cancel()
 
 				for _, entry := range parsedInput {
 					if err := callInfo.State.GetProgramState(callInfo.Program).Remove(ctx, entry.Key); err != nil {
-						fmt.Fprintln(os.Stderr, err)
 						return err
 					}
 				}

--- a/x/programs/runtime/import_state.go
+++ b/x/programs/runtime/import_state.go
@@ -6,6 +6,8 @@ package runtime
 import (
 	"context"
 	"errors"
+	"fmt"
+	"os"
 
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/near/borsh-go"
@@ -96,16 +98,21 @@ func NewStateAccessModule() *ImportModule {
 				return bytes, nil
 			})},
 			"delete_many": {FuelCost: putManyCost, Function: FunctionNoOutput(func(callInfo *CallInfo, input []byte) error {
+				// fmt.Fprintln(os.Stderr, "OK")
+				// return nil
 				var parsedInput [][]byte
 				if err := borsh.Deserialize(&parsedInput, input); err != nil {
+					fmt.Fprintln(os.Stderr, err)
 					return err
 				}
+				fmt.Fprintln(os.Stderr, "OK")
 
 				ctx, cancel := context.WithCancel(context.Background())
 				defer cancel()
 
 				for _, entry := range parsedInput {
 					if err := callInfo.State.GetProgramState(callInfo.Program).Remove(ctx, entry); err != nil {
+						fmt.Fprintln(os.Stderr, err)
 						return err
 					}
 				}

--- a/x/programs/runtime/import_state.go
+++ b/x/programs/runtime/import_state.go
@@ -33,10 +33,8 @@ func NewStateAccessModule() *ImportModule {
 				if err := borsh.Deserialize(&parsedInput, input); err != nil {
 					return nil, err
 				}
-
 				ctx, cancel := context.WithCancel(context.Background())
 				defer cancel()
-
 				val, err := callInfo.State.GetProgramState(callInfo.Program).GetValue(ctx, parsedInput)
 				if err != nil {
 					if errors.Is(err, database.ErrNotFound) {
@@ -44,7 +42,6 @@ func NewStateAccessModule() *ImportModule {
 					}
 					return nil, err
 				}
-
 				return val, nil
 			})},
 			"put": {FuelCost: putCost, Function: FunctionNoOutput(func(callInfo *CallInfo, input []byte) error {
@@ -52,10 +49,8 @@ func NewStateAccessModule() *ImportModule {
 				if err := borsh.Deserialize(parsedInput, input); err != nil {
 					return err
 				}
-
 				ctx, cancel := context.WithCancel(context.Background())
 				defer cancel()
-
 				return callInfo.State.GetProgramState(callInfo.Program).Insert(ctx, parsedInput.Key, parsedInput.Value)
 			})},
 			"put_many": {FuelCost: putManyCost, Function: FunctionNoOutput(func(callInfo *CallInfo, input []byte) error {
@@ -63,16 +58,13 @@ func NewStateAccessModule() *ImportModule {
 				if err := borsh.Deserialize(&parsedInput, input); err != nil {
 					return err
 				}
-
 				ctx, cancel := context.WithCancel(context.Background())
 				defer cancel()
-
 				for _, entry := range parsedInput {
 					if err := callInfo.State.GetProgramState(callInfo.Program).Insert(ctx, entry.Key, entry.Value); err != nil {
 						return err
 					}
 				}
-
 				return nil
 			})},
 			"delete": {FuelCost: deleteCost, Function: Function(func(callInfo *CallInfo, input []byte) ([]byte, error) {
@@ -83,7 +75,6 @@ func NewStateAccessModule() *ImportModule {
 
 				ctx, cancel := context.WithCancel(context.Background())
 				defer cancel()
-
 				programState := callInfo.State.GetProgramState(callInfo.Program)
 				bytes, err := programState.GetValue(ctx, parsedInput)
 				if err != nil {

--- a/x/programs/runtime/import_state.go
+++ b/x/programs/runtime/import_state.go
@@ -24,10 +24,6 @@ type keyValueInput struct {
 	Value []byte
 }
 
-type keyInput struct {
-	Key []byte
-}
-
 func NewStateAccessModule() *ImportModule {
 	return &ImportModule{
 		Name: "state",
@@ -100,7 +96,7 @@ func NewStateAccessModule() *ImportModule {
 				return bytes, nil
 			})},
 			"delete_many": {FuelCost: putManyCost, Function: FunctionNoOutput(func(callInfo *CallInfo, input []byte) error {
-				var parsedInput []keyInput
+				var parsedInput [][]byte
 				if err := borsh.Deserialize(&parsedInput, input); err != nil {
 					return err
 				}
@@ -109,7 +105,7 @@ func NewStateAccessModule() *ImportModule {
 				defer cancel()
 
 				for _, entry := range parsedInput {
-					if err := callInfo.State.GetProgramState(callInfo.Program).Remove(ctx, entry.Key); err != nil {
+					if err := callInfo.State.GetProgramState(callInfo.Program).Remove(ctx, entry); err != nil {
 						return err
 					}
 				}

--- a/x/programs/runtime/import_state_test.go
+++ b/x/programs/runtime/import_state_test.go
@@ -45,10 +45,6 @@ func TestImportStateRemove(t *testing.T) {
 	require.NoError(err)
 	require.Nil(result)
 
-	result, err = program.Call("get")
-	require.NoError(err)
-	require.Equal(append([]byte{1}, valueBytes...), result)
-
 	result, err = program.Call("delete")
 	require.NoError(err)
 	require.Equal(append([]byte{1}, valueBytes...), result)

--- a/x/programs/runtime/import_state_test.go
+++ b/x/programs/runtime/import_state_test.go
@@ -45,6 +45,10 @@ func TestImportStateRemove(t *testing.T) {
 	require.NoError(err)
 	require.Nil(result)
 
+	result, err = program.Call("get")
+	require.NoError(err)
+	require.Equal(append([]byte{1}, valueBytes...), result)
+
 	result, err = program.Call("delete")
 	require.NoError(err)
 	require.Equal(append([]byte{1}, valueBytes...), result)

--- a/x/programs/rust/sdk-macros/src/lib.rs
+++ b/x/programs/rust/sdk-macros/src/lib.rs
@@ -257,7 +257,7 @@ pub fn state_keys(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
     // add default attributes
     item_enum.attrs.push(parse_quote! {
-         #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+        #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
     });
 
     let name = &item_enum.ident;
@@ -272,6 +272,12 @@ pub fn state_keys(_attr: TokenStream, item: TokenStream) -> TokenStream {
         )
         .into_compile_error()
         .into();
+    }
+
+    if !variants.is_empty() {
+        item_enum.attrs.push(parse_quote! {
+            #[repr(u8)] // suppress the null-pointer optimization https://doc.rust-lang.org/nomicon/other-reprs.html#repru-repri
+        });
     }
 
     let match_arms: Result<Vec<_>, _> = variants

--- a/x/programs/rust/sdk-macros/src/lib.rs
+++ b/x/programs/rust/sdk-macros/src/lib.rs
@@ -274,12 +274,6 @@ pub fn state_keys(_attr: TokenStream, item: TokenStream) -> TokenStream {
         .into();
     }
 
-    if !variants.is_empty() {
-        item_enum.attrs.push(parse_quote! {
-            #[repr(u8)] // suppress the null-pointer optimization https://doc.rust-lang.org/nomicon/other-reprs.html#repru-repri
-        });
-    }
-
     let match_arms: Result<Vec<_>, _> = variants
         .iter()
         .enumerate()

--- a/x/programs/rust/wasmlanche-sdk/src/program.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/program.rs
@@ -1,18 +1,18 @@
 use crate::{
     memory::HostPtr,
-    state::{Error as StateError, Key, State},
+    state::{Cache, Error as StateError, Key, State},
     types::Address,
     Gas,
 };
 use borsh::{BorshDeserialize, BorshSerialize};
-use std::{cell::RefCell, collections::HashMap};
+use std::cell::RefCell;
 
 /// Represents the current Program in the context of the caller. Or an external
 /// program that is being invoked.
 #[derive(Debug)]
 pub struct Program<K = ()> {
     account: Address,
-    state_cache: RefCell<HashMap<K, Vec<u8>>>,
+    state_cache: RefCell<Cache<K>>,
 }
 
 impl<K> BorshSerialize for Program<K> {
@@ -30,7 +30,7 @@ impl<K> BorshDeserialize for Program<K> {
         let account: Address = BorshDeserialize::deserialize_reader(reader)?;
         Ok(Self {
             account,
-            state_cache: RefCell::default(),
+            state_cache: RefCell::new(Cache::new()),
         })
     }
 }

--- a/x/programs/rust/wasmlanche-sdk/src/program.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/program.rs
@@ -1,18 +1,18 @@
 use crate::{
     memory::HostPtr,
-    state::{Cache, Error as StateError, Key, State},
+    state::{CachedData, Error as StateError, Key, State},
     types::Address,
     Gas,
 };
 use borsh::{BorshDeserialize, BorshSerialize};
-use std::cell::RefCell;
+use std::{cell::RefCell, collections::HashMap};
 
 /// Represents the current Program in the context of the caller. Or an external
 /// program that is being invoked.
 #[derive(Debug)]
 pub struct Program<K = ()> {
     account: Address,
-    state_cache: RefCell<Cache<K>>,
+    state_cache: RefCell<HashMap<K, CachedData>>,
 }
 
 impl<K> BorshSerialize for Program<K> {

--- a/x/programs/rust/wasmlanche-sdk/src/program.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/program.rs
@@ -30,7 +30,7 @@ impl<K> BorshDeserialize for Program<K> {
         let account: Address = BorshDeserialize::deserialize_reader(reader)?;
         Ok(Self {
             account,
-            state_cache: RefCell::new(Cache::new()),
+            state_cache: RefCell::default(),
         })
     }
 }

--- a/x/programs/rust/wasmlanche-sdk/src/state.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/state.rs
@@ -207,7 +207,7 @@ impl<'a, K: Key> State<'a, K> {
         }
 
         if !deletes.is_empty() {
-            let serialized_args = borsh::to_vec(&deletes).expect("failed to serialize");
+            let serialized_args = borsh::to_vec(&deletes.as_slice()).expect("failed to serialize");
             unsafe { delete_many_bytes(serialized_args.as_ptr(), serialized_args.len()) };
         }
     }

--- a/x/programs/rust/wasmlanche-sdk/src/state.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/state.rs
@@ -1,5 +1,8 @@
 use crate::{memory::HostPtr, state::Error as StateError};
 use borsh::{from_slice, to_vec, BorshDeserialize, BorshSerialize};
+use std::cell::RefMut;
+use std::collections::hash_map::Entry;
+use std::collections::HashSet;
 use std::{cell::RefCell, collections::HashMap, hash::Hash};
 
 #[derive(Clone, thiserror::Error, Debug)]
@@ -38,8 +41,51 @@ pub enum Error {
     Delete,
 }
 
+#[derive(Debug, Default)]
+pub struct Cache<K = ()> {
+    puts: HashMap<K, Vec<u8>>,
+    deletes: HashSet<K>,
+}
+
+impl<K> Cache<K> {
+    pub fn new() -> Self {
+        Cache {
+            puts: HashMap::new(),
+            deletes: HashSet::new(),
+        }
+    }
+}
+
+impl<K: Key> Cache<K> {
+    fn is_empty(&self) -> bool {
+        self.puts.is_empty() && self.deletes.is_empty()
+    }
+
+    fn get(&mut self, k: &K) -> Option<Option<&Vec<u8>>> {
+        self.puts
+            .get(k)
+            .map(|data| Some(data))
+            .or_else(|| self.deletes.get(k).map_or(None, |_| Some(None)))
+    }
+
+    fn put(&mut self, k: K, v: Vec<u8>) {
+        self.deletes.remove(&k);
+        self.puts.insert(k, v);
+    }
+
+    fn delete(&mut self, k: K) -> Option<Vec<u8>> {
+        let v = self.puts.remove(&k);
+        self.deletes.insert(k);
+        v
+    }
+
+    fn entry(&mut self, k: K) -> Entry<K, Vec<u8>> {
+        self.puts.entry(k)
+    }
+}
+
 pub struct State<'a, K: Key> {
-    cache: &'a RefCell<HashMap<K, Vec<u8>>>,
+    cache: &'a RefCell<Cache<K>>,
 }
 
 /// # Safety
@@ -57,7 +103,7 @@ impl<'a, K: Key> Drop for State<'a, K> {
 
 impl<'a, K: Key> State<'a, K> {
     #[must_use]
-    pub fn new(cache: &'a RefCell<HashMap<K, Vec<u8>>>) -> Self {
+    pub fn new(cache: &'a RefCell<Cache<K>>) -> Self {
         Self { cache }
     }
 
@@ -71,9 +117,29 @@ impl<'a, K: Key> State<'a, K> {
         V: BorshSerialize,
     {
         let serialized = to_vec(&value).map_err(|_| StateError::Deserialization)?;
-        self.cache.borrow_mut().insert(key, serialized);
+        self.cache.borrow_mut().put(key, serialized);
 
         Ok(())
+    }
+
+    /// Delete a value from the hosts's storage.
+    /// # Errors
+    /// Returns an [Error] if the key cannot be serialized
+    /// or if the host fails to delete the key and the associated value
+    pub fn delete<T: BorshDeserialize>(self, key: K) -> Result<Option<T>, Error> {
+        let mut cache = self.cache.borrow_mut();
+
+        if let Some(bytes) = if let Some(cached_bytes) = &cache.delete(key) {
+            Some(cached_bytes)
+        } else {
+            Self::get_from_host::<K>(&mut cache, key)?
+        } {
+            Ok(Some(
+                from_slice(bytes).map_err(|_| StateError::Deserialization)?,
+            ))
+        } else {
+            Ok(None)
+        }
     }
 
     /// Get a value from the host's storage.
@@ -90,26 +156,14 @@ impl<'a, K: Key> State<'a, K> {
     where
         V: BorshDeserialize,
     {
-        #[link(wasm_import_module = "state")]
-        extern "C" {
-            #[link_name = "get"]
-            fn get_bytes(ptr: *const u8, len: usize) -> HostPtr;
-        }
-
         let mut cache = self.cache.borrow_mut();
-
-        let val_bytes = if let Some(val) = cache.get(&key) {
-            val
-        } else {
-            let args_bytes = borsh::to_vec(&key).map_err(|_| StateError::Serialization)?;
-
-            let ptr = unsafe { get_bytes(args_bytes.as_ptr(), args_bytes.len()) };
-
-            if ptr.is_null() {
-                return Ok(None);
-            }
-
-            cache.entry(key).or_insert(ptr.into())
+        let val_bytes = match cache.get(&key) {
+            Some(Some(val)) => val,
+            Some(None) => return Ok(None),
+            None => match Self::get_from_host::<K>(&mut cache, key)? {
+                Some(bytes) => bytes,
+                None => return Ok(None),
+            },
         };
 
         from_slice::<V>(val_bytes)
@@ -117,27 +171,25 @@ impl<'a, K: Key> State<'a, K> {
             .map(Some)
     }
 
-    /// Delete a value from the hosts's storage.
-    /// # Errors
-    /// Returns an [Error] if the key cannot be serialized
-    /// or if the host fails to delete the key and the associated value
-    pub fn delete<T: BorshDeserialize>(self, key: K) -> Result<Option<T>, Error> {
+    pub fn get_from_host<'b, V>(
+        cache: &'b mut RefMut<Cache<K>>,
+        key: K,
+    ) -> Result<Option<&'b Vec<u8>>, Error> {
         #[link(wasm_import_module = "state")]
         extern "C" {
-            #[link_name = "delete"]
-            fn delete(ptr: *const u8, len: usize) -> HostPtr;
+            #[link_name = "get"]
+            fn get_bytes(ptr: *const u8, len: usize) -> HostPtr;
         }
-
-        // TODO:
-        // we should actually cache deletes as well
-        // to avoid cache misses after delete
-        self.cache.borrow_mut().remove(&key);
 
         let args_bytes = borsh::to_vec(&key).map_err(|_| StateError::Serialization)?;
 
-        let bytes = unsafe { delete(args_bytes.as_ptr(), args_bytes.len()) };
+        let ptr = unsafe { get_bytes(args_bytes.as_ptr(), args_bytes.len()) };
 
-        from_slice(&bytes).map_err(|_| StateError::Deserialization)
+        if ptr.is_null() {
+            return Ok(None);
+        }
+
+        Ok(Some(cache.entry(key).or_insert(ptr.into())))
     }
 
     /// Apply all pending operations to storage and mark the cache as flushed
@@ -146,6 +198,9 @@ impl<'a, K: Key> State<'a, K> {
         extern "C" {
             #[link_name = "put_many"]
             fn put_many_bytes(ptr: *const u8, len: usize);
+
+            #[link_name = "delete_many"]
+            fn delete_many_bytes(ptr: *const u8, len: usize);
         }
 
         #[derive(BorshSerialize)]
@@ -157,10 +212,33 @@ impl<'a, K: Key> State<'a, K> {
         let mut cache = self.cache.borrow_mut();
 
         let args: Vec<_> = cache
+            .puts
             .drain()
             .map(|(key, value)| PutArgs { key, value })
             .collect();
         let serialized_args = borsh::to_vec(&args).expect("failed to serialize");
         unsafe { put_many_bytes(serialized_args.as_ptr(), serialized_args.len()) };
+
+        let args: Vec<_> = cache.deletes.drain().collect();
+        let serialized_args = borsh::to_vec(&args).expect("failed to serialize");
+        unsafe { delete_many_bytes(serialized_args.as_ptr(), serialized_args.len()) };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Cache, Key};
+
+    impl Key for usize {}
+
+    #[test]
+    fn cache_operations() {
+        let mut cache = Cache::new();
+        assert!(cache.is_empty());
+        assert!(cache.get(&0).is_none());
+        assert!(cache.delete(0).is_none());
+        assert_eq!(cache.get(&0), Some(None));
+        cache.put(0, vec![1]);
+        assert_eq!(cache.get(&0), Some(Some(&vec![1])));
     }
 }

--- a/x/programs/rust/wasmlanche-sdk/src/state.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/state.rs
@@ -191,18 +191,13 @@ impl<'a, K: Key> State<'a, K> {
             value: Vec<u8>,
         }
 
-        #[derive(BorshSerialize)]
-        struct DeleteArgs<Key> {
-            key: Key,
-        }
-
         let (mut puts, mut deletes) = (Vec::new(), Vec::new());
         self.cache
             .borrow_mut()
             .drain()
             .for_each(|(key, value)| match value {
                 CachedData::Data(value) => puts.push(PutArgs { key, value }),
-                CachedData::ToDelete => deletes.push(DeleteArgs { key }),
+                CachedData::ToDelete => deletes.push(key),
                 CachedData::Deleted => (),
             });
 


### PR DESCRIPTION
Cache deletes in the program state so that we now avoid cache misses when it comes to data deletion.
Also added a cache insertion when calling `get`.
The new cache now tells the caller wether the data is here `Data(Vec<u8>)`, has been deleted `Deleted` or `ToDelete` if it's scheduled to be deleted when the cache is flushed.
There is a caveat though which is that ZST Vecs are completely disabled by borsh-rs. That's because they want to avoid a potential DOS since huge vecs can easily be crafted using ZST (they are free memory-wise!) with `vec![(), !0]`.
See https://github.com/near/borsh-rs/issues/52
We need to make sure that we are not exposed to that, or that fuel is correctly metering to avoid abuses.

Closes https://github.com/ava-labs/hypersdk/issues/867
Closes https://github.com/ava-labs/hypersdk/issues/868