### PR TITLE
[x/programs] Clean up test utils

### DIFF
--- a/x/programs/runtime/call_context.go
+++ b/x/programs/runtime/call_context.go
@@ -89,3 +89,8 @@ func (c CallContext) WithActionID(actionID ids.ID) CallContext {
 	c.defaultCallInfo.ActionID = actionID
 	return c
 }
+
+func (c CallContext) WithTimestamp(timestamp uint64) CallContext {
+	c.defaultCallInfo.Timestamp = timestamp
+	return c
+}

--- a/x/programs/runtime/import_program_test.go
+++ b/x/programs/runtime/import_program_test.go
@@ -153,7 +153,7 @@ func TestImportGetRemainingFuel(t *testing.T) {
 	program := newTestProgram(ctx, "fuel")
 	result, err := program.Call("get_fuel")
 	require.NoError(err)
-	require.LessOrEqual(into[uint64](result), program.Runtime.DefaultGas)
+	require.LessOrEqual(into[uint64](result), program.Runtime.Runtime.defaultCallInfo.Fuel)
 }
 
 func TestImportOutOfFuel(t *testing.T) {

--- a/x/programs/runtime/import_program_test.go
+++ b/x/programs/runtime/import_program_test.go
@@ -20,8 +20,9 @@ func TestImportProgramDeployProgram(t *testing.T) {
 	defer cancel()
 
 	program := newTestProgram(ctx, "deploy_program")
+	runtime := program.Runtime
 	otherProgramID := ids.GenerateTestID()
-	program.Runtime.AddProgram(otherProgramID, "call_program")
+	runtime.AddProgram(otherProgramID, "call_program")
 
 	result, err := program.Call(
 		"deploy",
@@ -30,10 +31,7 @@ func TestImportProgramDeployProgram(t *testing.T) {
 
 	newAccount := into[codec.Address](result)
 
-	result, err = program.Runtime.CallProgram(Context{
-		Program: newAccount,
-		Actor:   codec.EmptyAddress,
-	}, "simple_call")
+	result, err = runtime.CallProgram(newAccount, "simple_call")
 	require.NoError(err)
 	require.Equal(uint64(0), into[uint64](result))
 }
@@ -69,7 +67,7 @@ func TestImportProgramCallProgramActor(t *testing.T) {
 	program := newTestProgram(ctx, "call_program")
 	actor := codec.CreateAddress(1, ids.GenerateTestID())
 
-	result, err := program.CallWithActor(actor, "actor_check")
+	result, err := program.WithActor(actor).Call("actor_check")
 	require.NoError(err)
 	expected, err := Serialize(actor)
 	require.NoError(err)
@@ -85,8 +83,7 @@ func TestImportProgramCallProgramActorChange(t *testing.T) {
 	program := newTestProgram(ctx, "call_program")
 	actor := codec.CreateAddress(1, ids.GenerateTestID())
 
-	result, err := program.CallWithActor(
-		actor,
+	result, err := program.WithActor(actor).Call(
 		"actor_check_external",
 		program.Address, uint64(100000))
 	require.NoError(err)
@@ -153,7 +150,7 @@ func TestImportGetRemainingFuel(t *testing.T) {
 	program := newTestProgram(ctx, "fuel")
 	result, err := program.Call("get_fuel")
 	require.NoError(err)
-	require.LessOrEqual(into[uint64](result), program.Runtime.Runtime.defaultCallInfo.Fuel)
+	require.LessOrEqual(into[uint64](result), program.Runtime.callContext.defaultCallInfo.Fuel)
 }
 
 func TestImportOutOfFuel(t *testing.T) {

--- a/x/programs/runtime/runtime_test.go
+++ b/x/programs/runtime/runtime_test.go
@@ -67,7 +67,7 @@ func TestContextInjection(t *testing.T) {
 		{
 			name: "timestamp",
 			fun: func(program *testProgram, require *require.Assertions) {
-				result, err := program.CallWithTimestamp(1, "get_timestamp")
+				result, err := program.WithTimestamp(1).Call("get_timestamp")
 				require.NoError(err)
 				require.Equal(uint64(1), into[uint64](result))
 			},
@@ -75,7 +75,7 @@ func TestContextInjection(t *testing.T) {
 		{
 			name: "height",
 			fun: func(program *testProgram, require *require.Assertions) {
-				result, err := program.CallWithHeight(1, "get_height")
+				result, err := program.WithHeight(1).Call("get_height")
 				require.NoError(err)
 				require.Equal(uint64(1), into[uint64](result))
 			},
@@ -83,7 +83,7 @@ func TestContextInjection(t *testing.T) {
 		{
 			name: "actor",
 			fun: func(program *testProgram, require *require.Assertions) {
-				result, err := program.CallWithActor(codec.CreateAddress(0, ids.GenerateTestID()), "get_actor")
+				result, err := program.WithActor(codec.CreateAddress(0, ids.GenerateTestID())).Call("get_actor")
 				require.NoError(err)
 				require.NotEqual(ids.Empty, into[ids.ID](result))
 			},

--- a/x/programs/runtime/util_test.go
+++ b/x/programs/runtime/util_test.go
@@ -15,22 +15,64 @@ import (
 
 type testRuntime struct {
 	Context      context.Context
-	Runtime      CallContext
+	callContext  CallContext
 	StateManager StateManager
+}
+
+func (t *testRuntime) WithStateManager(manager StateManager) *testRuntime {
+	t.callContext = t.callContext.WithStateManager(manager)
+	return t
+}
+
+func (t *testRuntime) WithActor(address codec.Address) *testRuntime {
+	t.callContext = t.callContext.WithActor(address)
+	return t
+}
+
+func (t *testRuntime) WithFunction(s string) *testRuntime {
+	t.callContext = t.callContext.WithFunction(s)
+	return t
+}
+
+func (t *testRuntime) WithProgram(address codec.Address) *testRuntime {
+	t.callContext = t.callContext.WithProgram(address)
+	return t
+}
+
+func (t *testRuntime) WithFuel(u uint64) *testRuntime {
+	t.callContext = t.callContext.WithFuel(u)
+	return t
+}
+
+func (t *testRuntime) WithParams(bytes []byte) *testRuntime {
+	t.callContext = t.callContext.WithParams(bytes)
+	return t
+}
+
+func (t *testRuntime) WithHeight(height uint64) *testRuntime {
+	t.callContext = t.callContext.WithHeight(height)
+	return t
+}
+
+func (t *testRuntime) WithActionID(actionID ids.ID) *testRuntime {
+	t.callContext = t.callContext.WithActionID(actionID)
+	return t
+}
+
+func (t *testRuntime) WithTimestamp(ts uint64) *testRuntime {
+	t.callContext = t.callContext.WithTimestamp(ts)
+	return t
 }
 
 func (t *testRuntime) AddProgram(programID ids.ID, programName string) {
 	t.StateManager.(test.StateManager).ProgramsMap[programID] = programName
 }
 
-func (t *testRuntime) CallProgram(callContext Context, function string, params ...interface{}) ([]byte, error) {
-	return t.Runtime.CallProgram(
+func (t *testRuntime) CallProgram(program codec.Address, function string, params ...interface{}) ([]byte, error) {
+	return t.callContext.CallProgram(
 		t.Context,
 		&CallInfo{
-			Program:      callContext.Program,
-			Actor:        callContext.Actor,
-			Height:       callContext.Height,
-			Timestamp:    callContext.Timestamp,
+			Program:      program,
 			State:        t.StateManager,
 			FunctionName: function,
 			Params:       test.SerializeParams(params...),
@@ -43,7 +85,7 @@ func newTestProgram(ctx context.Context, program string) *testProgram {
 	return &testProgram{
 		Runtime: &testRuntime{
 			Context: ctx,
-			Runtime: NewRuntime(
+			callContext: NewRuntime(
 				NewConfig(),
 				logging.NoLog{}).WithDefaults(&CallInfo{Fuel: 10000000}),
 			StateManager: test.StateManager{ProgramsMap: map[ids.ID]string{id: program}, AccountMap: map[codec.Address]ids.ID{account: id}, Mu: test.NewTestDB()},
@@ -59,50 +101,54 @@ type testProgram struct {
 
 func (t *testProgram) Call(function string, params ...interface{}) ([]byte, error) {
 	return t.Runtime.CallProgram(
-		Context{
-			Program:   t.Address,
-			Actor:     codec.CreateAddress(0, ids.GenerateTestID()),
-			Height:    0,
-			Timestamp: 0,
-		},
+		t.Address,
 		function,
 		params...)
 }
 
-func (t *testProgram) CallWithActor(actor codec.Address, function string, params ...interface{}) ([]byte, error) {
-	return t.Runtime.CallProgram(
-		Context{
-			Program:   t.Address,
-			Actor:     actor,
-			Height:    0,
-			Timestamp: 0,
-		},
-		function,
-		params...)
+func (t *testProgram) WithStateManager(manager StateManager) *testProgram {
+	t.Runtime = t.Runtime.WithStateManager(manager)
+	return t
 }
 
-func (t *testProgram) CallWithHeight(height uint64, function string, params ...interface{}) ([]byte, error) {
-	return t.Runtime.CallProgram(
-		Context{
-			Program:   t.Address,
-			Actor:     codec.CreateAddress(0, ids.GenerateTestID()),
-			Height:    height,
-			Timestamp: 0,
-		},
-		function,
-		params...)
+func (t *testProgram) WithActor(address codec.Address) *testProgram {
+	t.Runtime = t.Runtime.WithActor(address)
+	return t
 }
 
-func (t *testProgram) CallWithTimestamp(timestamp uint64, function string, params ...interface{}) ([]byte, error) {
-	return t.Runtime.CallProgram(
-		Context{
-			Program:   t.Address,
-			Actor:     codec.CreateAddress(0, ids.GenerateTestID()),
-			Height:    0,
-			Timestamp: timestamp,
-		},
-		function,
-		params...)
+func (t *testProgram) WithFunction(s string) *testProgram {
+	t.Runtime = t.Runtime.WithFunction(s)
+	return t
+}
+
+func (t *testProgram) WithProgram(address codec.Address) *testProgram {
+	t.Runtime = t.Runtime.WithProgram(address)
+	return t
+}
+
+func (t *testProgram) WithFuel(u uint64) *testProgram {
+	t.Runtime = t.Runtime.WithFuel(u)
+	return t
+}
+
+func (t *testProgram) WithParams(bytes []byte) *testProgram {
+	t.Runtime = t.Runtime.WithParams(bytes)
+	return t
+}
+
+func (t *testProgram) WithHeight(height uint64) *testProgram {
+	t.Runtime = t.Runtime.WithHeight(height)
+	return t
+}
+
+func (t *testProgram) WithActionID(actionID ids.ID) *testProgram {
+	t.Runtime = t.Runtime.WithActionID(actionID)
+	return t
+}
+
+func (t *testProgram) WithTimestamp(ts uint64) *testProgram {
+	t.Runtime = t.Runtime.WithTimestamp(ts)
+	return t
 }
 
 func into[T any](data []byte) T {

--- a/x/programs/runtime/util_test.go
+++ b/x/programs/runtime/util_test.go
@@ -15,9 +15,8 @@ import (
 
 type testRuntime struct {
 	Context      context.Context
-	Runtime      *WasmRuntime
+	Runtime      CallContext
 	StateManager StateManager
-	DefaultGas   uint64
 }
 
 func (t *testRuntime) AddProgram(programID ids.ID, programName string) {
@@ -35,7 +34,6 @@ func (t *testRuntime) CallProgram(callContext Context, function string, params .
 			State:        t.StateManager,
 			FunctionName: function,
 			Params:       test.SerializeParams(params...),
-			Fuel:         t.DefaultGas,
 		})
 }
 
@@ -47,9 +45,8 @@ func newTestProgram(ctx context.Context, program string) *testProgram {
 			Context: ctx,
 			Runtime: NewRuntime(
 				NewConfig(),
-				logging.NoLog{}),
+				logging.NoLog{}).WithDefaults(&CallInfo{Fuel: 10000000}),
 			StateManager: test.StateManager{ProgramsMap: map[ids.ID]string{id: program}, AccountMap: map[codec.Address]ids.ID{account: id}, Mu: test.NewTestDB()},
-			DefaultGas:   10000000,
 		},
 		Address: account,
 	}


### PR DESCRIPTION
Clean up the test utils to properly use the call context and have only a single call style function instead of a bunch of CallWithX.