### PR TITLE
[x/program] Add Program cache back to runtime

### DIFF
--- a/x/programs/README.md
+++ b/x/programs/README.md
@@ -20,3 +20,9 @@ functionality of a HyperSDK VM without the need to change its code.
 - Execution - See the test examples defined in the `examples/` directory.
 
 - Building - Checkout the `rust/` directory examples of programs written in Rust.
+
+
+
+#### Assumptions
+
+A program ID maps uniquely and permanently to the same []byte.

--- a/x/programs/runtime/config.go
+++ b/x/programs/runtime/config.go
@@ -25,6 +25,7 @@ var (
 	DefaultProfilingStrategy    = wasmtime.ProfilingStrategyNone
 	DefaultMultiValue           = false
 
+	defaultProgramCacheSize             = 10 * units.MiB
 	defaultWasmThreads                  = false
 	defaultFuelMetering                 = true
 	defaultWasmMultiMemory              = false
@@ -40,7 +41,8 @@ var (
 // NewConfig creates a new engine config with default settings
 func NewConfig() *Config {
 	return &Config{
-		wasmConfig: DefaultWasmtimeConfig(),
+		wasmConfig:       DefaultWasmtimeConfig(),
+		ProgramCacheSize: defaultProgramCacheSize,
 	}
 }
 
@@ -50,6 +52,8 @@ type Config struct {
 
 	// CompileStrategy helps the engine to understand if the files has been precompiled.
 	CompileStrategy CompileStrategy `json:"compileStrategy,omitempty" yaml:"compile_strategy,omitempty"`
+
+	ProgramCacheSize int
 }
 
 // Get returns the underlying wasmtime config.

--- a/x/programs/runtime/runtime.go
+++ b/x/programs/runtime/runtime.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ava-labs/avalanchego/cache"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/logging"
-	"github.com/ava-labs/avalanchego/utils/units"
 	"github.com/bytecodealliance/wasmtime-go/v14"
 
 	"github.com/ava-labs/hypersdk/codec"
@@ -53,7 +52,7 @@ func NewRuntime(
 		hostImports:               NewImports(),
 		callerInfo:                map[uintptr]*CallInfo{},
 		linkerNeedsInitialization: true,
-		programCache: cache.NewSizedLRU(units.GiB, func(id ids.ID, mod *wasmtime.Module) int {
+		programCache: cache.NewSizedLRU(cfg.ProgramCacheSize, func(id ids.ID, mod *wasmtime.Module) int {
 			bytes, err := mod.Serialize()
 			if err != nil {
 				panic(err)

--- a/x/programs/runtime/runtime.go
+++ b/x/programs/runtime/runtime.go
@@ -5,12 +5,12 @@ package runtime
 
 import (
 	"context"
-	"github.com/ava-labs/avalanchego/cache"
-	"github.com/ava-labs/avalanchego/utils/units"
 	"reflect"
 
+	"github.com/ava-labs/avalanchego/cache"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/logging"
+	"github.com/ava-labs/avalanchego/utils/units"
 	"github.com/bytecodealliance/wasmtime-go/v14"
 
 	"github.com/ava-labs/hypersdk/codec"
@@ -96,6 +96,9 @@ func (r *WasmRuntime) CallProgram(ctx context.Context, callInfo *CallInfo) (resu
 		return nil, err
 	}
 	programModule, err := r.getModule(ctx, callInfo, programID)
+	if err != nil {
+		return nil, err
+	}
 	inst, err := r.getInstance(programModule, r.hostImports)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Add the program cache back into the runtime.  Caching via ID should be safe.  We need to enforce that an ID-> []byte never changes, but that should be a reasonable assumption that I will mark in the documentation once that gets rewritten.