### PR TITLE
reverse `ProgramCallErrorCode` order

### DIFF
--- a/x/programs/runtime/import_program.go
+++ b/x/programs/runtime/import_program.go
@@ -24,8 +24,8 @@ const (
 )
 
 const (
-	CallPanicked ProgramCallErrorCode = iota
-	ExecutionFailure
+	ExecutionFailure ProgramCallErrorCode = iota
+	CallPanicked
 	OutOfFuel
 )
 


### PR DESCRIPTION
The `CallPanicked` was put first while the `ExternalCallError` enum on the Rust side had it second with the `ExecutionFailure` first, those two were reversed.