### PR TITLE
Remove host `delete` and `put` functions

### DIFF
--- a/x/programs/runtime/import_state.go
+++ b/x/programs/runtime/import_state.go
@@ -39,40 +39,22 @@ func NewStateAccessModule() *ImportModule {
 				}
 				return val, nil
 			})},
-			"put": {FuelCost: putCost, Function: FunctionNoOutput[keyValueInput](func(callInfo *CallInfo, input keyValueInput) error {
-				ctx, cancel := context.WithCancel(context.Background())
-				defer cancel()
-				return callInfo.State.GetProgramState(callInfo.Program).Insert(ctx, input.Key, input.Value)
-			})},
-			"put_many": {FuelCost: putManyCost, Function: FunctionNoOutput[[]keyValueInput](func(callInfo *CallInfo, input []keyValueInput) error {
-				ctx, cancel := context.WithCancel(context.Background())
-				defer cancel()
-				for _, entry := range input {
-					if err := callInfo.State.GetProgramState(callInfo.Program).Insert(ctx, entry.Key, entry.Value); err != nil {
-						return err
-					}
-				}
-				return nil
-			})},
-			"delete": {FuelCost: deleteCost, Function: Function[[]byte, RawBytes](func(callInfo *CallInfo, input []byte) (RawBytes, error) {
+			"put": {FuelCost: putManyCost, Function: FunctionNoOutput[[]keyValueInput](func(callInfo *CallInfo, input []keyValueInput) error {
 				ctx, cancel := context.WithCancel(context.Background())
 				defer cancel()
 				programState := callInfo.State.GetProgramState(callInfo.Program)
-				bytes, err := programState.GetValue(ctx, input)
-				if err != nil {
-					if errors.Is(err, database.ErrNotFound) {
-						return nil, nil
+				for _, entry := range input {
+					if len(entry.Value) == 0 {
+						if err := programState.Remove(ctx, entry.Key); err != nil {
+							return err
+						}
+					} else {
+						if err := programState.Insert(ctx, entry.Key, entry.Value); err != nil {
+							return err
+						}
 					}
-
-					return nil, err
 				}
-
-				err = programState.Remove(ctx, input)
-				if err != nil {
-					return nil, err
-				}
-
-				return bytes, nil
+				return nil
 			})},
 		},
 	}

--- a/x/programs/rust/wasmlanche-sdk/src/state.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/state.rs
@@ -158,7 +158,7 @@ impl<'a, K: Key> State<'a, K> {
             key,
             value: Vec::new(),
         };
-        let args_bytes = borsh::to_vec(&[args]).map_err(|_| StateError::Serialization)?;
+        let args_bytes = borsh::to_vec(&vec![args]).map_err(|_| StateError::Serialization)?;
 
         unsafe { put(args_bytes.as_ptr(), args_bytes.len()) };
 

--- a/x/programs/rust/wasmlanche-sdk/src/state.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/state.rs
@@ -158,7 +158,8 @@ impl<'a, K: Key> State<'a, K> {
             key,
             value: Vec::new(),
         };
-        let args_bytes = borsh::to_vec(&vec![args]).map_err(|_| StateError::Serialization)?;
+        let args_bytes =
+            borsh::to_vec(&[args].as_slice()).map_err(|_| StateError::Serialization)?;
 
         unsafe { put(args_bytes.as_ptr(), args_bytes.len()) };
 

--- a/x/programs/rust/wasmlanche-sdk/src/state.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/state.rs
@@ -101,9 +101,9 @@ impl<'a, K: Key> State<'a, K> {
         let val_bytes = if let Some(val) = cache.get(&key) {
             if val.is_empty() {
                 return Ok(None);
-            } else {
-                val
             }
+
+            val
         } else {
             let args_bytes = borsh::to_vec(&key).map_err(|_| StateError::Serialization)?;
 
@@ -129,18 +129,18 @@ impl<'a, K: Key> State<'a, K> {
         #[link(wasm_import_module = "state")]
         extern "C" {
             #[link_name = "put"]
-            fn put_many_bytes(ptr: *const u8, len: usize);
-        }
-
-        let value = self.get(key)?;
-        if value.is_none() {
-            return Ok(None);
+            fn put(ptr: *const u8, len: usize);
         }
 
         #[derive(BorshSerialize)]
         struct PutArgs<Key> {
             key: Key,
             value: Vec<u8>,
+        }
+
+        let value = self.get(key)?;
+        if value.is_none() {
+            return Ok(None);
         }
 
         // TODO:
@@ -152,7 +152,7 @@ impl<'a, K: Key> State<'a, K> {
         };
         let args_bytes = borsh::to_vec(&vec![args]).map_err(|_| StateError::Serialization)?;
 
-        unsafe { put_many_bytes(args_bytes.as_ptr(), args_bytes.len()) };
+        unsafe { put(args_bytes.as_ptr(), args_bytes.len()) };
 
         Ok(value)
     }
@@ -162,7 +162,7 @@ impl<'a, K: Key> State<'a, K> {
         #[link(wasm_import_module = "state")]
         extern "C" {
             #[link_name = "put"]
-            fn put_many_bytes(ptr: *const u8, len: usize);
+            fn put(ptr: *const u8, len: usize);
         }
 
         #[derive(BorshSerialize)]
@@ -178,6 +178,6 @@ impl<'a, K: Key> State<'a, K> {
             .map(|(key, value)| PutArgs { key, value })
             .collect();
         let serialized_args = borsh::to_vec(&args).expect("failed to serialize");
-        unsafe { put_many_bytes(serialized_args.as_ptr(), serialized_args.len()) };
+        unsafe { put(serialized_args.as_ptr(), serialized_args.len()) };
     }
 }

--- a/x/programs/rust/wasmlanche-sdk/src/state.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/state.rs
@@ -70,7 +70,15 @@ impl<'a, K: Key> State<'a, K> {
     where
         V: BorshSerialize,
     {
-        let serialized = to_vec(&value).map_err(|_| StateError::Deserialization)?;
+        let serialized = to_vec(&value)
+            .map_err(|_| StateError::Deserialization)
+            .and_then(|bytes| {
+                if bytes.is_empty() {
+                    Err(StateError::InvalidByteLength(0))
+                } else {
+                    Ok(bytes)
+                }
+            })?;
         self.cache.borrow_mut().insert(key, serialized);
 
         Ok(())

--- a/x/programs/rust/wasmlanche-sdk/src/state.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/state.rs
@@ -150,7 +150,7 @@ impl<'a, K: Key> State<'a, K> {
             key,
             value: Vec::new(),
         };
-        let args_bytes = borsh::to_vec(&vec![args]).map_err(|_| StateError::Serialization)?;
+        let args_bytes = borsh::to_vec(&[args]).map_err(|_| StateError::Serialization)?;
 
         unsafe { put(args_bytes.as_ptr(), args_bytes.len()) };
 


### PR DESCRIPTION
Rename the `put_many` function to `put` and make it handle deletes if the value is empty
Addresses https://github.com/ava-labs/hypersdk/pull/1029#discussion_r1633309815