### PR TITLE
Immutable context

### DIFF
--- a/x/programs/rust/examples/counter/src/lib.rs
+++ b/x/programs/rust/examples/counter/src/lib.rs
@@ -18,9 +18,9 @@ type Count = u64;
 #[public]
 pub fn inc(context: Context<StateKeys>, to: Address, amount: Count) -> bool {
     let counter = amount + get_value_internal(&context, to);
-    let Context { program, .. } = context;
 
-    program
+    context
+        .program()
         .state()
         .store(StateKeys::Counter(to), &counter)
         .expect("failed to store counter");
@@ -50,7 +50,7 @@ pub fn get_value(context: Context<StateKeys>, of: Address) -> Count {
 #[cfg(not(feature = "bindings"))]
 fn get_value_internal(context: &Context<StateKeys>, of: Address) -> Count {
     context
-        .program
+        .program()
         .state()
         .get(StateKeys::Counter(of))
         .expect("state corrupt")

--- a/x/programs/rust/examples/token/src/lib.rs
+++ b/x/programs/rust/examples/token/src/lib.rs
@@ -21,7 +21,7 @@ pub enum StateKeys {
 /// Initializes the program with a name, symbol, and total supply.
 #[public]
 pub fn init(context: Context<StateKeys>) {
-    let Context { program, .. } = context;
+    let program = context.program();
 
     // set total supply
     program
@@ -45,9 +45,8 @@ pub fn init(context: Context<StateKeys>) {
 /// Returns the total supply of the token.
 #[public]
 pub fn get_total_supply(context: Context<StateKeys>) -> u64 {
-    let Context { program, .. } = context;
-
-    program
+    context
+        .program()
         .state()
         .get(StateKeys::TotalSupply)
         .expect("failed to get total supply")
@@ -67,7 +66,7 @@ fn mint_to_internal(
     recipient: Address,
     amount: u64,
 ) -> Context<StateKeys> {
-    let program = &context.program;
+    let program = context.program();
 
     let balance = program
         .state()
@@ -86,8 +85,8 @@ fn mint_to_internal(
 /// Burn the token from the recipient.
 #[public]
 pub fn burn_from(context: Context<StateKeys>, recipient: Address) -> u64 {
-    let Context { program, .. } = context;
-    program
+    context
+        .program()
         .state()
         .delete::<u64>(StateKeys::Balance(recipient))
         .expect("failed to burn recipient tokens")
@@ -102,8 +101,9 @@ pub fn transfer(
     recipient: Address,
     amount: u64,
 ) -> bool {
-    let Context { program, .. } = context;
     assert_ne!(sender, recipient, "sender and recipient must be different");
+
+    let program = context.program();
 
     // ensure the sender has adequate balance
     let sender_balance = program
@@ -152,8 +152,8 @@ pub fn mint_to_many(context: Context<StateKeys>, minters: Vec<Minter>) -> bool {
 /// Gets the balance of the recipient.
 #[public]
 pub fn get_balance(context: Context<StateKeys>, recipient: Address) -> i64 {
-    let Context { program, .. } = context;
-    program
+    context
+        .program()
         .state()
         .get(StateKeys::Balance(recipient))
         .expect("state corrupt")

--- a/x/programs/rust/wasmlanche-sdk/src/lib.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/lib.rs
@@ -27,11 +27,33 @@ use types::Address;
 /// Representation of the context that is passed to programs at runtime.
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub struct Context<K = ()> {
-    pub program: Program<K>,
-    pub actor: Address,
-    pub height: u64,
-    pub timestamp: u64,
-    pub action_id: Id,
+    program: Program<K>,
+    actor: Address,
+    height: u64,
+    timestamp: u64,
+    action_id: Id,
+}
+
+impl<K> Context<K> {
+    pub fn program(&self) -> &Program<K> {
+        &self.program
+    }
+
+    pub fn actor(&self) -> Address {
+        self.actor
+    }
+
+    pub fn height(&self) -> u64 {
+        self.height
+    }
+
+    pub fn timestamp(&self) -> u64 {
+        self.timestamp
+    }
+
+    pub fn action_id(&self) -> Id {
+        self.action_id
+    }
 }
 
 impl<K> BorshSerialize for Context<K> {

--- a/x/programs/rust/wasmlanche-sdk/tests/public_function.rs
+++ b/x/programs/rust/wasmlanche-sdk/tests/public_function.rs
@@ -2,10 +2,7 @@ use std::{
     path::{Path, PathBuf},
     process::Command,
 };
-use wasmlanche_sdk::{
-    types::{Address, Id, ID_LEN},
-    Context, Program,
-};
+use wasmlanche_sdk::types::{Address, ID_LEN};
 use wasmtime::{Caller, Extern, Func, Instance, Module, Store, TypedFunc};
 
 const WASM_TARGET: &str = "wasm32-unknown-unknown";
@@ -123,24 +120,18 @@ impl TestCrate {
     }
 
     fn write_context(&mut self) -> AllocReturn {
-        let program_id: [u8; Address::LEN] = std::array::from_fn(|_| 1);
-        // this is a hack to create a program since the constructor is private
-        let program: Program<()> =
-            borsh::from_slice(&program_id).expect("the program should deserialize");
-
-        let action: [u8; ID_LEN] = std::array::from_fn(|_| 1);
-        let action_id: Id = borsh::from_slice(&action).expect("the action_id should deserialize");
-        let actor = Address::default();
+        let program_id = vec![1; Address::LEN];
+        let mut actor = vec![0; Address::LEN];
         let height: u64 = 0;
         let timestamp: u64 = 0;
-        let context = Context {
-            program,
-            actor,
-            height,
-            timestamp,
-            action_id,
-        };
-        let serialized_context = borsh::to_vec(&context).expect("failed to serialize context");
+        let mut action_id = vec![1; ID_LEN];
+
+        // this is a hack to create a context since the constructor is private
+        let mut serialized_context = program_id;
+        serialized_context.append(&mut actor);
+        serialized_context.append(&mut height.to_le_bytes().to_vec());
+        serialized_context.append(&mut timestamp.to_le_bytes().to_vec());
+        serialized_context.append(&mut action_id);
 
         self.allocate(serialized_context)
     }

--- a/x/programs/rust/wasmlanche-sdk/tests/test-crate/src/lib.rs
+++ b/x/programs/rust/wasmlanche-sdk/tests/test-crate/src/lib.rs
@@ -13,7 +13,7 @@ pub fn always_true(_: Context<StateKeys>) -> bool {
 #[public]
 pub fn combine_last_bit_of_each_id_byte(context: Context<StateKeys>) -> u32 {
     context
-        .program
+        .program()
         .account()
         .into_iter()
         .map(|byte| byte as u32)

--- a/x/programs/test/programs/call_program/src/lib.rs
+++ b/x/programs/test/programs/call_program/src/lib.rs
@@ -16,8 +16,7 @@ pub fn simple_call_external(_: Context, target: Program, max_units: Gas) -> i64 
 
 #[public]
 pub fn actor_check(context: Context) -> Address {
-    let Context { actor, .. } = context;
-    actor
+    context.actor()
 }
 
 #[public]

--- a/x/programs/test/programs/fuel/src/lib.rs
+++ b/x/programs/test/programs/fuel/src/lib.rs
@@ -2,6 +2,5 @@ use wasmlanche_sdk::{public, Context};
 
 #[public]
 pub fn get_fuel(ctx: Context) -> u64 {
-    let Context { program, .. } = ctx;
-    program.remaining_fuel()
+    ctx.program().remaining_fuel()
 }

--- a/x/programs/test/programs/return_complex_type/src/lib.rs
+++ b/x/programs/test/programs/return_complex_type/src/lib.rs
@@ -1,17 +1,17 @@
 use borsh::BorshSerialize;
-use wasmlanche_sdk::{public, types::Gas, Context, Program};
+use wasmlanche_sdk::{public, types::Address, types::Gas, Context};
 
 #[derive(BorshSerialize)]
 pub struct ComplexReturn {
-    program: Program,
+    account: Address,
     max_units: Gas,
 }
 
 #[public]
 pub fn get_value(ctx: Context) -> ComplexReturn {
-    let Context { program, .. } = ctx;
+    let account = *ctx.program().account();
     ComplexReturn {
-        program,
+        account,
         max_units: 1000,
     }
 }

--- a/x/programs/test/programs/state_access/src/lib.rs
+++ b/x/programs/test/programs/state_access/src/lib.rs
@@ -9,8 +9,8 @@ pub enum StateKeys {
 /// Initializes the program with a name, symbol, and total supply.
 #[public]
 pub fn put(context: Context<StateKeys>, value: i64) {
-    let Context { program, .. } = context;
-    program
+    context
+        .program()
         .state()
         .store(StateKeys::State, &value)
         .expect("failed to store state");
@@ -18,8 +18,8 @@ pub fn put(context: Context<StateKeys>, value: i64) {
 
 #[public]
 pub fn get(context: Context<StateKeys>) -> Option<i64> {
-    let Context { program, .. } = context;
-    program
+    context
+        .program()
         .state()
         .get::<i64>(StateKeys::State)
         .expect("failed to get state")
@@ -27,8 +27,8 @@ pub fn get(context: Context<StateKeys>) -> Option<i64> {
 
 #[public]
 pub fn delete(context: Context<StateKeys>) -> Option<i64> {
-    let Context { program, .. } = context;
-    program
+    context
+        .program()
         .state()
         .delete(StateKeys::State)
         .expect("failed to get state")


### PR DESCRIPTION
Closes https://github.com/ava-labs/hypersdk/issues/1046 (TODO This issue should be updated to reflect what this is fixing)

Makes fields of the `Context` struct private and instead provide accessors that takes a reference to them.