### PR TITLE
Remove unused caller key

### DIFF
--- a/x/programs/cmd/simulator/cmd/config.go
+++ b/x/programs/cmd/simulator/cmd/config.go
@@ -15,8 +15,6 @@ const (
 )
 
 type Step struct {
-	// The key of the caller used.
-	CallerKey string `json:"callerKey"`
 	// The API endpoint to call. (required)
 	Endpoint Endpoint `json:"endpoint"`
 	// The method to call on the endpoint.

--- a/x/programs/cmd/simulator/src/lib.rs
+++ b/x/programs/cmd/simulator/src/lib.rs
@@ -46,15 +46,6 @@ pub struct Step {
     pub params: Vec<Param>,
 }
 
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct SimulatorStep<'a> {
-    /// The key of the caller used in each step of the plan.
-    pub caller_key: &'a str,
-    #[serde(flatten)]
-    pub step: &'a Step,
-}
-
 impl Step {
     /// Create a [`Step`] that creates a key.
     #[must_use]
@@ -357,11 +348,10 @@ where
     W: Write,
     R: Iterator<Item = StepResultItem>,
 {
-    pub fn run_step(&mut self, caller_key: &str, step: &Step) -> StepResultItem {
+    pub fn run_step(&mut self, step: &Step) -> StepResultItem {
         let run_command = b"run --step '";
         self.writer.write_all(run_command)?;
 
-        let step = SimulatorStep { caller_key, step };
         let input = serde_json::to_vec(&step).map_err(StepError::Serde)?;
         self.writer.write_all(&input)?;
         self.writer.write_all(b"'\n")?;

--- a/x/programs/cmd/simulator/test/context_injection/src/lib.rs
+++ b/x/programs/cmd/simulator/test/context_injection/src/lib.rs
@@ -29,11 +29,11 @@ mod tests {
         let owner = String::from("owner");
 
         simulator
-            .run_step(&owner, &Step::create_key(Key::Ed25519(owner.clone())))
+            .run_step(&Step::create_key(Key::Ed25519(owner.clone())))
             .unwrap();
 
         let program_id = simulator
-            .run_step(&owner, &Step::create_program(PROGRAM_PATH))
+            .run_step(&Step::create_program(PROGRAM_PATH))
             .unwrap()
             .id;
 
@@ -42,15 +42,12 @@ mod tests {
         test_context.timestamp = timestamp;
 
         let response = simulator
-            .run_step(
-                &owner,
-                &Step {
-                    endpoint: Endpoint::Execute,
-                    method: "get_timestamp".into(),
-                    max_units: 1000000,
-                    params: vec![test_context.into()],
-                },
-            )
+            .run_step(&Step {
+                endpoint: Endpoint::Execute,
+                method: "get_timestamp".into(),
+                max_units: 1000000,
+                params: vec![test_context.into()],
+            })
             .unwrap()
             .result
             .response::<u64>()
@@ -66,11 +63,11 @@ mod tests {
         let owner = String::from("owner");
 
         simulator
-            .run_step(&owner, &Step::create_key(Key::Ed25519(owner.clone())))
+            .run_step(&Step::create_key(Key::Ed25519(owner.clone())))
             .unwrap();
 
         let program_id = simulator
-            .run_step(&owner, &Step::create_program(PROGRAM_PATH))
+            .run_step(&Step::create_program(PROGRAM_PATH))
             .unwrap()
             .id;
 
@@ -79,15 +76,12 @@ mod tests {
         test_context.height = height;
 
         let response = simulator
-            .run_step(
-                &owner,
-                &Step {
-                    endpoint: Endpoint::Execute,
-                    method: "get_height".into(),
-                    max_units: 1000000,
-                    params: vec![test_context.into()],
-                },
-            )
+            .run_step(&Step {
+                endpoint: Endpoint::Execute,
+                method: "get_height".into(),
+                max_units: 1000000,
+                params: vec![test_context.into()],
+            })
             .unwrap()
             .result
             .response::<u64>()
@@ -103,33 +97,30 @@ mod tests {
         let owner = String::from("owner");
 
         simulator
-            .run_step(&owner, &Step::create_key(Key::Ed25519(owner.clone())))
+            .run_step(&Step::create_key(Key::Ed25519(owner.clone())))
             .unwrap();
 
         let program_id = simulator
-            .run_step(&owner, &Step::create_program(PROGRAM_PATH))
+            .run_step(&Step::create_program(PROGRAM_PATH))
             .unwrap()
             .id;
 
         let actor_key = Key::Ed25519(String::from("actor"));
 
         simulator
-            .run_step(&owner, &Step::create_key(actor_key.clone()))
+            .run_step(&Step::create_key(actor_key.clone()))
             .unwrap();
 
         let mut test_context = TestContext::from(program_id);
         test_context.actor_key = Some(actor_key);
 
         let response = simulator
-            .run_step(
-                &owner,
-                &Step {
-                    endpoint: Endpoint::Execute,
-                    method: "get_actor".into(),
-                    max_units: 1000000,
-                    params: vec![test_context.into()],
-                },
-            )
+            .run_step(&Step {
+                endpoint: Endpoint::Execute,
+                method: "get_actor".into(),
+                max_units: 1000000,
+                params: vec![test_context.into()],
+            })
             .unwrap()
             .result
             .response::<Address>()

--- a/x/programs/rust/examples/automated-market-maker/src/lib.rs
+++ b/x/programs/rust/examples/automated-market-maker/src/lib.rs
@@ -130,29 +130,26 @@ mod tests {
     fn init_state() {
         let mut simulator = simulator::ClientBuilder::new().try_build().unwrap();
 
-        let owner = "owner";
+        let owner = String::from("owner");
 
         let program_id = simulator
-            .run_step(owner, &Step::create_program(PROGRAM_PATH))
+            .run_step(&Step::create_program(PROGRAM_PATH))
             .unwrap()
             .id;
 
         simulator
-            .run_step(owner, &Step::create_key(Key::Ed25519(owner.to_string())))
+            .run_step(&Step::create_key(Key::Ed25519(owner)))
             .unwrap();
 
         let test_context = TestContext::from(program_id);
 
         let resp_err = simulator
-            .run_step(
-                owner,
-                &Step {
-                    endpoint: Endpoint::Execute,
-                    method: "remove_liquidity".to_string(),
-                    max_units: u64::MAX,
-                    params: vec![test_context.clone().into(), 100000u64.into()],
-                },
-            )
+            .run_step(&Step {
+                endpoint: Endpoint::Execute,
+                method: "remove_liquidity".to_string(),
+                max_units: u64::MAX,
+                params: vec![test_context.clone().into(), 100000u64.into()],
+            })
             .unwrap()
             .result
             .response::<(u64, u64)>()
@@ -165,15 +162,12 @@ mod tests {
         assert!(matches!(call_err, ExternalCallError::CallPanicked));
 
         let resp_err = simulator
-            .run_step(
-                owner,
-                &Step {
-                    endpoint: Endpoint::Execute,
-                    method: "swap".to_string(),
-                    max_units: u64::MAX,
-                    params: vec![test_context.into(), 100000u64.into(), true.into()],
-                },
-            )
+            .run_step(&Step {
+                endpoint: Endpoint::Execute,
+                method: "swap".to_string(),
+                max_units: u64::MAX,
+                params: vec![test_context.into(), 100000u64.into(), true.into()],
+            })
             .unwrap()
             .result
             .response::<u64>()
@@ -190,29 +184,26 @@ mod tests {
     fn add_liquidity_same_ratio() {
         let mut simulator = simulator::ClientBuilder::new().try_build().unwrap();
 
-        let owner = "owner";
+        let owner = String::from("owner");
 
         let program_id = simulator
-            .run_step(owner, &Step::create_program(PROGRAM_PATH))
+            .run_step(&Step::create_program(PROGRAM_PATH))
             .unwrap()
             .id;
 
         simulator
-            .run_step(owner, &Step::create_key(Key::Ed25519(owner.to_string())))
+            .run_step(&Step::create_key(Key::Ed25519(owner)))
             .unwrap();
 
         let test_context = TestContext::from(program_id);
 
         let resp = simulator
-            .run_step(
-                owner,
-                &Step {
-                    endpoint: Endpoint::Execute,
-                    method: "add_liquidity".to_string(),
-                    max_units: u64::MAX,
-                    params: vec![test_context.clone().into(), 1000u64.into(), 1000u64.into()],
-                },
-            )
+            .run_step(&Step {
+                endpoint: Endpoint::Execute,
+                method: "add_liquidity".to_string(),
+                max_units: u64::MAX,
+                params: vec![test_context.clone().into(), 1000u64.into(), 1000u64.into()],
+            })
             .unwrap()
             .result
             .response::<u64>()
@@ -221,15 +212,12 @@ mod tests {
         assert_eq!(resp, 1000);
 
         let resp = simulator
-            .run_step(
-                owner,
-                &Step {
-                    endpoint: Endpoint::Execute,
-                    method: "add_liquidity".to_string(),
-                    max_units: u64::MAX,
-                    params: vec![test_context.into(), 1000u64.into(), 1001u64.into()],
-                },
-            )
+            .run_step(&Step {
+                endpoint: Endpoint::Execute,
+                method: "add_liquidity".to_string(),
+                max_units: u64::MAX,
+                params: vec![test_context.into(), 1000u64.into(), 1001u64.into()],
+            })
             .unwrap()
             .result
             .response::<u64>()
@@ -246,29 +234,26 @@ mod tests {
     fn swap_changes_ratio() {
         let mut simulator = simulator::ClientBuilder::new().try_build().unwrap();
 
-        let owner = "owner";
+        let owner = String::from("owner");
 
         let program_id = simulator
-            .run_step(owner, &Step::create_program(PROGRAM_PATH))
+            .run_step(&Step::create_program(PROGRAM_PATH))
             .unwrap()
             .id;
 
         simulator
-            .run_step(owner, &Step::create_key(Key::Ed25519(owner.to_string())))
+            .run_step(&Step::create_key(Key::Ed25519(owner)))
             .unwrap();
 
         let test_context = TestContext::from(program_id);
 
         let resp = simulator
-            .run_step(
-                owner,
-                &Step {
-                    endpoint: Endpoint::Execute,
-                    method: "add_liquidity".to_string(),
-                    max_units: u64::MAX,
-                    params: vec![test_context.clone().into(), 1000u64.into(), 1000u64.into()],
-                },
-            )
+            .run_step(&Step {
+                endpoint: Endpoint::Execute,
+                method: "add_liquidity".to_string(),
+                max_units: u64::MAX,
+                params: vec![test_context.clone().into(), 1000u64.into(), 1000u64.into()],
+            })
             .unwrap()
             .result
             .response::<u64>()
@@ -277,27 +262,21 @@ mod tests {
         assert_eq!(resp, 1000);
 
         simulator
-            .run_step(
-                owner,
-                &Step {
-                    endpoint: Endpoint::Execute,
-                    method: "swap".to_string(),
-                    max_units: u64::MAX,
-                    params: vec![test_context.clone().into(), 10u64.into(), true.into()],
-                },
-            )
+            .run_step(&Step {
+                endpoint: Endpoint::Execute,
+                method: "swap".to_string(),
+                max_units: u64::MAX,
+                params: vec![test_context.clone().into(), 10u64.into(), true.into()],
+            })
             .unwrap();
 
         let (amount_x, amount_y) = simulator
-            .run_step(
-                owner,
-                &Step {
-                    endpoint: Endpoint::Execute,
-                    method: "remove_liquidity".to_string(),
-                    max_units: u64::MAX,
-                    params: vec![test_context.into(), 1000.into()],
-                },
-            )
+            .run_step(&Step {
+                endpoint: Endpoint::Execute,
+                method: "remove_liquidity".to_string(),
+                max_units: u64::MAX,
+                params: vec![test_context.into(), 1000.into()],
+            })
             .unwrap()
             .result
             .response::<(u64, u64)>()

--- a/x/programs/rust/examples/counter-external/src/lib.rs
+++ b/x/programs/rust/examples/counter-external/src/lib.rs
@@ -30,17 +30,17 @@ mod tests {
         let owner_key = Key::Ed25519(owner.clone());
 
         simulator
-            .run_step(&owner, &Step::create_key(owner_key.clone()))
+            .run_step(&Step::create_key(owner_key.clone()))
             .unwrap();
         let owner_key = Param::Key(owner_key);
 
         let counter_external = simulator
-            .run_step(&owner, &Step::create_program(PROGRAM_PATH))
+            .run_step(&Step::create_program(PROGRAM_PATH))
             .expect("should be able to create this program")
             .id;
 
         let counter = simulator
-            .run_step(&owner, &Step::create_program(counter_path))
+            .run_step(&Step::create_program(counter_path))
             .expect("should be able to create the counter")
             .id;
         let counter = Param::Id(counter);
@@ -52,27 +52,21 @@ mod tests {
         ];
 
         simulator
-            .run_step(
-                &owner,
-                &Step {
-                    endpoint: Endpoint::Execute,
-                    method: "inc".into(),
-                    max_units: 100_000_000,
-                    params: params.clone(),
-                },
-            )
+            .run_step(&Step {
+                endpoint: Endpoint::Execute,
+                method: "inc".into(),
+                max_units: 100_000_000,
+                params: params.clone(),
+            })
             .expect("call inc");
 
         let response = simulator
-            .run_step(
-                &owner,
-                &Step {
-                    endpoint: Endpoint::ReadOnly,
-                    method: "get_value".into(),
-                    max_units: 1_000_000,
-                    params,
-                },
-            )
+            .run_step(&Step {
+                endpoint: Endpoint::ReadOnly,
+                method: "get_value".into(),
+                max_units: 1_000_000,
+                params,
+            })
             .expect("call get_value")
             .result
             .response::<u64>()

--- a/x/programs/rust/examples/counter/src/lib.rs
+++ b/x/programs/rust/examples/counter/src/lib.rs
@@ -78,15 +78,15 @@ mod tests {
         let alice = String::from("alice");
 
         simulator
-            .run_step(&owner, &Step::create_key(Key::Ed25519(owner.clone())))
+            .run_step(&Step::create_key(Key::Ed25519(owner.clone())))
             .unwrap();
 
         simulator
-            .run_step(&owner, &Step::create_key(Key::Ed25519(alice)))
+            .run_step(&Step::create_key(Key::Ed25519(alice)))
             .unwrap();
 
         simulator
-            .run_step(&owner, &Step::create_program(PROGRAM_PATH))
+            .run_step(&Step::create_program(PROGRAM_PATH))
             .unwrap();
     }
 
@@ -99,46 +99,38 @@ mod tests {
         let bob_key_param = Param::Key(bob_key.clone());
 
         simulator
-            .run_step(&owner, &Step::create_key(Key::Ed25519(owner.clone())))
+            .run_step(&Step::create_key(Key::Ed25519(owner.clone())))
             .unwrap();
 
-        simulator
-            .run_step(&owner, &Step::create_key(bob_key))
-            .unwrap();
+        simulator.run_step(&Step::create_key(bob_key)).unwrap();
 
         let counter_id = simulator
-            .run_step(&owner, &Step::create_program(PROGRAM_PATH))
+            .run_step(&Step::create_program(PROGRAM_PATH))
             .unwrap()
             .id;
 
         let test_context = TestContext::from(counter_id);
 
         simulator
-            .run_step(
-                &owner,
-                &Step {
-                    endpoint: Endpoint::Execute,
-                    method: "inc".into(),
-                    max_units: 1000000,
-                    params: vec![
-                        test_context.clone().into(),
-                        bob_key_param.clone(),
-                        10u64.into(),
-                    ],
-                },
-            )
+            .run_step(&Step {
+                endpoint: Endpoint::Execute,
+                method: "inc".into(),
+                max_units: 1000000,
+                params: vec![
+                    test_context.clone().into(),
+                    bob_key_param.clone(),
+                    10u64.into(),
+                ],
+            })
             .unwrap();
 
         let value = simulator
-            .run_step(
-                &owner,
-                &Step {
-                    endpoint: Endpoint::ReadOnly,
-                    method: "get_value".into(),
-                    max_units: 0,
-                    params: vec![test_context.into(), bob_key_param],
-                },
-            )
+            .run_step(&Step {
+                endpoint: Endpoint::ReadOnly,
+                method: "get_value".into(),
+                max_units: 0,
+                params: vec![test_context.into(), bob_key_param],
+            })
             .unwrap()
             .result
             .response::<u64>()
@@ -155,23 +147,18 @@ mod tests {
         let bob_key_param = Param::Key(bob_key.clone());
 
         simulator
-            .run_step(
-                &owner_key,
-                &Step::create_key(Key::Ed25519(owner_key.clone())),
-            )
+            .run_step(&Step::create_key(Key::Ed25519(owner_key.clone())))
             .unwrap();
 
-        simulator
-            .run_step(&owner_key, &Step::create_key(bob_key))
-            .unwrap();
+        simulator.run_step(&Step::create_key(bob_key)).unwrap();
 
         let counter1_id = simulator
-            .run_step(&owner_key, &Step::create_program(PROGRAM_PATH))
+            .run_step(&Step::create_program(PROGRAM_PATH))
             .unwrap()
             .id;
 
         let counter2_id = simulator
-            .run_step(&owner_key, &Step::create_program(PROGRAM_PATH))
+            .run_step(&Step::create_program(PROGRAM_PATH))
             .unwrap()
             .id;
 
@@ -179,15 +166,12 @@ mod tests {
         let test_context2 = TestContext::from(counter2_id);
 
         let value = simulator
-            .run_step(
-                &owner_key,
-                &Step {
-                    endpoint: Endpoint::ReadOnly,
-                    method: "get_value".into(),
-                    max_units: 0,
-                    params: vec![test_context2.into(), bob_key_param.clone()],
-                },
-            )
+            .run_step(&Step {
+                endpoint: Endpoint::ReadOnly,
+                method: "get_value".into(),
+                max_units: 0,
+                params: vec![test_context2.into(), bob_key_param.clone()],
+            })
             .unwrap()
             .result
             .response::<u64>()
@@ -195,38 +179,32 @@ mod tests {
         assert_eq!(value, 0);
 
         simulator
-            .run_step(
-                &owner_key,
-                &Step {
-                    endpoint: Endpoint::Execute,
-                    method: "inc_external".into(),
-                    max_units: 100_000_000,
-                    params: vec![
-                        test_context1.clone().into(),
-                        counter2_id.into(),
-                        1_000_000.into(),
-                        bob_key_param.clone(),
-                        10.into(),
-                    ],
-                },
-            )
+            .run_step(&Step {
+                endpoint: Endpoint::Execute,
+                method: "inc_external".into(),
+                max_units: 100_000_000,
+                params: vec![
+                    test_context1.clone().into(),
+                    counter2_id.into(),
+                    1_000_000.into(),
+                    bob_key_param.clone(),
+                    10.into(),
+                ],
+            })
             .unwrap();
 
         let value = simulator
-            .run_step(
-                &owner_key,
-                &Step {
-                    endpoint: Endpoint::ReadOnly,
-                    method: "get_value_external".into(),
-                    max_units: 0,
-                    params: vec![
-                        test_context1.into(),
-                        counter2_id.into(),
-                        1_000_000.into(),
-                        bob_key_param,
-                    ],
-                },
-            )
+            .run_step(&Step {
+                endpoint: Endpoint::ReadOnly,
+                method: "get_value_external".into(),
+                max_units: 0,
+                params: vec![
+                    test_context1.into(),
+                    counter2_id.into(),
+                    1_000_000.into(),
+                    bob_key_param,
+                ],
+            })
             .unwrap()
             .result
             .response::<u64>()

--- a/x/programs/rust/examples/token/src/lib.rs
+++ b/x/programs/rust/examples/token/src/lib.rs
@@ -172,13 +172,10 @@ mod tests {
         let owner_key = String::from("owner");
 
         simulator
-            .run_step(
-                &owner_key,
-                &Step::create_key(Key::Ed25519(owner_key.clone())),
-            )
+            .run_step(&Step::create_key(Key::Ed25519(owner_key.clone())))
             .unwrap();
         simulator
-            .run_step(&owner_key, &Step::create_program(PROGRAM_PATH))
+            .run_step(&Step::create_program(PROGRAM_PATH))
             .unwrap();
     }
 
@@ -189,40 +186,31 @@ mod tests {
         let owner_key = String::from("owner");
 
         simulator
-            .run_step(
-                &owner_key,
-                &Step::create_key(Key::Ed25519(owner_key.clone())),
-            )
+            .run_step(&Step::create_key(Key::Ed25519(owner_key.clone())))
             .unwrap();
         let program_id = simulator
-            .run_step(&owner_key, &Step::create_program(PROGRAM_PATH))
+            .run_step(&Step::create_program(PROGRAM_PATH))
             .unwrap()
             .id;
 
         let test_context = TestContext::from(program_id);
 
         simulator
-            .run_step(
-                &owner_key,
-                &Step {
-                    endpoint: Endpoint::Execute,
-                    method: "init".into(),
-                    params: vec![test_context.clone().into()],
-                    max_units: 1000000,
-                },
-            )
+            .run_step(&Step {
+                endpoint: Endpoint::Execute,
+                method: "init".into(),
+                params: vec![test_context.clone().into()],
+                max_units: 1000000,
+            })
             .unwrap();
 
         let supply = simulator
-            .run_step(
-                &owner_key,
-                &Step {
-                    endpoint: Endpoint::ReadOnly,
-                    method: "get_total_supply".into(),
-                    max_units: 0,
-                    params: vec![test_context.into()],
-                },
-            )
+            .run_step(&Step {
+                endpoint: Endpoint::ReadOnly,
+                method: "get_total_supply".into(),
+                max_units: 0,
+                params: vec![test_context.into()],
+            })
             .unwrap()
             .result
             .response::<u64>()
@@ -241,61 +229,47 @@ mod tests {
         let alice_initial_balance = 1000;
 
         simulator
-            .run_step(
-                &owner_key,
-                &Step::create_key(Key::Ed25519(owner_key.clone())),
-            )
+            .run_step(&Step::create_key(Key::Ed25519(owner_key.clone())))
             .unwrap();
 
         let program_id = simulator
-            .run_step(&owner_key, &Step::create_program(PROGRAM_PATH))
+            .run_step(&Step::create_program(PROGRAM_PATH))
             .unwrap()
             .id;
 
-        simulator
-            .run_step(&owner_key, &Step::create_key(alice_key))
-            .unwrap();
+        simulator.run_step(&Step::create_key(alice_key)).unwrap();
 
         let test_context = TestContext::from(program_id);
 
         simulator
-            .run_step(
-                &owner_key,
-                &Step {
-                    endpoint: Endpoint::Execute,
-                    method: "init".into(),
-                    params: vec![test_context.clone().into()],
-                    max_units: 1000000,
-                },
-            )
+            .run_step(&Step {
+                endpoint: Endpoint::Execute,
+                method: "init".into(),
+                params: vec![test_context.clone().into()],
+                max_units: 1000000,
+            })
             .unwrap();
 
         simulator
-            .run_step(
-                &owner_key,
-                &Step {
-                    endpoint: Endpoint::Execute,
-                    method: "mint_to".into(),
-                    params: vec![
-                        test_context.clone().into(),
-                        alice_key_param.clone(),
-                        Param::U64(alice_initial_balance),
-                    ],
-                    max_units: 1000000,
-                },
-            )
+            .run_step(&Step {
+                endpoint: Endpoint::Execute,
+                method: "mint_to".into(),
+                params: vec![
+                    test_context.clone().into(),
+                    alice_key_param.clone(),
+                    Param::U64(alice_initial_balance),
+                ],
+                max_units: 1000000,
+            })
             .unwrap();
 
         let balance = simulator
-            .run_step(
-                &owner_key,
-                &Step {
-                    endpoint: Endpoint::ReadOnly,
-                    method: "get_balance".into(),
-                    max_units: 0,
-                    params: vec![test_context.into(), alice_key_param],
-                },
-            )
+            .run_step(&Step {
+                endpoint: Endpoint::ReadOnly,
+                method: "get_balance".into(),
+                max_units: 0,
+                params: vec![test_context.into(), alice_key_param],
+            })
             .unwrap()
             .result
             .response::<u64>()
@@ -316,82 +290,67 @@ mod tests {
         let post_transfer_balance = alice_initial_balance - transfer_amount;
 
         simulator
-            .run_step(
-                &owner_key,
-                &Step::create_key(Key::Ed25519(owner_key.clone())),
-            )
+            .run_step(&Step::create_key(Key::Ed25519(owner_key.clone())))
             .unwrap();
 
         let program_id = simulator
-            .run_step(&owner_key, &Step::create_program(PROGRAM_PATH))
+            .run_step(&Step::create_program(PROGRAM_PATH))
             .unwrap()
             .id;
 
         simulator
-            .run_step(&owner_key, &Step::create_key(alice_key.clone()))
+            .run_step(&Step::create_key(alice_key.clone()))
             .unwrap();
 
         simulator
-            .run_step(&owner_key, &Step::create_key(bob_key.clone()))
+            .run_step(&Step::create_key(bob_key.clone()))
             .unwrap();
 
         let test_context = TestContext::from(program_id);
 
         simulator
-            .run_step(
-                &owner_key,
-                &Step {
-                    endpoint: Endpoint::Execute,
-                    method: "init".into(),
-                    params: vec![test_context.clone().into()],
-                    max_units: 1000000,
-                },
-            )
+            .run_step(&Step {
+                endpoint: Endpoint::Execute,
+                method: "init".into(),
+                params: vec![test_context.clone().into()],
+                max_units: 1000000,
+            })
             .unwrap();
 
         simulator
-            .run_step(
-                &owner_key,
-                &Step {
-                    endpoint: Endpoint::Execute,
-                    method: "mint_to".into(),
-                    params: vec![
-                        test_context.clone().into(),
-                        alice_key_param.clone(),
-                        Param::U64(alice_initial_balance),
-                    ],
-                    max_units: 1000000,
-                },
-            )
+            .run_step(&Step {
+                endpoint: Endpoint::Execute,
+                method: "mint_to".into(),
+                params: vec![
+                    test_context.clone().into(),
+                    alice_key_param.clone(),
+                    Param::U64(alice_initial_balance),
+                ],
+                max_units: 1000000,
+            })
             .unwrap();
 
         simulator
-            .run_step(
-                &owner_key,
-                &Step {
-                    endpoint: Endpoint::Execute,
-                    method: "transfer".into(),
-                    params: vec![
-                        test_context.clone().into(),
-                        alice_key_param.clone(),
-                        bob_key_param.clone(),
-                        Param::U64(transfer_amount),
-                    ],
-                    max_units: 1000000,
-                },
-            )
+            .run_step(&Step {
+                endpoint: Endpoint::Execute,
+                method: "transfer".into(),
+                params: vec![
+                    test_context.clone().into(),
+                    alice_key_param.clone(),
+                    bob_key_param.clone(),
+                    Param::U64(transfer_amount),
+                ],
+                max_units: 1000000,
+            })
             .unwrap();
 
         let supply = simulator
-            .run_step(
-                &owner_key,
-                &Step {
-                    endpoint: Endpoint::ReadOnly,
-                    method: "get_total_supply".into(),
-                    max_units: 0,
-                    params: vec![test_context.clone().into()],
-                },
-            )
+            .run_step(&Step {
+                endpoint: Endpoint::ReadOnly,
+                method: "get_total_supply".into(),
+                max_units: 0,
+                params: vec![test_context.clone().into()],
+            })
             .unwrap()
             .result
             .response::<u64>()
@@ -399,15 +358,12 @@ mod tests {
         assert_eq!(supply, INITIAL_SUPPLY);
 
         let balance = simulator
-            .run_step(
-                &owner_key,
-                &Step {
-                    endpoint: Endpoint::ReadOnly,
-                    method: "get_balance".into(),
-                    max_units: 0,
-                    params: vec![test_context.clone().into(), alice_key_param.clone()],
-                },
-            )
+            .run_step(&Step {
+                endpoint: Endpoint::ReadOnly,
+                method: "get_balance".into(),
+                max_units: 0,
+                params: vec![test_context.clone().into(), alice_key_param.clone()],
+            })
             .unwrap()
             .result
             .response::<u64>()
@@ -415,15 +371,12 @@ mod tests {
         assert_eq!(balance, post_transfer_balance);
 
         let balance = simulator
-            .run_step(
-                &owner_key,
-                &Step {
-                    endpoint: Endpoint::ReadOnly,
-                    method: "get_balance".into(),
-                    max_units: 0,
-                    params: vec![test_context.clone().into(), bob_key_param],
-                },
-            )
+            .run_step(&Step {
+                endpoint: Endpoint::ReadOnly,
+                method: "get_balance".into(),
+                max_units: 0,
+                params: vec![test_context.clone().into(), bob_key_param],
+            })
             .unwrap()
             .result
             .response::<u64>()
@@ -431,15 +384,12 @@ mod tests {
         assert_eq!(balance, transfer_amount);
 
         let balance = simulator
-            .run_step(
-                &owner_key,
-                &Step {
-                    endpoint: Endpoint::Execute,
-                    method: "burn_from".into(),
-                    params: vec![test_context.clone().into(), alice_key_param.clone()],
-                    max_units: 1000000,
-                },
-            )
+            .run_step(&Step {
+                endpoint: Endpoint::Execute,
+                method: "burn_from".into(),
+                params: vec![test_context.clone().into(), alice_key_param.clone()],
+                max_units: 1000000,
+            })
             .unwrap()
             .result
             .response::<u64>()
@@ -447,15 +397,12 @@ mod tests {
         assert_eq!(balance, post_transfer_balance);
 
         let balance = simulator
-            .run_step(
-                &owner_key,
-                &Step {
-                    endpoint: Endpoint::ReadOnly,
-                    method: "get_balance".into(),
-                    max_units: 0,
-                    params: vec![test_context.clone().into(), alice_key_param],
-                },
-            )
+            .run_step(&Step {
+                endpoint: Endpoint::ReadOnly,
+                method: "get_balance".into(),
+                max_units: 0,
+                params: vec![test_context.clone().into(), alice_key_param],
+            })
             .unwrap()
             .result
             .response::<u64>()


### PR DESCRIPTION
Closes https://github.com/ava-labs/hypersdk/issues/1081
Remove the unused `caller_key` and `CallerKey` on the Go side since it was unused.
If we need to impersonate the actor during execution, the `testContext` can be now used.