### PR TITLE
Implement cache deletes and unify the host API

### DIFF
--- a/x/programs/rust/wasmlanche-sdk/src/program.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/program.rs
@@ -26,7 +26,7 @@ pub enum ExternalCallError {
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub struct Program<K = ()> {
     account: Address,
-    state_cache: RefCell<HashMap<K, Vec<u8>>>,
+    state_cache: RefCell<HashMap<K, Option<Vec<u8>>>>,
 }
 
 impl<K> BorshSerialize for Program<K> {

--- a/x/programs/rust/wasmlanche-sdk/src/state.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/state.rs
@@ -137,18 +137,18 @@ impl<'a, K: Key> State<'a, K> {
         #[link(wasm_import_module = "state")]
         extern "C" {
             #[link_name = "put"]
-            fn put_many_bytes(ptr: *const u8, len: usize);
-        }
-
-        let value = self.get(key)?;
-        if value.is_none() {
-            return Ok(None);
+            fn put(ptr: *const u8, len: usize);
         }
 
         #[derive(BorshSerialize)]
         struct PutArgs<Key> {
             key: Key,
             value: Vec<u8>,
+        }
+
+        let value = self.get(key)?;
+        if value.is_none() {
+            return Ok(None);
         }
 
         // TODO:
@@ -160,7 +160,7 @@ impl<'a, K: Key> State<'a, K> {
         };
         let args_bytes = borsh::to_vec(&vec![args]).map_err(|_| StateError::Serialization)?;
 
-        unsafe { put_many_bytes(args_bytes.as_ptr(), args_bytes.len()) };
+        unsafe { put(args_bytes.as_ptr(), args_bytes.len()) };
 
         Ok(value)
     }
@@ -170,7 +170,7 @@ impl<'a, K: Key> State<'a, K> {
         #[link(wasm_import_module = "state")]
         extern "C" {
             #[link_name = "put"]
-            fn put_many_bytes(ptr: *const u8, len: usize);
+            fn put(ptr: *const u8, len: usize);
         }
 
         #[derive(BorshSerialize)]
@@ -186,6 +186,6 @@ impl<'a, K: Key> State<'a, K> {
             .map(|(key, value)| PutArgs { key, value })
             .collect();
         let serialized_args = borsh::to_vec(&args).expect("failed to serialize");
-        unsafe { put_many_bytes(serialized_args.as_ptr(), serialized_args.len()) };
+        unsafe { put(serialized_args.as_ptr(), serialized_args.len()) };
     }
 }

--- a/x/programs/rust/wasmlanche-sdk/src/state.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/state.rs
@@ -158,7 +158,7 @@ impl<'a, K: Key> State<'a, K> {
             key,
             value: Vec::new(),
         };
-        let args_bytes = borsh::to_vec(&[args]).map_err(|_| StateError::Serialization)?;
+        let args_bytes = borsh::to_vec(&vec![args]).map_err(|_| StateError::Serialization)?;
 
         unsafe { put(args_bytes.as_ptr(), args_bytes.len()) };
 

--- a/x/programs/rust/wasmlanche-sdk/src/state.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/state.rs
@@ -158,7 +158,8 @@ impl<'a, K: Key> State<'a, K> {
             key,
             value: Vec::new(),
         };
-        let args_bytes = borsh::to_vec(&vec![args]).map_err(|_| StateError::Serialization)?;
+        let args_bytes =
+            borsh::to_vec(&[args].as_slice()).map_err(|_| StateError::Serialization)?;
 
         unsafe { put(args_bytes.as_ptr(), args_bytes.len()) };
 

--- a/x/programs/rust/wasmlanche-sdk/src/state.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/state.rs
@@ -158,7 +158,7 @@ impl<'a, K: Key> State<'a, K> {
             key,
             value: Vec::new(),
         };
-        let args_bytes = borsh::to_vec(&vec![args]).map_err(|_| StateError::Serialization)?;
+        let args_bytes = borsh::to_vec(&[args]).map_err(|_| StateError::Serialization)?;
 
         unsafe { put(args_bytes.as_ptr(), args_bytes.len()) };
 

--- a/x/programs/rust/wasmlanche-sdk/src/state.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/state.rs
@@ -39,7 +39,7 @@ pub enum Error {
 }
 
 pub struct State<'a, K: Key> {
-    cache: &'a RefCell<HashMap<K, Vec<u8>>>,
+    cache: &'a RefCell<HashMap<K, Option<Vec<u8>>>>,
 }
 
 /// # Safety
@@ -57,7 +57,7 @@ impl<'a, K: Key> Drop for State<'a, K> {
 
 impl<'a, K: Key> State<'a, K> {
     #[must_use]
-    pub fn new(cache: &'a RefCell<HashMap<K, Vec<u8>>>) -> Self {
+    pub fn new(cache: &'a RefCell<HashMap<K, Option<Vec<u8>>>>) -> Self {
         Self { cache }
     }
 
@@ -79,7 +79,7 @@ impl<'a, K: Key> State<'a, K> {
                     Ok(bytes)
                 }
             })?;
-        self.cache.borrow_mut().insert(key, serialized);
+        self.cache.borrow_mut().insert(key, Some(serialized));
 
         Ok(())
     }
@@ -98,30 +98,24 @@ impl<'a, K: Key> State<'a, K> {
     where
         V: BorshDeserialize,
     {
-        #[link(wasm_import_module = "state")]
-        extern "C" {
-            #[link_name = "get"]
-            fn get_bytes(ptr: *const u8, len: usize) -> HostPtr;
-        }
-
         let mut cache = self.cache.borrow_mut();
+        let val_bytes = match cache.get(&key) {
+            Some(Some(val)) => {
+                if val.is_empty() {
+                    return Ok(None);
+                }
 
-        let val_bytes = if let Some(val) = cache.get(&key) {
-            if val.is_empty() {
-                return Ok(None);
+                val
             }
-
-            val
-        } else {
-            let args_bytes = borsh::to_vec(&key).map_err(|_| StateError::Serialization)?;
-
-            let ptr = unsafe { get_bytes(args_bytes.as_ptr(), args_bytes.len()) };
-
-            if ptr.is_null() {
-                return Ok(None);
+            Some(None) => return Ok(None),
+            None => {
+                if let Some(val) = Self::get_host(key)? {
+                    cache.entry(key).or_insert(Some(val)).as_ref().unwrap()
+                } else {
+                    cache.insert(key, None);
+                    return Ok(None);
+                }
             }
-
-            cache.entry(key).or_insert(ptr.into())
         };
 
         from_slice::<V>(val_bytes)
@@ -129,41 +123,54 @@ impl<'a, K: Key> State<'a, K> {
             .map(Some)
     }
 
-    /// Delete a value from the hosts's storage.
-    /// # Errors
-    /// Returns an [Error] if the key cannot be serialized
-    /// or if the host fails to delete the key and the associated value
-    pub fn delete<T: BorshDeserialize>(self, key: K) -> Result<Option<T>, Error> {
+    fn get_host(key: K) -> Result<Option<Vec<u8>>, Error> {
         #[link(wasm_import_module = "state")]
         extern "C" {
-            #[link_name = "put"]
-            fn put(ptr: *const u8, len: usize);
+            #[link_name = "get"]
+            fn get_bytes(ptr: *const u8, len: usize) -> HostPtr;
         }
 
-        #[derive(BorshSerialize)]
-        struct PutArgs<Key> {
-            key: Key,
-            value: Vec<u8>,
-        }
+        let args_bytes = borsh::to_vec(&key).map_err(|_| StateError::Serialization)?;
 
-        let value = self.get(key)?;
-        if value.is_none() {
-            return Ok(None);
-        }
+        let ptr = unsafe { get_bytes(args_bytes.as_ptr(), args_bytes.len()) };
 
-        // TODO:
-        // we should actually cache deletes as well
-        // to avoid cache misses after delete
-        let args = PutArgs {
-            key,
-            value: Vec::new(),
+        if ptr.is_null() {
+            Ok(None)
+        } else {
+            Ok(Some(ptr.into()))
+        }
+    }
+
+    /// Delete a value from the hosts's storage.
+    /// # Errors
+    /// Returns an [Error] if the value is inexistent
+    /// or if the key cannot be serialized
+    /// or if the host fails to delete the key and the associated value
+    pub fn delete<V: BorshDeserialize>(self, key: K) -> Result<Option<V>, Error> {
+        let mut cache = self.cache.borrow_mut();
+        let val_bytes = match cache.get(&key) {
+            Some(Some(val)) => {
+                if val.is_empty() {
+                    cache.entry(key).or_insert(None);
+                    return Ok(None);
+                }
+
+                val
+            }
+            Some(None) => return Ok(None),
+            None => {
+                &if let Some(val) = Self::get_host(key)? {
+                    cache.entry(key).or_insert(Some(Vec::new()));
+                    val
+                } else {
+                    return Ok(None);
+                }
+            }
         };
-        let args_bytes =
-            borsh::to_vec(&[args].as_slice()).map_err(|_| StateError::Serialization)?;
 
-        unsafe { put(args_bytes.as_ptr(), args_bytes.len()) };
-
-        Ok(value)
+        from_slice::<V>(val_bytes)
+            .map_err(|_| StateError::Deserialization)
+            .map(Some)
     }
 
     /// Apply all pending operations to storage and mark the cache as flushed
@@ -184,9 +191,12 @@ impl<'a, K: Key> State<'a, K> {
 
         let args: Vec<_> = cache
             .drain()
-            .map(|(key, value)| PutArgs { key, value })
+            .filter_map(|(key, val)| val.map(|value| PutArgs { key, value }))
             .collect();
-        let serialized_args = borsh::to_vec(&args).expect("failed to serialize");
-        unsafe { put(serialized_args.as_ptr(), serialized_args.len()) };
+
+        if !args.is_empty() {
+            let serialized_args = borsh::to_vec(&args).expect("failed to serialize");
+            unsafe { put(serialized_args.as_ptr(), serialized_args.len()) };
+        }
     }
 }

--- a/x/programs/rust/wasmlanche-sdk/src/state.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/state.rs
@@ -137,18 +137,18 @@ impl<'a, K: Key> State<'a, K> {
         #[link(wasm_import_module = "state")]
         extern "C" {
             #[link_name = "put"]
-            fn put(ptr: *const u8, len: usize);
+            fn put_many_bytes(ptr: *const u8, len: usize);
+        }
+
+        let value = self.get(key)?;
+        if value.is_none() {
+            return Ok(None);
         }
 
         #[derive(BorshSerialize)]
         struct PutArgs<Key> {
             key: Key,
             value: Vec<u8>,
-        }
-
-        let value = self.get(key)?;
-        if value.is_none() {
-            return Ok(None);
         }
 
         // TODO:
@@ -158,10 +158,9 @@ impl<'a, K: Key> State<'a, K> {
             key,
             value: Vec::new(),
         };
-        let args_bytes =
-            borsh::to_vec(&[args].as_slice()).map_err(|_| StateError::Serialization)?;
+        let args_bytes = borsh::to_vec(&vec![args]).map_err(|_| StateError::Serialization)?;
 
-        unsafe { put(args_bytes.as_ptr(), args_bytes.len()) };
+        unsafe { put_many_bytes(args_bytes.as_ptr(), args_bytes.len()) };
 
         Ok(value)
     }
@@ -171,7 +170,7 @@ impl<'a, K: Key> State<'a, K> {
         #[link(wasm_import_module = "state")]
         extern "C" {
             #[link_name = "put"]
-            fn put(ptr: *const u8, len: usize);
+            fn put_many_bytes(ptr: *const u8, len: usize);
         }
 
         #[derive(BorshSerialize)]
@@ -187,6 +186,6 @@ impl<'a, K: Key> State<'a, K> {
             .map(|(key, value)| PutArgs { key, value })
             .collect();
         let serialized_args = borsh::to_vec(&args).expect("failed to serialize");
-        unsafe { put(serialized_args.as_ptr(), serialized_args.len()) };
+        unsafe { put_many_bytes(serialized_args.as_ptr(), serialized_args.len()) };
     }
 }


### PR DESCRIPTION
Followup of https://github.com/ava-labs/hypersdk/pull/1059

Centralizing of the host API so that we only have a single `put` function which manages insert, delete, and a `get` which is like previously.
Cache deletes have also been implemented at the guest level.

Closes https://github.com/ava-labs/hypersdk/issues/867, closes https://github.com/ava-labs/hypersdk/issues/868