### PR TITLE
Add docs and call_function example

### DIFF
--- a/x/programs/rust/examples/counter/src/lib.rs
+++ b/x/programs/rust/examples/counter/src/lib.rs
@@ -1,6 +1,10 @@
 #[cfg(not(feature = "bindings"))]
 use wasmlanche_sdk::Context;
-use wasmlanche_sdk::{public, state_keys, types::Address, Gas, Program};
+use wasmlanche_sdk::{
+    public, state_keys,
+    types::{Address, Gas},
+    Program,
+};
 
 #[state_keys]
 pub enum StateKeys {

--- a/x/programs/rust/wasmlanche-sdk/src/lib.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/lib.rs
@@ -1,6 +1,9 @@
 #![deny(clippy::pedantic)]
 
+/// State-related operations in programs.
 pub mod state;
+
+/// Program types.
 pub mod types;
 
 mod logging;
@@ -12,6 +15,7 @@ pub use self::{
     memory::HostPtr,
     program::{ExternalCallError, Program},
 };
+use crate::types::{Gas, Id};
 
 #[cfg(feature = "build")]
 pub mod build;
@@ -20,18 +24,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 pub use sdk_macros::{public, state_keys};
 use types::Address;
 
-pub const ID_LEN: usize = 32;
-pub type Id = [u8; ID_LEN];
-pub type Gas = u64;
-
-#[derive(Debug, thiserror::Error)]
-pub enum Error {
-    #[error("State error: {0}")]
-    State(#[from] state::Error),
-    #[error("Param error: {0}")]
-    Param(#[from] std::io::Error),
-}
-
+/// Representation of the context that is passed to programs at runtime.
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub struct Context<K = ()> {
     pub program: Program<K>,
@@ -76,6 +69,7 @@ impl<K> BorshDeserialize for Context<K> {
     }
 }
 
+/// Special context that is passed to external programs.
 pub struct ExternalCallContext {
     program: Program,
     max_units: Gas,

--- a/x/programs/rust/wasmlanche-sdk/src/logging.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/logging.rs
@@ -1,3 +1,4 @@
+/// Prints and returns the value of a given expression for quick and dirty debugging.
 #[macro_export]
 macro_rules! dbg {
     () => {
@@ -31,6 +32,7 @@ macro_rules! dbg {
     };
 }
 
+/// Catch panics by sending their information to the host.
 pub fn register_panic() {
     #[cfg(debug_assertions)]
     {
@@ -46,13 +48,14 @@ pub fn register_panic() {
     }
 }
 
-/// # Panics
-/// Panics if there was an issue regarding memory allocation on the host
+/// Log an arbitrary [&str] on the terminal.
 pub fn log(text: &str) {
     log_bytes(text.as_bytes());
 }
 
-/// Logging facility for debugging purposes
+/// Logging facility for debugging purposes.
+/// # Panics
+/// Panics if there was an issue regarding memory allocation on the host
 pub(super) fn log_bytes(bytes: &[u8]) {
     #[link(wasm_import_module = "log")]
     extern "C" {

--- a/x/programs/rust/wasmlanche-sdk/src/memory.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/memory.rs
@@ -11,6 +11,7 @@ thread_local! {
     static ALLOCATIONS: RefCell<HashMap<*const u8, usize>> = RefCell::new(HashMap::new());
 }
 
+/// A pointer where data points to the host.
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[repr(transparent)]
 pub struct HostPtr(*const u8);

--- a/x/programs/rust/wasmlanche-sdk/src/program.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/program.rs
@@ -8,6 +8,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use std::{cell::RefCell, collections::HashMap};
 use thiserror::Error;
 
+/// An error that is returned from call to public functions.
 #[derive(Error, Debug, BorshDeserialize)]
 #[repr(u8)]
 #[non_exhaustive]
@@ -21,7 +22,7 @@ pub enum ExternalCallError {
     OutOfFuel = 2,
 }
 
-/// Represents the current Program in the context of the caller. Or an external
+/// Represents the current Program in the context of the caller, or an external
 /// program that is being invoked.
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub struct Program<K = ()> {
@@ -64,6 +65,19 @@ impl<K> Program<K> {
     /// Will panic if the args cannot be serialized
     /// # Safety
     /// The caller must ensure that `function_name` + `args` point to valid memory locations.
+    /// # Examples
+    /// ```no_run
+    /// # use wasmlanche_sdk::{types::Address, Program};
+    ///
+    /// # let program_id = [0; Address::LEN];
+    /// # let target: Program<()> = borsh::from_slice(&program_id).expect("the program should deserialize");
+    /// let increment = 10;
+    /// let params = borsh::to_vec(&increment).expect("failed to borsh serialize params");
+    /// let max_units = 1000000;
+    /// target
+    ///     .call_function("call_with_param", &params, max_units)
+    ///     .unwrap()
+    /// ```
     pub fn call_function<T: BorshDeserialize>(
         &self,
         function_name: &str,

--- a/x/programs/rust/wasmlanche-sdk/src/program.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/program.rs
@@ -68,7 +68,7 @@ impl<K> Program<K> {
     /// # Examples
     /// ```no_run
     /// # use wasmlanche_sdk::{types::Address, Program};
-    ///
+    /// #
     /// # let program_id = [0; Address::LEN];
     /// # let target: Program<()> = borsh::from_slice(&program_id).expect("the program should deserialize");
     /// let increment = 10;

--- a/x/programs/rust/wasmlanche-sdk/src/state.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/state.rs
@@ -4,44 +4,21 @@ use std::{cell::RefCell, collections::HashMap, hash::Hash};
 
 #[derive(Clone, thiserror::Error, Debug)]
 pub enum Error {
-    #[error("an unclassified error has occurred: {0}")]
-    Other(String),
-
-    #[error("invalid byte format")]
-    InvalidBytes,
-
     #[error("invalid byte length: {0}")]
     InvalidByteLength(usize),
-
-    #[error("invalid pointer offset")]
-    InvalidPointer,
-
-    #[error("invalid tag: {0}")]
-    InvalidTag(u8),
-
-    #[error("failed to write to host storage")]
-    Write,
-
-    #[error("failed to read from host storage")]
-    Read,
 
     #[error("failed to serialize bytes")]
     Serialization,
 
     #[error("failed to deserialize bytes")]
     Deserialization,
-
-    #[error("failed to convert integer")]
-    IntegerConversion,
-
-    #[error("failed to delete from host storage")]
-    Delete,
 }
 
 pub struct State<'a, K: Key> {
     cache: &'a RefCell<HashMap<K, Option<Vec<u8>>>>,
 }
 
+/// Key trait for program state keys
 /// # Safety
 /// This trait should only be implemented using the [`state_keys`](crate::state_keys) macro.
 pub unsafe trait Key: Copy + PartialEq + Eq + Hash + BorshSerialize {}

--- a/x/programs/rust/wasmlanche-sdk/src/types.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/types.rs
@@ -1,7 +1,13 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 
-/// A struct that enforces a fixed length of 32 bytes which represents an address.
+/// Byte length of an action ID.
+pub const ID_LEN: usize = 32;
+/// Action id.
+pub type Id = [u8; ID_LEN];
+/// Gas type alias.
+pub type Gas = u64;
 
+/// A struct that enforces a fixed length of 32 bytes which represents an address.
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Clone, Copy, PartialEq, Eq, BorshSerialize, BorshDeserialize, Hash)]
 pub struct Address([u8; Self::LEN]);

--- a/x/programs/rust/wasmlanche-sdk/tests/public_function.rs
+++ b/x/programs/rust/wasmlanche-sdk/tests/public_function.rs
@@ -2,7 +2,10 @@ use std::{
     path::{Path, PathBuf},
     process::Command,
 };
-use wasmlanche_sdk::{types::Address, Context, Id, Program, ID_LEN};
+use wasmlanche_sdk::{
+    types::{Address, Id, ID_LEN},
+    Context, Program,
+};
 use wasmtime::{Caller, Extern, Func, Instance, Module, Store, TypedFunc};
 
 const WASM_TARGET: &str = "wasm32-unknown-unknown";

--- a/x/programs/test/programs/call_program/src/lib.rs
+++ b/x/programs/test/programs/call_program/src/lib.rs
@@ -1,4 +1,8 @@
-use wasmlanche_sdk::{public, types::Address, Context, Gas, Program};
+use wasmlanche_sdk::{
+    public,
+    types::{Address, Gas},
+    Context, Program,
+};
 
 #[public]
 pub fn simple_call(_: Context) -> i64 {

--- a/x/programs/test/programs/return_complex_type/src/lib.rs
+++ b/x/programs/test/programs/return_complex_type/src/lib.rs
@@ -1,5 +1,5 @@
 use borsh::BorshSerialize;
-use wasmlanche_sdk::{public, Context, Gas, Program};
+use wasmlanche_sdk::{public, types::Gas, Context, Program};
 
 #[derive(BorshSerialize)]
 pub struct ComplexReturn {


### PR DESCRIPTION
Closes https://github.com/ava-labs/hypersdk/issues/1053
Add docs for all relevant user-facing modules, functions, types, and macros.
Also add a doc test for the usage of `call_function`