### PR TITLE
Update to avalanchego v1.11.8 and add quick update avalanchego script

### DIFF
--- a/examples/morpheusvm/go.mod
+++ b/examples/morpheusvm/go.mod
@@ -1,10 +1,10 @@
 module github.com/ava-labs/hypersdk/examples/morpheusvm
 
-go 1.21.10
+go 1.21.11
 
 require (
 	github.com/ava-labs/avalanche-network-runner v1.7.4-rc.0
-	github.com/ava-labs/avalanchego v1.11.6
+	github.com/ava-labs/avalanchego v1.11.8
 	github.com/ava-labs/hypersdk v0.0.1
 	github.com/fatih/color v1.13.0
 	github.com/onsi/ginkgo/v2 v2.13.1
@@ -19,7 +19,7 @@ require (
 	github.com/DataDog/zstd v1.5.2 // indirect
 	github.com/NYTimes/gziphandler v1.1.1 // indirect
 	github.com/VictoriaMetrics/fastcache v1.12.1 // indirect
-	github.com/ava-labs/coreth v0.13.4-rc.0 // indirect
+	github.com/ava-labs/coreth v0.13.5-rc.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bits-and-blooms/bitset v1.10.0 // indirect
 	github.com/btcsuite/btcd/btcec/v2 v2.3.2 // indirect

--- a/examples/morpheusvm/go.sum
+++ b/examples/morpheusvm/go.sum
@@ -60,12 +60,9 @@ github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/ava-labs/avalanche-network-runner v1.7.4-rc.0 h1:xNbCMNqenaDr0bb35j27sqwa+C8t8BgRz51vXd6q0QM=
 github.com/ava-labs/avalanche-network-runner v1.7.4-rc.0/go.mod h1:B7Ynk/avkCk49CCIWbM4j1UrPlqIi0IHCPAB2MZNvLw=
-github.com/ava-labs/avalanchego v1.11.6 h1:gPWNQSV+bY3XW9OhfJ4wNwxp/qidTSHA4V+VYP8kWpQ=
-github.com/ava-labs/avalanchego v1.11.6/go.mod h1:s8U9tOakcU6ftSL4JcRcFrNNYI5JbekNCjTkdqZWYdE=
 github.com/ava-labs/avalanchego v1.11.8 h1:Q/der5bC/q3BQbIqxT7nNC0F30c+6X1G/eQzzMQ2CLk=
 github.com/ava-labs/avalanchego v1.11.8/go.mod h1:aPYTETkM0KjtC7vFwPO6S8z2L0QTKaXjVUi98pTdNO4=
-github.com/ava-labs/coreth v0.13.4-rc.0 h1:UU7SOlLVeviT59Y+FyDyrdt0Wvl+SOj0EyET8ZtH1ZY=
-github.com/ava-labs/coreth v0.13.4-rc.0/go.mod h1:mP1QRzaQKq+y+bqyx3xMR3/K/+TpjHbPJi+revI6Y38=
+github.com/ava-labs/coreth v0.13.5-rc.0 h1:PJQbR9o2RrW3j9ba4r1glXnmM2PNAP3xR569+gMcBd0=
 github.com/ava-labs/coreth v0.13.5-rc.0/go.mod h1:cm5c12xo5NiTgtbmeduv8i2nYdzgkczz9Wm3yiwwTRU=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/examples/morpheusvm/go.sum
+++ b/examples/morpheusvm/go.sum
@@ -62,8 +62,11 @@ github.com/ava-labs/avalanche-network-runner v1.7.4-rc.0 h1:xNbCMNqenaDr0bb35j27
 github.com/ava-labs/avalanche-network-runner v1.7.4-rc.0/go.mod h1:B7Ynk/avkCk49CCIWbM4j1UrPlqIi0IHCPAB2MZNvLw=
 github.com/ava-labs/avalanchego v1.11.6 h1:gPWNQSV+bY3XW9OhfJ4wNwxp/qidTSHA4V+VYP8kWpQ=
 github.com/ava-labs/avalanchego v1.11.6/go.mod h1:s8U9tOakcU6ftSL4JcRcFrNNYI5JbekNCjTkdqZWYdE=
+github.com/ava-labs/avalanchego v1.11.8 h1:Q/der5bC/q3BQbIqxT7nNC0F30c+6X1G/eQzzMQ2CLk=
+github.com/ava-labs/avalanchego v1.11.8/go.mod h1:aPYTETkM0KjtC7vFwPO6S8z2L0QTKaXjVUi98pTdNO4=
 github.com/ava-labs/coreth v0.13.4-rc.0 h1:UU7SOlLVeviT59Y+FyDyrdt0Wvl+SOj0EyET8ZtH1ZY=
 github.com/ava-labs/coreth v0.13.4-rc.0/go.mod h1:mP1QRzaQKq+y+bqyx3xMR3/K/+TpjHbPJi+revI6Y38=
+github.com/ava-labs/coreth v0.13.5-rc.0/go.mod h1:cm5c12xo5NiTgtbmeduv8i2nYdzgkczz9Wm3yiwwTRU=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=

--- a/examples/morpheusvm/scripts/run.sh
+++ b/examples/morpheusvm/scripts/run.sh
@@ -199,7 +199,7 @@ ACK_GINKGO_RC=true ginkgo build ./tests/e2e
 # download avalanche-network-runner
 # https://github.com/ava-labs/avalanche-network-runner
 ANR_REPO_PATH=github.com/ava-labs/avalanche-network-runner
-ANR_VERSION=v1.8.0
+ANR_VERSION=80d33ed0b7b977c4154910c999ce07640fdefb0e
 # version set
 go install -v "${ANR_REPO_PATH}"@"${ANR_VERSION}"
 

--- a/examples/morpheusvm/scripts/run.sh
+++ b/examples/morpheusvm/scripts/run.sh
@@ -17,7 +17,7 @@ if ! [[ "$0" =~ scripts/run.sh ]]; then
   exit 255
 fi
 
-VERSION=v1.11.6
+VERSION=v1.11.8
 MAX_UINT64=18446744073709551615
 MODE=${MODE:-run}
 LOG_LEVEL=${LOG_LEVEL:-INFO}

--- a/examples/morpheusvm/scripts/run.sh
+++ b/examples/morpheusvm/scripts/run.sh
@@ -199,7 +199,7 @@ ACK_GINKGO_RC=true ginkgo build ./tests/e2e
 # download avalanche-network-runner
 # https://github.com/ava-labs/avalanche-network-runner
 ANR_REPO_PATH=github.com/ava-labs/avalanche-network-runner
-ANR_VERSION=80d33ed0b7b977c4154910c999ce07640fdefb0e
+ANR_VERSION=v1.8.1
 # version set
 go install -v "${ANR_REPO_PATH}"@"${ANR_VERSION}"
 

--- a/examples/morpheusvm/tests/integration/integration_test.go
+++ b/examples/morpheusvm/tests/integration/integration_test.go
@@ -205,7 +205,7 @@ var _ = ginkgo.BeforeSuite(func() {
 			NodeID:         nodeID,
 			Log:            l,
 			ChainDataDir:   dname,
-			Metrics:        metrics.NewOptionalGatherer(),
+			Metrics:        metrics.NewPrefixGatherer(),
 			PublicKey:      bls.PublicFromSecretKey(sk),
 			ValidatorState: &validators.TestState{},
 		}

--- a/examples/tokenvm/go.mod
+++ b/examples/tokenvm/go.mod
@@ -1,10 +1,10 @@
 module github.com/ava-labs/hypersdk/examples/tokenvm
 
-go 1.21.10
+go 1.21.11
 
 require (
 	github.com/ava-labs/avalanche-network-runner v1.7.4-rc.0
-	github.com/ava-labs/avalanchego v1.11.6
+	github.com/ava-labs/avalanchego v1.11.8
 	github.com/ava-labs/hypersdk v0.0.1
 	github.com/fatih/color v1.13.0
 	github.com/onsi/ginkgo/v2 v2.13.1
@@ -21,7 +21,7 @@ require (
 	github.com/DataDog/zstd v1.5.2 // indirect
 	github.com/NYTimes/gziphandler v1.1.1 // indirect
 	github.com/VictoriaMetrics/fastcache v1.12.1 // indirect
-	github.com/ava-labs/coreth v0.13.4-rc.0 // indirect
+	github.com/ava-labs/coreth v0.13.5-rc.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bep/debounce v1.2.1 // indirect
 	github.com/bits-and-blooms/bitset v1.10.0 // indirect

--- a/examples/tokenvm/go.sum
+++ b/examples/tokenvm/go.sum
@@ -60,12 +60,9 @@ github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/ava-labs/avalanche-network-runner v1.7.4-rc.0 h1:xNbCMNqenaDr0bb35j27sqwa+C8t8BgRz51vXd6q0QM=
 github.com/ava-labs/avalanche-network-runner v1.7.4-rc.0/go.mod h1:B7Ynk/avkCk49CCIWbM4j1UrPlqIi0IHCPAB2MZNvLw=
-github.com/ava-labs/avalanchego v1.11.6 h1:gPWNQSV+bY3XW9OhfJ4wNwxp/qidTSHA4V+VYP8kWpQ=
-github.com/ava-labs/avalanchego v1.11.6/go.mod h1:s8U9tOakcU6ftSL4JcRcFrNNYI5JbekNCjTkdqZWYdE=
 github.com/ava-labs/avalanchego v1.11.8 h1:Q/der5bC/q3BQbIqxT7nNC0F30c+6X1G/eQzzMQ2CLk=
 github.com/ava-labs/avalanchego v1.11.8/go.mod h1:aPYTETkM0KjtC7vFwPO6S8z2L0QTKaXjVUi98pTdNO4=
-github.com/ava-labs/coreth v0.13.4-rc.0 h1:UU7SOlLVeviT59Y+FyDyrdt0Wvl+SOj0EyET8ZtH1ZY=
-github.com/ava-labs/coreth v0.13.4-rc.0/go.mod h1:mP1QRzaQKq+y+bqyx3xMR3/K/+TpjHbPJi+revI6Y38=
+github.com/ava-labs/coreth v0.13.5-rc.0 h1:PJQbR9o2RrW3j9ba4r1glXnmM2PNAP3xR569+gMcBd0=
 github.com/ava-labs/coreth v0.13.5-rc.0/go.mod h1:cm5c12xo5NiTgtbmeduv8i2nYdzgkczz9Wm3yiwwTRU=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/examples/tokenvm/go.sum
+++ b/examples/tokenvm/go.sum
@@ -62,8 +62,11 @@ github.com/ava-labs/avalanche-network-runner v1.7.4-rc.0 h1:xNbCMNqenaDr0bb35j27
 github.com/ava-labs/avalanche-network-runner v1.7.4-rc.0/go.mod h1:B7Ynk/avkCk49CCIWbM4j1UrPlqIi0IHCPAB2MZNvLw=
 github.com/ava-labs/avalanchego v1.11.6 h1:gPWNQSV+bY3XW9OhfJ4wNwxp/qidTSHA4V+VYP8kWpQ=
 github.com/ava-labs/avalanchego v1.11.6/go.mod h1:s8U9tOakcU6ftSL4JcRcFrNNYI5JbekNCjTkdqZWYdE=
+github.com/ava-labs/avalanchego v1.11.8 h1:Q/der5bC/q3BQbIqxT7nNC0F30c+6X1G/eQzzMQ2CLk=
+github.com/ava-labs/avalanchego v1.11.8/go.mod h1:aPYTETkM0KjtC7vFwPO6S8z2L0QTKaXjVUi98pTdNO4=
 github.com/ava-labs/coreth v0.13.4-rc.0 h1:UU7SOlLVeviT59Y+FyDyrdt0Wvl+SOj0EyET8ZtH1ZY=
 github.com/ava-labs/coreth v0.13.4-rc.0/go.mod h1:mP1QRzaQKq+y+bqyx3xMR3/K/+TpjHbPJi+revI6Y38=
+github.com/ava-labs/coreth v0.13.5-rc.0/go.mod h1:cm5c12xo5NiTgtbmeduv8i2nYdzgkczz9Wm3yiwwTRU=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=

--- a/examples/tokenvm/scripts/run.sh
+++ b/examples/tokenvm/scripts/run.sh
@@ -205,7 +205,7 @@ ACK_GINKGO_RC=true ginkgo build ./tests/e2e
 # download avalanche-network-runner
 # https://github.com/ava-labs/avalanche-network-runner
 ANR_REPO_PATH=github.com/ava-labs/avalanche-network-runner
-ANR_VERSION=v1.8.0
+ANR_VERSION=80d33ed0b7b977c4154910c999ce07640fdefb0e
 # version set
 go install -v "${ANR_REPO_PATH}"@"${ANR_VERSION}"
 

--- a/examples/tokenvm/scripts/run.sh
+++ b/examples/tokenvm/scripts/run.sh
@@ -205,7 +205,7 @@ ACK_GINKGO_RC=true ginkgo build ./tests/e2e
 # download avalanche-network-runner
 # https://github.com/ava-labs/avalanche-network-runner
 ANR_REPO_PATH=github.com/ava-labs/avalanche-network-runner
-ANR_VERSION=80d33ed0b7b977c4154910c999ce07640fdefb0e
+ANR_VERSION=v1.8.1
 # version set
 go install -v "${ANR_REPO_PATH}"@"${ANR_VERSION}"
 

--- a/examples/tokenvm/scripts/run.sh
+++ b/examples/tokenvm/scripts/run.sh
@@ -17,7 +17,7 @@ if ! [[ "$0" =~ scripts/run.sh ]]; then
   exit 255
 fi
 
-VERSION=v1.11.6
+VERSION=v1.11.8
 MAX_UINT64=18446744073709551615
 MODE=${MODE:-run}
 LOG_LEVEL=${LOG_LEVEL:-INFO}

--- a/examples/tokenvm/tests/integration/integration_test.go
+++ b/examples/tokenvm/tests/integration/integration_test.go
@@ -226,7 +226,7 @@ var _ = ginkgo.BeforeSuite(func() {
 			NodeID:         nodeID,
 			Log:            l,
 			ChainDataDir:   dname,
-			Metrics:        metrics.NewOptionalGatherer(),
+			Metrics:        metrics.NewPrefixGatherer(),
 			PublicKey:      bls.PublicFromSecretKey(sk),
 			ValidatorState: &validators.TestState{},
 		}

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,12 @@
 module github.com/ava-labs/hypersdk
 
-go 1.21.10
+go 1.21.11
 
 require (
 	github.com/NYTimes/gziphandler v1.1.1
 	github.com/akamensky/argparse v1.4.0
 	github.com/ava-labs/avalanche-network-runner v1.7.4-rc.0
-	github.com/ava-labs/avalanchego v1.11.6
+	github.com/ava-labs/avalanchego v1.11.8
 	github.com/btcsuite/btcd/btcutil v1.1.3
 	github.com/bytecodealliance/wasmtime-go/v14 v14.0.0
 	github.com/cockroachdb/pebble v0.0.0-20230928194634-aa077af62593
@@ -84,7 +84,6 @@ require (
 	golang.org/x/sys v0.18.0 // indirect
 	golang.org/x/term v0.18.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
-	golang.org/x/tools v0.17.0 // indirect
 	gonum.org/v1/gonum v0.11.0 // indirect
 	google.golang.org/genproto v0.0.0-20240123012728-ef4313101c80 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240123012728-ef4313101c80 // indirect

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,8 @@ github.com/akamensky/argparse v1.4.0/go.mod h1:S5kwC7IuDcEr5VeXtGPRVZ5o/FdhcMlQz
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/ava-labs/avalanche-network-runner v1.7.4-rc.0 h1:xNbCMNqenaDr0bb35j27sqwa+C8t8BgRz51vXd6q0QM=
 github.com/ava-labs/avalanche-network-runner v1.7.4-rc.0/go.mod h1:B7Ynk/avkCk49CCIWbM4j1UrPlqIi0IHCPAB2MZNvLw=
-github.com/ava-labs/avalanchego v1.11.6 h1:gPWNQSV+bY3XW9OhfJ4wNwxp/qidTSHA4V+VYP8kWpQ=
-github.com/ava-labs/avalanchego v1.11.6/go.mod h1:s8U9tOakcU6ftSL4JcRcFrNNYI5JbekNCjTkdqZWYdE=
+github.com/ava-labs/avalanchego v1.11.8 h1:Q/der5bC/q3BQbIqxT7nNC0F30c+6X1G/eQzzMQ2CLk=
+github.com/ava-labs/avalanchego v1.11.8/go.mod h1:aPYTETkM0KjtC7vFwPO6S8z2L0QTKaXjVUi98pTdNO4=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=

--- a/pebble/metrics.go
+++ b/pebble/metrics.go
@@ -36,8 +36,7 @@ type metrics struct {
 func newMetrics() (*prometheus.Registry, *metrics, error) {
 	r := prometheus.NewRegistry()
 	writeStall, err := metric.NewAverager(
-		"pebble",
-		"write_stall",
+		"pebble_write_stall",
 		"time spent waiting for disk write",
 		r,
 	)
@@ -45,8 +44,7 @@ func newMetrics() (*prometheus.Registry, *metrics, error) {
 		return nil, nil, err
 	}
 	getLatency, err := metric.NewAverager(
-		"pebble",
-		"read_latency",
+		"pebble_read_latency",
 		"time spent waiting for db get",
 		r,
 	)

--- a/scripts/update_avalanchego_version.sh
+++ b/scripts/update_avalanchego_version.sh
@@ -37,7 +37,7 @@ update_avalanchego_mod_version() {
     local version=$2
 
     # Set the working directory to the provided path and update the AvalancheGo dependency
-    (cd "$path" && go get "github.com/ava-labs/avalanchego@v$version")
+    (cd "$path" && go get "github.com/ava-labs/avalanchego@v$version" && go mod tidy)
 }
 
 # Function to update the version in the format "VERSION=vXX.XX.XX" in the provided file

--- a/scripts/update_avalanchego_version.sh
+++ b/scripts/update_avalanchego_version.sh
@@ -21,7 +21,7 @@ update_avalanchego_mod_version() {
     local version=$2
 
     # Set the working directory to the provided path and update the AvalancheGo dependency
-    (cd "$path" && go get "github.com/ava-labs/avalanchego@v$version")
+    (cd "$path" && go get "github.com/ava-labs/avalanchego@v$version && go mod tidy")
 }
 
 # Funciont to update the version in the format "VERSION=vXX.XX.XX" in the provided file

--- a/scripts/update_avalanchego_version.sh
+++ b/scripts/update_avalanchego_version.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
+# See the file LICENSE for licensing terms.
+
+# Check if a version argument is provided
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <version>"
+    exit 1
+fi
+
+if ! [[ "$0" =~ scripts/update_avalanchego_version.sh ]]; then
+  echo "must be run from repository root"
+  exit 255
+fi
+
+VERSION=$1
+
+# Function to update version in go.mod and run go get
+update_avalanchego_mod_version() {
+    local path=$1
+    local version=$2
+
+    # Set the working directory to the provided path and update the AvalancheGo dependency
+    (cd "$path" && go get "github.com/ava-labs/avalanchego@v$version")
+}
+
+# Funciont to update the version in the format "VERSION=vXX.XX.XX" in the provided file
+# Intended to run on the given run.sh files for each example VM.
+update_avalanchego_run_version() {
+    local file_path=$1
+    local version=$2
+
+    # Use sed to find and replace the version in the file
+    # macOS requires an empty string after -i, but this may not work on Linux
+    sed -i '' "s/^VERSION=v[0-9]*\.[0-9]*\.[0-9]*/VERSION=v$version/" "$file_path"
+}
+
+PWD=$(PWD)
+# Update version in the root directory
+update_avalanchego_mod_version "$PWD" "$VERSION"
+
+# Update AvalancheGo version in examples/morpheusvm
+update_avalanchego_mod_version "$PWD/examples/morpheusvm" "$VERSION"
+update_avalanchego_run_version "$PWD/examples/morpheusvm/scripts/run.sh" "$VERSION"
+
+# Update AvalancheGo version in examples/tokenvm
+update_avalanchego_mod_version "$PWD/examples/tokenvm" "$VERSION"
+update_avalanchego_run_version "$PWD/examples/tokenvm/scripts/run.sh" "$VERSION"  

--- a/scripts/update_avalanchego_version.sh
+++ b/scripts/update_avalanchego_version.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
-# Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
+# Copyright (C) 2024, Ava Labs, Inc. All rights reserved.
 # See the file LICENSE for licensing terms.
+
+set -euo pipefail
 
 # Check if a version argument is provided
 if [ "$#" -ne 1 ]; then
@@ -13,6 +15,20 @@ if ! [[ "$0" =~ scripts/update_avalanchego_version.sh ]]; then
   exit 255
 fi
 
+# Function to validate that the first argument matches the XX.XX.XX format
+validate_version_format() {
+    local version=$1
+
+    # Regular expression to match the XX.XX.XX format
+    local regex="^[0-9]+\.[0-9]+\.[0-9]+$"
+
+    if ! [[ $version =~ $regex ]]; then
+        echo "Error: Version must be in XX.XX.XX format."
+        exit 1
+    fi
+}
+
+validate_version_format "$1"
 VERSION=$1
 
 # Function to update version in go.mod and run go get
@@ -21,10 +37,10 @@ update_avalanchego_mod_version() {
     local version=$2
 
     # Set the working directory to the provided path and update the AvalancheGo dependency
-    (cd "$path" && go get "github.com/ava-labs/avalanchego@v$version && go mod tidy")
+    (cd "$path" && go get "github.com/ava-labs/avalanchego@v$version")
 }
 
-# Funciont to update the version in the format "VERSION=vXX.XX.XX" in the provided file
+# Funcion to update the version in the format "VERSION=vXX.XX.XX" in the provided file
 # Intended to run on the given run.sh files for each example VM.
 update_avalanchego_run_version() {
     local file_path=$1
@@ -35,7 +51,6 @@ update_avalanchego_run_version() {
     sed -i '' "s/^VERSION=v[0-9]*\.[0-9]*\.[0-9]*/VERSION=v$version/" "$file_path"
 }
 
-PWD=$(PWD)
 # Update version in the root directory
 update_avalanchego_mod_version "$PWD" "$VERSION"
 

--- a/scripts/update_avalanchego_version.sh
+++ b/scripts/update_avalanchego_version.sh
@@ -40,7 +40,7 @@ update_avalanchego_mod_version() {
     (cd "$path" && go get "github.com/ava-labs/avalanchego@v$version")
 }
 
-# Funcion to update the version in the format "VERSION=vXX.XX.XX" in the provided file
+# Function to update the version in the format "VERSION=vXX.XX.XX" in the provided file
 # Intended to run on the given run.sh files for each example VM.
 update_avalanchego_run_version() {
     local file_path=$1

--- a/vm/metrics.go
+++ b/vm/metrics.go
@@ -66,8 +66,7 @@ func newMetrics() (*prometheus.Registry, *Metrics, error) {
 	r := prometheus.NewRegistry()
 
 	rootCalculated, err := metric.NewAverager(
-		"chain",
-		"root_calculated",
+		"chain_root_calculated",
 		"time spent calculating the state root in verify",
 		r,
 	)
@@ -75,8 +74,7 @@ func newMetrics() (*prometheus.Registry, *Metrics, error) {
 		return nil, nil, err
 	}
 	waitRoot, err := metric.NewAverager(
-		"chain",
-		"wait_root",
+		"chain_wait_root",
 		"time spent waiting for root calculation in verify",
 		r,
 	)
@@ -84,8 +82,7 @@ func newMetrics() (*prometheus.Registry, *Metrics, error) {
 		return nil, nil, err
 	}
 	waitSignatures, err := metric.NewAverager(
-		"chain",
-		"wait_signatures",
+		"chain_wait_signatures",
 		"time spent waiting for signature verification in verify",
 		r,
 	)
@@ -93,8 +90,7 @@ func newMetrics() (*prometheus.Registry, *Metrics, error) {
 		return nil, nil, err
 	}
 	blockBuild, err := metric.NewAverager(
-		"chain",
-		"block_build",
+		"chain_block_build",
 		"time spent building blocks",
 		r,
 	)
@@ -102,8 +98,7 @@ func newMetrics() (*prometheus.Registry, *Metrics, error) {
 		return nil, nil, err
 	}
 	blockParse, err := metric.NewAverager(
-		"chain",
-		"block_parse",
+		"chain_block_parse",
 		"time spent parsing blocks",
 		r,
 	)
@@ -111,8 +106,7 @@ func newMetrics() (*prometheus.Registry, *Metrics, error) {
 		return nil, nil, err
 	}
 	blockVerify, err := metric.NewAverager(
-		"chain",
-		"block_verify",
+		"chain_block_verify",
 		"time spent verifying blocks",
 		r,
 	)
@@ -120,8 +114,7 @@ func newMetrics() (*prometheus.Registry, *Metrics, error) {
 		return nil, nil, err
 	}
 	blockAccept, err := metric.NewAverager(
-		"chain",
-		"block_accept",
+		"chain_block_accept",
 		"time spent accepting blocks",
 		r,
 	)
@@ -129,8 +122,7 @@ func newMetrics() (*prometheus.Registry, *Metrics, error) {
 		return nil, nil, err
 	}
 	blockProcess, err := metric.NewAverager(
-		"chain",
-		"block_process",
+		"chain_block_process",
 		"time spent processing blocks",
 		r,
 	)

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -147,8 +147,8 @@ func (vm *VM) Initialize(
 	vm.seenValidityWindow = make(chan struct{})
 	vm.ready = make(chan struct{})
 	vm.stop = make(chan struct{})
-	gatherer := avametrics.NewMultiGatherer()
-	if err := vm.snowCtx.Metrics.Register(gatherer); err != nil {
+	gatherer := avametrics.NewPrefixGatherer()
+	if err := vm.snowCtx.Metrics.Register("", gatherer); err != nil {
 		return err
 	}
 	defaultRegistry, metrics, err := newMetrics()

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -147,6 +147,7 @@ func (vm *VM) Initialize(
 	vm.seenValidityWindow = make(chan struct{})
 	vm.ready = make(chan struct{})
 	vm.stop = make(chan struct{})
+	// TODO: cleanup metrics registration
 	gatherer := avametrics.NewPrefixGatherer()
 	if err := vm.snowCtx.Metrics.Register("", gatherer); err != nil {
 		return err

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -42,7 +42,7 @@ func TestBlockCache(t *testing.T) {
 	bByHeight, _ := cache.NewFIFO[uint64, ids.ID](3)
 	controller := NewMockController(ctrl)
 	vm := VM{
-		snowCtx: &snow.Context{Log: logging.NoLog{}, Metrics: metrics.NewOptionalGatherer()},
+		snowCtx: &snow.Context{Log: logging.NoLog{}, Metrics: metrics.NewPrefixGatherer()},
 		config:  &config.Config{},
 
 		vmDB: memdb.New(),
@@ -59,12 +59,12 @@ func TestBlockCache(t *testing.T) {
 	}
 
 	// Init metrics (called in [Accepted])
-	gatherer := metrics.NewMultiGatherer()
+	gatherer := metrics.NewPrefixGatherer()
 	reg, m, err := newMetrics()
 	require.NoError(err)
 	vm.metrics = m
 	require.NoError(gatherer.Register("hypersdk", reg))
-	require.NoError(vm.snowCtx.Metrics.Register(gatherer))
+	require.NoError(vm.snowCtx.Metrics.Register("", gatherer))
 
 	// put the block into the cache "vm.blocks"
 	// and delete from "vm.verifiedBlocks"


### PR DESCRIPTION
This PR updates the AvalancheGo dependency from v1.11.6 to v1.11.8.

This also adds a convenient bash script to update the AvalancheGo version as it's specified in the dependencies for HyperSDK, TokenVM, and MorpheusVM's go.mod file as well as in the run script of both TokenVM and MorpheusVM.

A future improvement would be to set this in one location as opposed to using a helper to handle the fact it's set in multiple.