### PR TITLE
Make `store` take a list of (key, value) to "store many"

### DIFF
--- a/x/programs/rust/examples/automated-market-maker/src/lib.rs
+++ b/x/programs/rust/examples/automated-market-maker/src/lib.rs
@@ -31,15 +31,11 @@ pub fn add_liquidity(context: Context<StateKeys>, amount_x: u64, amount_y: u64) 
 
     program
         .state()
-        .store(StateKeys::ReserveX, &(reserve_x + amount_x))
-        .unwrap();
-    program
-        .state()
-        .store(StateKeys::ReserveY, &(reserve_y + amount_y))
-        .unwrap();
-    program
-        .state()
-        .store(StateKeys::TotalySupply, &(total_supply + minted))
+        .store([
+            (StateKeys::ReserveX, &(reserve_x + amount_x)),
+            (StateKeys::ReserveY, &(reserve_y + amount_y)),
+            (StateKeys::TotalySupply, &(total_supply + minted)),
+        ])
         .unwrap();
 
     minted
@@ -57,15 +53,11 @@ pub fn remove_liquidity(context: Context<StateKeys>, shares: u64) -> (u64, u64) 
 
     program
         .state()
-        .store(StateKeys::ReserveX, &(reserve_x - amount_x))
-        .unwrap();
-    program
-        .state()
-        .store(StateKeys::ReserveY, &(reserve_y - amount_y))
-        .unwrap();
-    program
-        .state()
-        .store(StateKeys::TotalySupply, &(total_supply - shares))
+        .store([
+            (StateKeys::ReserveX, &(reserve_x - amount_x)),
+            (StateKeys::ReserveY, &(reserve_y - amount_y)),
+            (StateKeys::TotalySupply, &(total_supply - shares)),
+        ])
         .unwrap();
 
     (amount_x, amount_y)
@@ -95,11 +87,10 @@ pub fn swap(context: Context<StateKeys>, amount_in: u64, x_to_y: bool) -> u64 {
 
     program
         .state()
-        .store(StateKeys::ReserveX, &reserve_x)
-        .unwrap();
-    program
-        .state()
-        .store(StateKeys::ReserveY, &reserve_y)
+        .store([
+            (StateKeys::ReserveX, &reserve_x),
+            (StateKeys::ReserveY, &reserve_y),
+        ])
         .unwrap();
 
     out

--- a/x/programs/rust/examples/counter/src/lib.rs
+++ b/x/programs/rust/examples/counter/src/lib.rs
@@ -22,7 +22,7 @@ pub fn inc(context: Context<StateKeys>, to: Address, amount: Count) -> bool {
     context
         .program()
         .state()
-        .store(StateKeys::Counter(to), &counter)
+        .store_single(StateKeys::Counter(to), &counter)
         .expect("failed to store counter");
 
     true

--- a/x/programs/rust/examples/counter/src/lib.rs
+++ b/x/programs/rust/examples/counter/src/lib.rs
@@ -22,7 +22,7 @@ pub fn inc(context: Context<StateKeys>, to: Address, amount: Count) -> bool {
     context
         .program()
         .state()
-        .store_single(StateKeys::Counter(to), &counter)
+        .store_by_key(StateKeys::Counter(to), &counter)
         .expect("failed to store counter");
 
     true

--- a/x/programs/rust/examples/token/src/lib.rs
+++ b/x/programs/rust/examples/token/src/lib.rs
@@ -26,19 +26,19 @@ pub fn init(context: Context<StateKeys>) {
     // set total supply
     program
         .state()
-        .store(StateKeys::TotalSupply, &INITIAL_SUPPLY)
+        .store_single(StateKeys::TotalSupply, &INITIAL_SUPPLY)
         .expect("failed to store total supply");
 
     // set token name
     program
         .state()
-        .store(StateKeys::Name, b"WasmCoin")
+        .store_single(StateKeys::Name, b"WasmCoin")
         .expect("failed to store coin name");
 
     // set token symbol
     program
         .state()
-        .store(StateKeys::Symbol, b"WACK")
+        .store_single(StateKeys::Symbol, b"WACK")
         .expect("failed to store symbol");
 }
 
@@ -76,7 +76,7 @@ fn mint_to_internal(
 
     program
         .state()
-        .store(StateKeys::Balance(recipient), &(balance + amount))
+        .store_single(StateKeys::Balance(recipient), &(balance + amount))
         .expect("failed to store balance");
 
     context
@@ -123,12 +123,10 @@ pub fn transfer(
     // update balances
     program
         .state()
-        .store(StateKeys::Balance(sender), &(sender_balance - amount))
-        .expect("failed to store balance");
-
-    program
-        .state()
-        .store(StateKeys::Balance(recipient), &(recipient_balance + amount))
+        .store([
+            (StateKeys::Balance(sender), &(sender_balance - amount)),
+            (StateKeys::Balance(recipient), &(recipient_balance + amount)),
+        ])
         .expect("failed to store balance");
 
     true

--- a/x/programs/rust/examples/token/src/lib.rs
+++ b/x/programs/rust/examples/token/src/lib.rs
@@ -26,19 +26,19 @@ pub fn init(context: Context<StateKeys>) {
     // set total supply
     program
         .state()
-        .store_single(StateKeys::TotalSupply, &INITIAL_SUPPLY)
+        .store_by_key(StateKeys::TotalSupply, &INITIAL_SUPPLY)
         .expect("failed to store total supply");
 
     // set token name
     program
         .state()
-        .store_single(StateKeys::Name, b"WasmCoin")
+        .store_by_key(StateKeys::Name, b"WasmCoin")
         .expect("failed to store coin name");
 
     // set token symbol
     program
         .state()
-        .store_single(StateKeys::Symbol, b"WACK")
+        .store_by_key(StateKeys::Symbol, b"WACK")
         .expect("failed to store symbol");
 }
 
@@ -76,7 +76,7 @@ fn mint_to_internal(
 
     program
         .state()
-        .store_single(StateKeys::Balance(recipient), &(balance + amount))
+        .store_by_key(StateKeys::Balance(recipient), &(balance + amount))
         .expect("failed to store balance");
 
     context

--- a/x/programs/rust/wasmlanche-sdk/src/state.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/state.rs
@@ -1,7 +1,10 @@
 use crate::{memory::HostPtr, state::Error as StateError};
 use borsh::{from_slice, to_vec, BorshDeserialize, BorshSerialize};
-use std::cell::RefMut;
-use std::{cell::RefCell, collections::HashMap, hash::Hash};
+use std::{
+    cell::{RefCell, RefMut},
+    collections::HashMap,
+    hash::Hash,
+};
 
 #[derive(Clone, thiserror::Error, Debug)]
 pub enum Error {

--- a/x/programs/test/programs/state_access/src/lib.rs
+++ b/x/programs/test/programs/state_access/src/lib.rs
@@ -12,7 +12,7 @@ pub fn put(context: Context<StateKeys>, value: i64) {
     context
         .program()
         .state()
-        .store(StateKeys::State, &value)
+        .store_single(StateKeys::State, &value)
         .expect("failed to store state");
 }
 

--- a/x/programs/test/programs/state_access/src/lib.rs
+++ b/x/programs/test/programs/state_access/src/lib.rs
@@ -12,7 +12,7 @@ pub fn put(context: Context<StateKeys>, value: i64) {
     context
         .program()
         .state()
-        .store_single(StateKeys::State, &value)
+        .store_by_key(StateKeys::State, &value)
         .expect("failed to store state");
 }
 


### PR DESCRIPTION
Closes https://github.com/ava-labs/hypersdk/issues/1096

Update `store` so that it takes a list of tuples, and create a new `store_single` to match the old behavior.
The cache is not passed by mutable reference in order to avoid the runtime cost of borrowing it mutably many times.

The only pitfall is that because the function signature of `store` is now `fn store<V: BorshSerialize, Pairs: IntoIterator<Item = (K, &V)>`, the `V` has to be the same consistent type across the list.