### PR TITLE
Return raw bytes from `call_function`

### DIFF
--- a/x/programs/rust/examples/counter/src/lib.rs
+++ b/x/programs/rust/examples/counter/src/lib.rs
@@ -1,6 +1,6 @@
-#[cfg(not(feature = "bindings"))]
-use wasmlanche_sdk::Context;
 use wasmlanche_sdk::{public, state_keys, types::Address, Gas, Program};
+#[cfg(not(feature = "bindings"))]
+use wasmlanche_sdk::{Context, ExternalCallError};
 
 #[state_keys]
 pub enum StateKeys {
@@ -34,7 +34,10 @@ pub fn inc_external(
     amount: Count,
 ) -> bool {
     let args = borsh::to_vec(&(of, amount)).unwrap();
-    target.call_function("inc", &args, max_units).unwrap()
+    let res = &target.call_function("inc", &args, max_units);
+    borsh::from_slice::<Result<bool, ExternalCallError>>(res)
+        .unwrap()
+        .unwrap()
 }
 
 /// Gets the count at the address.
@@ -57,7 +60,10 @@ fn get_value_internal(context: &Context<StateKeys>, of: Address) -> Count {
 #[public]
 pub fn get_value_external(_: Context, target: Program, max_units: Gas, of: Address) -> Count {
     let args = borsh::to_vec(&of).unwrap();
-    target.call_function("get_value", &args, max_units).unwrap()
+    let res = &target.call_function("get_value", &args, max_units);
+    borsh::from_slice::<Result<Count, ExternalCallError>>(res)
+        .unwrap()
+        .unwrap()
 }
 
 #[cfg(test)]

--- a/x/programs/rust/sdk-macros/src/lib.rs
+++ b/x/programs/rust/sdk-macros/src/lib.rs
@@ -198,10 +198,12 @@ pub fn public(_: TokenStream, item: TokenStream) -> TokenStream {
 
     let block = Box::new(parse_quote! {{
         let args = borsh::to_vec(&(#(#args),*)).expect("error serializing args");
-        param_0
+        let res = param_0
             .program()
-            .call_function::<#return_type>(#name, &args, param_0.max_units())
+            .call_function(#name, &args, param_0.max_units());
+        borsh::from_slice::<Result<#return_type, wasmlanche_sdk::ExternalCallError>>(&res)
             .expect("calling the external program failed")
+            .expect("failed to deserialize args")
     }});
 
     let sig = Signature {

--- a/x/programs/rust/wasmlanche-sdk/src/program.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/program.rs
@@ -64,12 +64,7 @@ impl<K> Program<K> {
     /// Will panic if the args cannot be serialized
     /// # Safety
     /// The caller must ensure that `function_name` + `args` point to valid memory locations.
-    pub fn call_function<T: BorshDeserialize>(
-        &self,
-        function_name: &str,
-        args: &[u8],
-        max_units: Gas,
-    ) -> Result<T, ExternalCallError> {
+    pub fn call_function(&self, function_name: &str, args: &[u8], max_units: Gas) -> Vec<u8> {
         #[link(wasm_import_module = "program")]
         extern "C" {
             #[link_name = "call_program"]
@@ -87,7 +82,7 @@ impl<K> Program<K> {
 
         let bytes = unsafe { call_program(args_bytes.as_ptr(), args_bytes.len()) };
 
-        borsh::from_slice(&bytes).expect("failed to deserialize")
+        bytes.into()
     }
 
     /// Gets the remaining fuel available to this program

--- a/x/programs/test/programs/call_program/src/lib.rs
+++ b/x/programs/test/programs/call_program/src/lib.rs
@@ -1,3 +1,4 @@
+use wasmlanche_sdk::ExternalCallError;
 use wasmlanche_sdk::{public, types::Address, Context, Gas, Program};
 
 #[public]
@@ -7,7 +8,10 @@ pub fn simple_call(_: Context) -> i64 {
 
 #[public]
 pub fn simple_call_external(_: Context, target: Program, max_units: Gas) -> i64 {
-    target.call_function("simple_call", &[], max_units).unwrap()
+    let res = target.call_function("simple_call", &[], max_units);
+    borsh::from_slice::<Result<_, ExternalCallError>>(&res)
+        .unwrap()
+        .unwrap()
 }
 
 #[public]
@@ -18,9 +22,10 @@ pub fn actor_check(context: Context) -> Address {
 
 #[public]
 pub fn actor_check_external(_: Context, target: Program, max_units: Gas) -> Address {
-    target
-        .call_function("actor_check", &[], max_units)
+    let res = target.call_function("actor_check", &[], max_units);
+    borsh::from_slice::<Result<_, ExternalCallError>>(&res)
         .expect("failure")
+        .unwrap()
 }
 
 #[public]
@@ -30,8 +35,9 @@ pub fn call_with_param(_: Context, value: i64) -> i64 {
 
 #[public]
 pub fn call_with_param_external(_: Context, target: Program, max_units: Gas, value: i64) -> i64 {
-    target
-        .call_function("call_with_param", &value.to_le_bytes(), max_units)
+    let res = target.call_function("call_with_param", &value.to_le_bytes(), max_units);
+    borsh::from_slice::<Result<_, ExternalCallError>>(&res)
+        .unwrap()
         .unwrap()
 }
 
@@ -48,12 +54,9 @@ pub fn call_with_two_params_external(
     value1: i64,
     value2: i64,
 ) -> i64 {
-    let args: Vec<_> = value1
-        .to_le_bytes()
-        .into_iter()
-        .chain(value2.to_le_bytes())
-        .collect();
-    target
-        .call_function("call_with_two_params", &args, max_units)
+    let args = borsh::to_vec(&(value1, value2)).unwrap();
+    let res = target.call_function("call_with_two_params", &args, max_units);
+    borsh::from_slice::<Result<_, ExternalCallError>>(&res)
+        .unwrap()
         .unwrap()
 }


### PR DESCRIPTION
This is to make `call_function` lower-level and adapt it to use-cases such as arbitrary calls for timelocks and multisigs (and more!). It's okay to do the extra borsh deserialization handling because we should encourage users to use the bindings which do that for them.