### PR TITLE
[x/programs] Populate Program Context

### DIFF
--- a/x/programs/runtime/program.go
+++ b/x/programs/runtime/program.go
@@ -102,8 +102,11 @@ func (p *ProgramInstance) call(_ context.Context, callInfo *CallInfo) ([]byte, e
 
 	// create the program context
 	programCtx := Context{
-		Program: callInfo.Program,
-		Actor:   callInfo.Actor,
+		Program:   callInfo.Program,
+		Actor:     callInfo.Actor,
+		Height:    callInfo.Height,
+		Timestamp: callInfo.Timestamp,
+		ActionID:  callInfo.ActionID,
 	}
 	paramsBytes, err := serialize(programCtx)
 	if err != nil {


### PR DESCRIPTION
Accidentally didn't initialize the values on the Program Context during a call.