### PR TITLE
Fix simulator panic when invoked

### DIFF
--- a/x/programs/cmd/simulator/cmd/root.go
+++ b/x/programs/cmd/simulator/cmd/root.go
@@ -140,7 +140,6 @@ func (s *Simulator) Execute(ctx context.Context) error {
 
 	err := s.ParseCommandArgs(ctx, os.Args, false)
 	if err != nil {
-		s.log.Error("error when parsing command args", zap.Error(err))
 		return err
 	}
 


### PR DESCRIPTION
Closes #1082 
If the call to `parser.Parse` returns an error, we short-circuit and return the error. It was logged from the logger in `s` but this one was not setup because the log level (which is a flag) depends on the parsing and so it was just `nil`. So this call to the logger was just removed.