### PR TITLE
Allow for any borsh-serializable key for unnamed field

### DIFF
--- a/x/programs/rust/sdk-macros/src/lib.rs
+++ b/x/programs/rust/sdk-macros/src/lib.rs
@@ -297,12 +297,7 @@ pub fn state_keys(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
                     Ok(quote! {
                         Self::#variant_ident(#(#fields),*) => {
-                            let as_bytes = borsh::to_vec(&(#(#fields_2),*))?;
-                            let len = 1 + as_bytes.len();
-                            let len = u32::try_from(len).map_err(|_| std::io::ErrorKind::InvalidData)?;
-                            writer.write_all(&len.to_le_bytes())?;
-                            writer.write_all(&[#idx])?;
-                            writer.write_all(&as_bytes)?;
+                            borsh::to_vec(&(#idx, #(#fields_2),*))?.serialize(writer);
                         }
                     })
                 }

--- a/x/programs/rust/sdk-macros/src/lib.rs
+++ b/x/programs/rust/sdk-macros/src/lib.rs
@@ -294,17 +294,15 @@ pub fn state_keys(_attr: TokenStream, item: TokenStream) -> TokenStream {
                         .enumerate()
                         .map(|(i, field)| Ident::new(&format!("field_{i}"), field.span()));
                     let fields_2 = fields.clone();
-                    let fields_3 = fields.clone();
 
                     Ok(quote! {
                         Self::#variant_ident(#(#fields),*) => {
-                            let len = 1 + #(#fields_2.as_ref().len())+*;
+                            let as_bytes = borsh::to_vec(&(#(#fields_2),*))?;
+                            let len = 1 + as_bytes.len();
                             let len = u32::try_from(len).map_err(|_| std::io::ErrorKind::InvalidData)?;
                             writer.write_all(&len.to_le_bytes())?;
                             writer.write_all(&[#idx])?;
-                            #(
-                                writer.write_all(#fields_3.as_ref())?;
-                            )*
+                            writer.write_all(&as_bytes)?;
                         }
                     })
                 }

--- a/x/programs/rust/sdk-macros/src/lib.rs
+++ b/x/programs/rust/sdk-macros/src/lib.rs
@@ -297,7 +297,7 @@ pub fn state_keys(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
                     Ok(quote! {
                         Self::#variant_ident(#(#fields),*) => {
-                            borsh::to_vec(&(#idx, #(#fields_2),*))?.serialize(writer);
+                            borsh::to_vec(&(#idx, #(#fields_2),*))?.serialize(writer)?;
                         }
                     })
                 }

--- a/x/programs/rust/wasmlanche-sdk/src/state.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/state.rs
@@ -175,8 +175,8 @@ impl<'a, K: Key> State<'a, K> {
         }
 
         #[derive(BorshSerialize)]
-        struct PutArgs<Key> {
-            key: Key,
+        struct PutArgs<K> {
+            key: K,
             value: Vec<u8>,
         }
 

--- a/x/programs/rust/wasmlanche-sdk/src/state.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/state.rs
@@ -175,8 +175,8 @@ impl<'a, K: Key> State<'a, K> {
         }
 
         #[derive(BorshSerialize)]
-        struct PutArgs<K> {
-            key: K,
+        struct PutArgs<Key> {
+            key: Key,
             value: Vec<u8>,
         }
 


### PR DESCRIPTION
Closes https://github.com/ava-labs/hypersdk/issues/1045

We used to require the field that is in the state key to implement `AsRef` as well as having a `len()` function. The only requirement now is to implement `BorshSerialize`.