### PR TITLE
Make `call_function` take serialized arguments

### DIFF
--- a/x/programs/rust/examples/counter/src/lib.rs
+++ b/x/programs/rust/examples/counter/src/lib.rs
@@ -33,9 +33,8 @@ pub fn inc_external(
     of: Address,
     amount: Count,
 ) -> bool {
-    target
-        .call_function("inc", (of, amount), max_units)
-        .unwrap()
+    let args = borsh::to_vec(&(of, amount)).unwrap();
+    target.call_function("inc", &args, max_units).unwrap()
 }
 
 /// Gets the count at the address.
@@ -57,7 +56,8 @@ fn get_value_internal(context: &Context<StateKeys>, of: Address) -> Count {
 /// Gets the count at the address for an external program.
 #[public]
 pub fn get_value_external(_: Context, target: Program, max_units: Gas, of: Address) -> Count {
-    target.call_function("get_value", of, max_units).unwrap()
+    let args = borsh::to_vec(&of).unwrap();
+    target.call_function("get_value", &args, max_units).unwrap()
 }
 
 #[cfg(test)]

--- a/x/programs/rust/sdk-macros/src/lib.rs
+++ b/x/programs/rust/sdk-macros/src/lib.rs
@@ -197,9 +197,10 @@ pub fn public(_: TokenStream, item: TokenStream) -> TokenStream {
     };
 
     let block = Box::new(parse_quote! {{
+        let args = borsh::to_vec(&(#(#args),*)).expect("error serializing args");
         param_0
             .program()
-            .call_function::<#return_type, _>(#name, (#(#args),*), param_0.max_units())
+            .call_function::<#return_type>(#name, &args, param_0.max_units())
             .expect("calling the external program failed")
     }});
 

--- a/x/programs/rust/wasmlanche-sdk/src/program.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/program.rs
@@ -21,7 +21,8 @@ impl<K> BorshSerialize for Program<K> {
             account,
             state_cache: _,
         } = self;
-        BorshSerialize::serialize(account, writer)
+
+        account.serialize(writer)
     }
 }
 
@@ -47,10 +48,10 @@ impl<K> Program<K> {
     /// Returns a [`StateError`] if the call fails.
     /// # Safety
     /// The caller must ensure that `function_name` + `args` point to valid memory locations.
-    pub fn call_function<T: BorshDeserialize, ArgType: BorshSerialize>(
+    pub fn call_function<T: BorshDeserialize>(
         &self,
         function_name: &str,
-        args: ArgType,
+        args: &[u8],
         max_units: Gas,
     ) -> Result<T, StateError> {
         #[link(wasm_import_module = "program")]
@@ -59,12 +60,10 @@ impl<K> Program<K> {
             fn call_program(ptr: *const u8, len: usize) -> HostPtr;
         }
 
-        let args_ptr = borsh::to_vec(&args).map_err(|_| StateError::Serialization)?;
-
         let args = CallProgramArgs {
             target: self,
             function: function_name.as_bytes(),
-            args_ptr: &args_ptr,
+            args,
             max_units,
         };
 
@@ -103,7 +102,7 @@ impl<K: Key> Program<K> {
 struct CallProgramArgs<'a, K> {
     target: &'a Program<K>,
     function: &'a [u8],
-    args_ptr: &'a [u8],
+    args: &'a [u8],
     max_units: Gas,
 }
 
@@ -112,13 +111,15 @@ impl<K> BorshSerialize for CallProgramArgs<'_, K> {
         let Self {
             target,
             function,
-            args_ptr,
+            args,
             max_units,
         } = self;
-        BorshSerialize::serialize(target, writer)?;
-        BorshSerialize::serialize(function, writer)?;
-        BorshSerialize::serialize(args_ptr, writer)?;
-        BorshSerialize::serialize(max_units, writer)?;
+
+        target.serialize(writer)?;
+        function.serialize(writer)?;
+        args.serialize(writer)?;
+        max_units.serialize(writer)?;
+
         Ok(())
     }
 }

--- a/x/programs/test/programs/call_program/src/lib.rs
+++ b/x/programs/test/programs/call_program/src/lib.rs
@@ -7,7 +7,7 @@ pub fn simple_call(_: Context) -> i64 {
 
 #[public]
 pub fn simple_call_external(_: Context, target: Program, max_units: Gas) -> i64 {
-    target.call_function("simple_call", (), max_units).unwrap()
+    target.call_function("simple_call", &[], max_units).unwrap()
 }
 
 #[public]
@@ -19,7 +19,7 @@ pub fn actor_check(context: Context) -> Address {
 #[public]
 pub fn actor_check_external(_: Context, target: Program, max_units: Gas) -> Address {
     target
-        .call_function("actor_check", (), max_units)
+        .call_function("actor_check", &[], max_units)
         .expect("failure")
 }
 
@@ -31,7 +31,7 @@ pub fn call_with_param(_: Context, value: i64) -> i64 {
 #[public]
 pub fn call_with_param_external(_: Context, target: Program, max_units: Gas, value: i64) -> i64 {
     target
-        .call_function("call_with_param", value, max_units)
+        .call_function("call_with_param", &value.to_le_bytes(), max_units)
         .unwrap()
 }
 
@@ -48,7 +48,12 @@ pub fn call_with_two_params_external(
     value1: i64,
     value2: i64,
 ) -> i64 {
+    let args: Vec<_> = value1
+        .to_le_bytes()
+        .into_iter()
+        .chain(value2.to_le_bytes())
+        .collect();
     target
-        .call_function("call_with_two_params", (value1, value2), max_units)
+        .call_function("call_with_two_params", &args, max_units)
         .unwrap()
 }


### PR DESCRIPTION
This makes the generic use of `call_function` simpler in that you can call it with pre-serialized arguments. Since we now have the `bindings` feature, external calls can effectively be made manually with `call_function` where the author needs to check that the calling conventions work as expected, or automatically with the bindings feature. 

