### PR TITLE
Implement cache deletes

### DIFF
--- a/x/programs/rust/wasmlanche-sdk/src/program.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/program.rs
@@ -12,7 +12,7 @@ use std::{cell::RefCell, collections::HashMap};
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub struct Program<K = ()> {
     account: Address,
-    state_cache: RefCell<HashMap<K, Vec<u8>>>,
+    state_cache: RefCell<HashMap<K, Option<Vec<u8>>>>,
 }
 
 impl<K> BorshSerialize for Program<K> {

--- a/x/programs/rust/wasmlanche-sdk/src/state.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/state.rs
@@ -130,9 +130,9 @@ impl<'a, K: Key> State<'a, K> {
         let ptr = unsafe { get_bytes(args_bytes.as_ptr(), args_bytes.len()) };
 
         if ptr.is_null() {
-            return Ok(None);
+            Ok(None)
         } else {
-            return Ok(Some(ptr.into()));
+            Ok(Some(ptr.into()))
         }
     }
 
@@ -147,9 +147,9 @@ impl<'a, K: Key> State<'a, K> {
             Some(Some(val)) => {
                 if val.is_empty() {
                     return Ok(None);
-                } else {
-                    val
                 }
+
+                val
             }
             Some(None) => return Ok(None),
             None => {

--- a/x/programs/rust/wasmlanche-sdk/src/state.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/state.rs
@@ -39,7 +39,7 @@ pub enum Error {
 }
 
 pub struct State<'a, K: Key> {
-    cache: &'a RefCell<HashMap<K, Vec<u8>>>,
+    cache: &'a RefCell<HashMap<K, Option<Vec<u8>>>>,
 }
 
 /// # Safety
@@ -57,7 +57,7 @@ impl<'a, K: Key> Drop for State<'a, K> {
 
 impl<'a, K: Key> State<'a, K> {
     #[must_use]
-    pub fn new(cache: &'a RefCell<HashMap<K, Vec<u8>>>) -> Self {
+    pub fn new(cache: &'a RefCell<HashMap<K, Option<Vec<u8>>>>) -> Self {
         Self { cache }
     }
 
@@ -79,7 +79,7 @@ impl<'a, K: Key> State<'a, K> {
                     Ok(bytes)
                 }
             })?;
-        self.cache.borrow_mut().insert(key, serialized);
+        self.cache.borrow_mut().insert(key, Some(serialized));
 
         Ok(())
     }
@@ -98,30 +98,19 @@ impl<'a, K: Key> State<'a, K> {
     where
         V: BorshDeserialize,
     {
-        #[link(wasm_import_module = "state")]
-        extern "C" {
-            #[link_name = "get"]
-            fn get_bytes(ptr: *const u8, len: usize) -> HostPtr;
-        }
-
         let mut cache = self.cache.borrow_mut();
 
-        let val_bytes = if let Some(val) = cache.get(&key) {
-            if val.is_empty() {
-                return Ok(None);
+        let val_bytes = match cache.get(&key) {
+            Some(Some(val)) => val,
+            Some(None) => return Ok(None),
+            None => {
+                if let Some(val) = Self::get_host(key)? {
+                    cache.entry(key).or_insert(Some(val)).as_ref().unwrap()
+                } else {
+                    cache.insert(key, None);
+                    return Ok(None);
+                }
             }
-
-            val
-        } else {
-            let args_bytes = borsh::to_vec(&key).map_err(|_| StateError::Serialization)?;
-
-            let ptr = unsafe { get_bytes(args_bytes.as_ptr(), args_bytes.len()) };
-
-            if ptr.is_null() {
-                return Ok(None);
-            }
-
-            cache.entry(key).or_insert(ptr.into())
         };
 
         from_slice::<V>(val_bytes)
@@ -129,41 +118,53 @@ impl<'a, K: Key> State<'a, K> {
             .map(Some)
     }
 
-    /// Delete a value from the hosts's storage.
-    /// # Errors
-    /// Returns an [Error] if the key cannot be serialized
-    /// or if the host fails to delete the key and the associated value
-    pub fn delete<T: BorshDeserialize>(self, key: K) -> Result<Option<T>, Error> {
+    fn get_host(key: K) -> Result<Option<Vec<u8>>, Error> {
         #[link(wasm_import_module = "state")]
         extern "C" {
-            #[link_name = "put"]
-            fn put(ptr: *const u8, len: usize);
+            #[link_name = "get"]
+            fn get_bytes(ptr: *const u8, len: usize) -> HostPtr;
         }
 
-        #[derive(BorshSerialize)]
-        struct PutArgs<Key> {
-            key: Key,
-            value: Vec<u8>,
-        }
+        let args_bytes = borsh::to_vec(&key).map_err(|_| StateError::Serialization)?;
 
-        let value = self.get(key)?;
-        if value.is_none() {
+        let ptr = unsafe { get_bytes(args_bytes.as_ptr(), args_bytes.len()) };
+
+        if ptr.is_null() {
             return Ok(None);
+        } else {
+            return Ok(Some(ptr.into()));
         }
+    }
 
-        // TODO:
-        // we should actually cache deletes as well
-        // to avoid cache misses after delete
-        let args = PutArgs {
-            key,
-            value: Vec::new(),
+    /// Delete a value from the hosts's storage.
+    /// # Errors
+    /// Returns an [Error] if the value is inexistent
+    /// or if the key cannot be serialized
+    /// or if the host fails to delete the key and the associated value
+    pub fn delete<V: BorshDeserialize>(self, key: K) -> Result<Option<V>, Error> {
+        let mut cache = self.cache.borrow_mut();
+        let val_bytes = match cache.get(&key) {
+            Some(Some(val)) => {
+                if val.is_empty() {
+                    return Ok(None);
+                } else {
+                    val
+                }
+            }
+            Some(None) => return Ok(None),
+            None => {
+                &if let Some(val) = Self::get_host(key)? {
+                    cache.entry(key).or_insert(Some(Vec::new()));
+                    val
+                } else {
+                    return Ok(None);
+                }
+            }
         };
-        let args_bytes =
-            borsh::to_vec(&[args].as_slice()).map_err(|_| StateError::Serialization)?;
 
-        unsafe { put(args_bytes.as_ptr(), args_bytes.len()) };
-
-        Ok(value)
+        from_slice::<V>(val_bytes)
+            .map_err(|_| StateError::Deserialization)
+            .map(Some)
     }
 
     /// Apply all pending operations to storage and mark the cache as flushed
@@ -184,7 +185,7 @@ impl<'a, K: Key> State<'a, K> {
 
         let args: Vec<_> = cache
             .drain()
-            .map(|(key, value)| PutArgs { key, value })
+            .filter_map(|(key, val)| val.map(|value| PutArgs { key, value }))
             .collect();
         let serialized_args = borsh::to_vec(&args).expect("failed to serialize");
         unsafe { put(serialized_args.as_ptr(), serialized_args.len()) };


### PR DESCRIPTION
Closes https://github.com/ava-labs/hypersdk/issues/867, Closes https://github.com/ava-labs/hypersdk/issues/868

Rewrite of https://github.com/ava-labs/hypersdk/pull/1029
Opening this in favor of https://github.com/ava-labs/hypersdk/pull/1029 to avoid to force push and rewrite all the history. Richards comments are great too so we also avoid to make the commits have no meaning.

Cache deletes were missing, they were only working for "puts". This PR also adds cache for "get".
This PR is also based on https://github.com/ava-labs/hypersdk/pull/1057 so that we have only one centralized `put` API (which used to be `put_many`) that handles deletes by writing an empty vec. Meaning that deletes are now purely managed on the guest.