### PR TITLE
Normalize program example tests

### DIFF
--- a/x/programs/cmd/simulator/cmd/config.go
+++ b/x/programs/cmd/simulator/cmd/config.go
@@ -10,6 +10,7 @@ import (
 
 const (
 	ProgramCreate  = "program_create"
+	KeyCreate      = "key_create"
 	ProgramExecute = "execute"
 )
 

--- a/x/programs/cmd/simulator/cmd/errors.go
+++ b/x/programs/cmd/simulator/cmd/errors.go
@@ -20,6 +20,7 @@ var (
 	// Steps
 	ErrInvalidStep              = errors.New("invalid step")
 	ErrInvalidEndpoint          = errors.New("invalid endpoint")
+	ErrInvalidMethod            = errors.New("invalid method")
 	ErrInvalidParams            = errors.New("invalid params")
 	ErrConfigMissingRequired    = errors.New("missing required field")
 	ErrFirstParamRequiredString = errors.New("first param must be a string")

--- a/x/programs/cmd/simulator/cmd/plan.go
+++ b/x/programs/cmd/simulator/cmd/plan.go
@@ -121,9 +121,13 @@ func verifyEndpoint(i int, step *Step) error {
 
 	switch step.Endpoint {
 	case EndpointKey:
-		// verify the first param is a string for key name
-		if firstParamType != KeyEd25519 && firstParamType != KeySecp256k1 {
-			return fmt.Errorf("%w %d %w: expected ed25519 or secp256k1", ErrInvalidStep, i, ErrInvalidParamType)
+		if step.Method == KeyCreate {
+			// verify the first param is a string for key name
+			if firstParamType != KeyEd25519 && firstParamType != KeySecp256k1 {
+				return fmt.Errorf("%w %d %w: expected ed25519 or secp256k1", ErrInvalidStep, i, ErrInvalidParamType)
+			}
+		} else {
+			return fmt.Errorf("%w: %s", ErrInvalidMethod, step.Method)
 		}
 	case EndpointReadOnly:
 		// verify the first param is a program ID

--- a/x/programs/cmd/simulator/src/lib.rs
+++ b/x/programs/cmd/simulator/src/lib.rs
@@ -60,7 +60,7 @@ impl Step {
     pub fn create_key(key: Key) -> Self {
         Self {
             endpoint: Endpoint::Key,
-            method: "create_key".into(),
+            method: "key_create".into(),
             max_units: 0,
             params: vec![Param::Key(key)],
         }

--- a/x/programs/rust/examples/counter/src/lib.rs
+++ b/x/programs/rust/examples/counter/src/lib.rs
@@ -70,38 +70,19 @@ mod tests {
     fn init_program() {
         let mut simulator = simulator::ClientBuilder::new().try_build().unwrap();
 
-        let owner_key = String::from("owner");
-        let alice_key = Param::Key(Key::Ed25519(String::from("alice")));
+        let owner = String::from("owner");
+        let alice = String::from("alice");
 
         simulator
-            .run_step(
-                &owner_key,
-                &Step::create_key(Key::Ed25519(owner_key.clone())),
-            )
+            .run_step(&owner, &Step::create_key(Key::Ed25519(owner.clone())))
             .unwrap();
 
         simulator
-            .run_step(
-                &owner_key,
-                &Step {
-                    endpoint: Endpoint::Key,
-                    method: "key_create".into(),
-                    params: vec![alice_key.clone()],
-                    max_units: 0,
-                },
-            )
+            .run_step(&owner, &Step::create_key(Key::Ed25519(alice)))
             .unwrap();
 
         simulator
-            .run_step(
-                &owner_key,
-                &Step {
-                    endpoint: Endpoint::Execute,
-                    method: "program_create".into(),
-                    max_units: 1000000,
-                    params: vec![Param::String(PROGRAM_PATH.into())],
-                },
-            )
+            .run_step(&owner, &Step::create_program(PROGRAM_PATH))
             .unwrap();
     }
 
@@ -109,61 +90,43 @@ mod tests {
     fn increment() {
         let mut simulator = simulator::ClientBuilder::new().try_build().unwrap();
 
-        let owner_key = String::from("owner");
-        let bob_key = Param::Key(Key::Ed25519(String::from("bob")));
+        let owner = String::from("owner");
+        let bob_key = Key::Ed25519(String::from("bob"));
+        let bob_key_param = Param::Key(bob_key.clone());
 
         simulator
-            .run_step(
-                &owner_key,
-                &Step::create_key(Key::Ed25519(owner_key.clone())),
-            )
+            .run_step(&owner, &Step::create_key(Key::Ed25519(owner.clone())))
             .unwrap();
 
         simulator
-            .run_step(
-                &owner_key,
-                &Step {
-                    endpoint: Endpoint::Key,
-                    method: "key_create".into(),
-                    params: vec![bob_key.clone()],
-                    max_units: 0,
-                },
-            )
+            .run_step(&owner, &Step::create_key(bob_key))
             .unwrap();
 
         let counter_id = simulator
-            .run_step(
-                &owner_key,
-                &Step {
-                    endpoint: Endpoint::Execute,
-                    method: "program_create".into(),
-                    max_units: 1000000,
-                    params: vec![Param::String(PROGRAM_PATH.into())],
-                },
-            )
+            .run_step(&owner, &Step::create_program(PROGRAM_PATH))
             .unwrap()
             .id;
 
         simulator
             .run_step(
-                &owner_key,
+                &owner,
                 &Step {
                     endpoint: Endpoint::Execute,
                     method: "inc".into(),
                     max_units: 1000000,
-                    params: vec![counter_id.into(), bob_key.clone(), 10u64.into()],
+                    params: vec![counter_id.into(), bob_key_param.clone(), 10u64.into()],
                 },
             )
             .unwrap();
 
         let value = simulator
             .run_step(
-                &owner_key,
+                &owner,
                 &Step {
                     endpoint: Endpoint::ReadOnly,
                     method: "get_value".into(),
                     max_units: 0,
-                    params: vec![counter_id.into(), bob_key.clone()],
+                    params: vec![counter_id.into(), bob_key_param],
                 },
             )
             .unwrap()
@@ -178,7 +141,8 @@ mod tests {
         let mut simulator = simulator::ClientBuilder::new().try_build().unwrap();
 
         let owner_key = String::from("owner");
-        let bob_key = Param::Key(Key::Ed25519(String::from("bob")));
+        let bob_key = Key::Ed25519(String::from("bob"));
+        let bob_key_param = Param::Key(bob_key.clone());
 
         simulator
             .run_step(
@@ -188,40 +152,16 @@ mod tests {
             .unwrap();
 
         simulator
-            .run_step(
-                &owner_key,
-                &Step {
-                    endpoint: Endpoint::Key,
-                    method: "key_create".into(),
-                    params: vec![bob_key.clone()],
-                    max_units: 0,
-                },
-            )
+            .run_step(&owner_key, &Step::create_key(bob_key))
             .unwrap();
 
         let counter1_id = simulator
-            .run_step(
-                &owner_key,
-                &Step {
-                    endpoint: Endpoint::Execute,
-                    method: "program_create".into(),
-                    max_units: 1000000,
-                    params: vec![Param::String(PROGRAM_PATH.into())],
-                },
-            )
+            .run_step(&owner_key, &Step::create_program(PROGRAM_PATH))
             .unwrap()
             .id;
 
         let counter2_id = simulator
-            .run_step(
-                &owner_key,
-                &Step {
-                    endpoint: Endpoint::Execute,
-                    method: "program_create".into(),
-                    max_units: 1000000,
-                    params: vec![Param::String(PROGRAM_PATH.into())],
-                },
-            )
+            .run_step(&owner_key, &Step::create_program(PROGRAM_PATH))
             .unwrap()
             .id;
 
@@ -232,7 +172,7 @@ mod tests {
                     endpoint: Endpoint::ReadOnly,
                     method: "get_value".into(),
                     max_units: 0,
-                    params: vec![counter2_id.into(), bob_key.clone()],
+                    params: vec![counter2_id.into(), bob_key_param.clone()],
                 },
             )
             .unwrap()
@@ -252,7 +192,7 @@ mod tests {
                         counter1_id.into(),
                         counter2_id.into(),
                         1_000_000.into(),
-                        bob_key.clone(),
+                        bob_key_param.clone(),
                         10.into(),
                     ],
                 },
@@ -270,7 +210,7 @@ mod tests {
                         counter1_id.into(),
                         counter2_id.into(),
                         1_000_000.into(),
-                        bob_key.clone(),
+                        bob_key_param,
                     ],
                 },
             )

--- a/x/programs/rust/examples/token/src/lib.rs
+++ b/x/programs/rust/examples/token/src/lib.rs
@@ -197,15 +197,7 @@ mod tests {
             )
             .unwrap();
         let program_id = simulator
-            .run_step(
-                &owner_key,
-                &Step {
-                    endpoint: Endpoint::Execute,
-                    method: "program_create".into(),
-                    max_units: 0,
-                    params: vec![Param::String(PROGRAM_PATH.into())],
-                },
-            )
+            .run_step(&owner_key, &Step::create_program(PROGRAM_PATH))
             .unwrap()
             .id;
 
@@ -244,7 +236,8 @@ mod tests {
         let mut simulator = simulator::ClientBuilder::new().try_build().unwrap();
 
         let owner_key = String::from("owner");
-        let alice_key = Param::Key(Key::Ed25519(String::from("alice")));
+        let alice_key = Key::Ed25519(String::from("alice"));
+        let alice_key_param = Param::Key(alice_key.clone());
         let alice_initial_balance = 1000;
 
         simulator
@@ -255,28 +248,12 @@ mod tests {
             .unwrap();
 
         let program_id = simulator
-            .run_step(
-                &owner_key,
-                &Step {
-                    endpoint: Endpoint::Execute,
-                    method: "program_create".into(),
-                    max_units: 0,
-                    params: vec![Param::String(PROGRAM_PATH.into())],
-                },
-            )
+            .run_step(&owner_key, &Step::create_program(PROGRAM_PATH))
             .unwrap()
             .id;
 
         simulator
-            .run_step(
-                &owner_key,
-                &Step {
-                    endpoint: Endpoint::Key,
-                    method: "key_create".into(),
-                    params: vec![alice_key.clone()],
-                    max_units: 0,
-                },
-            )
+            .run_step(&owner_key, &Step::create_key(alice_key))
             .unwrap();
 
         simulator
@@ -299,7 +276,7 @@ mod tests {
                     method: "mint_to".into(),
                     params: vec![
                         program_id.into(),
-                        alice_key.clone(),
+                        alice_key_param.clone(),
                         Param::U64(alice_initial_balance),
                     ],
                     max_units: 1000000,
@@ -314,7 +291,7 @@ mod tests {
                     endpoint: Endpoint::ReadOnly,
                     method: "get_balance".into(),
                     max_units: 0,
-                    params: vec![program_id.into(), alice_key],
+                    params: vec![program_id.into(), alice_key_param],
                 },
             )
             .unwrap()
@@ -330,10 +307,8 @@ mod tests {
         let mut simulator = simulator::ClientBuilder::new().try_build().unwrap();
 
         let owner_key = String::from("owner");
-        let [alice_key, bob_key] = ["alice", "bob"]
-            .map(String::from)
-            .map(Key::Ed25519)
-            .map(Param::Key);
+        let [alice_key, bob_key] = ["alice", "bob"].map(String::from).map(Key::Ed25519);
+        let [alice_key_param, bob_key_param] = [alice_key.clone(), bob_key.clone()].map(Param::Key);
         let alice_initial_balance = 1000;
         let transfer_amount = 100;
         let post_transfer_balance = alice_initial_balance - transfer_amount;
@@ -346,40 +321,16 @@ mod tests {
             .unwrap();
 
         let program_id = simulator
-            .run_step(
-                &owner_key,
-                &Step {
-                    endpoint: Endpoint::Execute,
-                    method: "program_create".into(),
-                    max_units: 0,
-                    params: vec![Param::String(PROGRAM_PATH.into())],
-                },
-            )
+            .run_step(&owner_key, &Step::create_program(PROGRAM_PATH))
             .unwrap()
             .id;
 
         simulator
-            .run_step(
-                &owner_key,
-                &Step {
-                    endpoint: Endpoint::Key,
-                    method: "key_create".into(),
-                    params: vec![alice_key.clone()],
-                    max_units: 0,
-                },
-            )
+            .run_step(&owner_key, &Step::create_key(alice_key.clone()))
             .unwrap();
 
         simulator
-            .run_step(
-                &owner_key,
-                &Step {
-                    endpoint: Endpoint::Key,
-                    method: "key_create".into(),
-                    params: vec![bob_key.clone()],
-                    max_units: 0,
-                },
-            )
+            .run_step(&owner_key, &Step::create_key(bob_key.clone()))
             .unwrap();
 
         simulator
@@ -402,7 +353,7 @@ mod tests {
                     method: "mint_to".into(),
                     params: vec![
                         program_id.into(),
-                        alice_key.clone(),
+                        alice_key_param.clone(),
                         Param::U64(alice_initial_balance),
                     ],
                     max_units: 1000000,
@@ -418,8 +369,8 @@ mod tests {
                     method: "transfer".into(),
                     params: vec![
                         program_id.into(),
-                        alice_key.clone(),
-                        bob_key.clone(),
+                        alice_key_param.clone(),
+                        bob_key_param.clone(),
                         Param::U64(transfer_amount),
                     ],
                     max_units: 1000000,
@@ -450,7 +401,7 @@ mod tests {
                     endpoint: Endpoint::ReadOnly,
                     method: "get_balance".into(),
                     max_units: 0,
-                    params: vec![program_id.into(), alice_key.clone()],
+                    params: vec![program_id.into(), alice_key_param.clone()],
                 },
             )
             .unwrap()
@@ -466,7 +417,7 @@ mod tests {
                     endpoint: Endpoint::ReadOnly,
                     method: "get_balance".into(),
                     max_units: 0,
-                    params: vec![program_id.into(), bob_key],
+                    params: vec![program_id.into(), bob_key_param],
                 },
             )
             .unwrap()
@@ -481,7 +432,7 @@ mod tests {
                 &Step {
                     endpoint: Endpoint::Execute,
                     method: "burn_from".into(),
-                    params: vec![program_id.into(), alice_key.clone()],
+                    params: vec![program_id.into(), alice_key_param.clone()],
                     max_units: 1000000,
                 },
             )
@@ -498,7 +449,7 @@ mod tests {
                     endpoint: Endpoint::ReadOnly,
                     method: "get_balance".into(),
                     max_units: 0,
-                    params: vec![program_id.into(), alice_key],
+                    params: vec![program_id.into(), alice_key_param],
                 },
             )
             .unwrap()


### PR DESCRIPTION
Always use the `create_program` and `create_key` functions instead of raw steps, and also check for the method when using the `Key` endpoint to give stronger correctness guarantees regarding the simulator interaction.