### PR TITLE
Unify `StatelessBlock` and `StatefulBlock`

### DIFF
--- a/chain/builder.go
+++ b/chain/builder.go
@@ -398,7 +398,7 @@ func BuildBlock(
 	if err != nil {
 		return nil, err
 	}
-	b.StateRoot = root
+	b.Root = root
 
 	// Get view from [tstate] after writing all changed keys
 	view, err := ts.ExportMerkleDBView(ctx, vm.Tracer(), parentView)

--- a/chain/builder.go
+++ b/chain/builder.go
@@ -398,7 +398,7 @@ func BuildBlock(
 	if err != nil {
 		return nil, err
 	}
-	b.Root = root
+	b.StatRoot = root
 
 	// Get view from [tstate] after writing all changed keys
 	view, err := ts.ExportMerkleDBView(ctx, vm.Tracer(), parentView)

--- a/examples/tokenvm/cmd/token-wallet/backend/backend.go
+++ b/examples/tokenvm/cmd/token-wallet/backend/backend.go
@@ -506,7 +506,7 @@ func (b *Backend) collectBlocks() {
 		bi.Size = fmt.Sprintf("%.2fKB", float64(blk.Size())/units.KiB)
 		bi.Consumed = hcli.ParseDimensions(consumed)
 		bi.Prices = hcli.ParseDimensions(prices)
-		bi.StateRoot = blk.StateRoot.String()
+		bi.StateRoot = blk.StateRoot().String()
 		bi.FailTxs = failTxs
 		bi.Txs = len(blk.Txs)
 

--- a/vm/resolutions.go
+++ b/vm/resolutions.go
@@ -116,7 +116,7 @@ func (vm *VM) Verified(ctx context.Context, b *chain.StatelessBlock) {
 			zap.Stringer("blkID", b.ID()),
 			zap.Uint64("height", b.Hght),
 			zap.Int("txs", len(b.Txs)),
-			zap.Stringer("parent root", b.StateRoot),
+			zap.Stringer("parent root", b.StateRoot()),
 			zap.Bool("state ready", vm.StateReady()),
 			zap.Any("unit prices", fm.UnitPrices()),
 			zap.Any("units consumed", fm.UnitsConsumed()),
@@ -129,7 +129,7 @@ func (vm *VM) Verified(ctx context.Context, b *chain.StatelessBlock) {
 			zap.Stringer("blkID", b.ID()),
 			zap.Uint64("height", b.Hght),
 			zap.Int("txs", len(b.Txs)),
-			zap.Stringer("parent root", b.StateRoot),
+			zap.Stringer("parent root", b.StateRoot()),
 			zap.Bool("state ready", vm.StateReady()),
 		)
 	}
@@ -285,7 +285,7 @@ func (vm *VM) Accepted(ctx context.Context, b *chain.StatelessBlock) {
 		zap.Stringer("blkID", b.ID()),
 		zap.Uint64("height", b.Hght),
 		zap.Int("txs", len(b.Txs)),
-		zap.Stringer("parent root", b.StateRoot),
+		zap.Stringer("parent root", b.StateRoot()),
 		zap.Int("size", len(b.Bytes())),
 		zap.Int("dropped mempool txs", len(removed)),
 		zap.Bool("state ready", vm.StateReady()),

--- a/vm/syncervm_client.go
+++ b/vm/syncervm_client.go
@@ -144,7 +144,7 @@ func (s *stateSyncerClient) AcceptedSyncableBlock(
 		Client:                syncClient,
 		SimultaneousWorkLimit: s.vm.config.GetStateSyncParallelism(),
 		Log:                   s.vm.snowCtx.Log,
-		TargetRoot:            sb.StateRoot,
+		TargetRoot:            sb.StateRoot(),
 	})
 	if err != nil {
 		return block.StateSyncSkipped, err
@@ -258,7 +258,7 @@ func (s *stateSyncerClient) StateReady() bool {
 // UpdateSyncTarget returns a boolean indicating if the root was
 // updated and an error if one occurred while updating the root.
 func (s *stateSyncerClient) UpdateSyncTarget(b *chain.StatelessBlock) (bool, error) {
-	err := s.syncManager.UpdateSyncTarget(b.StateRoot)
+	err := s.syncManager.UpdateSyncTarget(b.StateRoot())
 	if errors.Is(err, avasync.ErrAlreadyClosed) {
 		<-s.done          // Wait for goroutine to exit for consistent return values with IsSyncing
 		return false, nil // Sync finished before update

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -344,7 +344,7 @@ func (vm *VM) Initialize(
 		vm.preferred, vm.lastAccepted = gBlkID, genesisBlk
 		snowCtx.Log.Info("initialized vm from genesis",
 			zap.Stringer("block", gBlkID),
-			zap.Stringer("pre-execution root", genesisBlk.StateRoot),
+			zap.Stringer("pre-execution root", genesisBlk.StateRoot()),
 			zap.Stringer("post-execution root", genesisRoot),
 		)
 	}


### PR DESCRIPTION
Closes https://github.com/ava-labs/hypersdk/issues/342

Create a single `Block` interface, with `StatelessBlock` and `StatefulBlock` which implements it.
New names for `StatelessBlock` and `StatefulBlock` are TBD.