### PR TITLE
Add timestamp to context

### DIFF
--- a/x/programs/runtime/program.go
+++ b/x/programs/runtime/program.go
@@ -21,10 +21,11 @@ const (
 )
 
 type Context struct {
-	Program  codec.Address
-	Actor    codec.Address
-	Height   uint64
-	ActionID ids.ID
+	Program   codec.Address
+	Actor     codec.Address
+	Height    uint64
+	Timestamp uint64
+	ActionID  ids.ID
 }
 
 type CallInfo struct {
@@ -47,6 +48,9 @@ type CallInfo struct {
 
 	// the height of the chain that this call was made from
 	Height uint64
+
+	// the timestamp of the chain at the time this call was made
+	Timestamp uint64
 
 	// the action id that triggered this call
 	ActionID ids.ID

--- a/x/programs/rust/wasmlanche-sdk/src/lib.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/lib.rs
@@ -37,6 +37,7 @@ pub struct Context<K = ()> {
     pub program: Program<K>,
     pub actor: Address,
     pub height: u64,
+    pub timestamp: u64,
     pub action_id: Id,
 }
 
@@ -46,11 +47,13 @@ impl<K> BorshSerialize for Context<K> {
             program,
             actor,
             height,
+            timestamp,
             action_id,
         } = self;
         BorshSerialize::serialize(program, writer)?;
         BorshSerialize::serialize(actor, writer)?;
         BorshSerialize::serialize(height, writer)?;
+        BorshSerialize::serialize(timestamp, writer)?;
         BorshSerialize::serialize(action_id, writer)?;
         Ok(())
     }
@@ -58,14 +61,16 @@ impl<K> BorshSerialize for Context<K> {
 
 impl<K> BorshDeserialize for Context<K> {
     fn deserialize_reader<R: std::io::prelude::Read>(reader: &mut R) -> std::io::Result<Self> {
-        let program: Program<K> = BorshDeserialize::deserialize_reader(reader)?;
-        let actor: Address = BorshDeserialize::deserialize_reader(reader)?;
-        let height: u64 = BorshDeserialize::deserialize_reader(reader)?;
-        let action_id: Id = BorshDeserialize::deserialize_reader(reader)?;
+        let program = BorshDeserialize::deserialize_reader(reader)?;
+        let actor = BorshDeserialize::deserialize_reader(reader)?;
+        let height = BorshDeserialize::deserialize_reader(reader)?;
+        let timestamp = BorshDeserialize::deserialize_reader(reader)?;
+        let action_id = BorshDeserialize::deserialize_reader(reader)?;
         Ok(Self {
             program,
             actor,
             height,
+            timestamp,
             action_id,
         })
     }

--- a/x/programs/rust/wasmlanche-sdk/tests/public_function.rs
+++ b/x/programs/rust/wasmlanche-sdk/tests/public_function.rs
@@ -129,10 +129,12 @@ impl TestCrate {
         let action_id: Id = borsh::from_slice(&action).expect("the action_id should deserialize");
         let actor = Address::default();
         let height: u64 = 0;
+        let timestamp: u64 = 0;
         let context = Context {
             program,
             actor,
             height,
+            timestamp,
             action_id,
         };
         let serialized_context = borsh::to_vec(&context).expect("failed to serialize context");


### PR DESCRIPTION
Add a measure of time to the context that is passed to calls, similar to https://github.com/ava-labs/hypersdk/pull/1056
This is a stub for now and we probably would need to be able to alter those environment values in tests.