### PR TITLE
Skip packing tx that exceeds MDF limit in block builder

### DIFF
--- a/chain/builder.go
+++ b/chain/builder.go
@@ -307,6 +307,9 @@ func BuildBlock(
 						stop = true
 						return errBlockFull
 					}
+					// Skip this transaction and continue packing if it exceeds the dimension's
+					// limit.
+					return nil
 				}
 
 				// Update block with new transaction


### PR DESCRIPTION
This PR modifies the block builder to skip packing a transaction when doing so exceeds the multi-dimensional fee limits.

Currently, we execute each transaction in parallel using the executor package: https://github.com/ava-labs/hypersdk/blob/c385e0fb5935f1756b8fb2ba6987d80c5f9df18f/chain/builder.go#L197.

After executing each transaction, we consume the multi-dimensional units of the transaction on top of the fee manager: https://github.com/ava-labs/hypersdk/blob/c385e0fb5935f1756b8fb2ba6987d80c5f9df18f/chain/builder.go#L293.

If this function returns false, then consuming the transaction would exceed the hard limit of the dimension returned alongside it. This means including the transaction in the block will make it invalid.

The current code checks if we have exceeded the target and returns `errBlockFull` to stop trying to add further transactions, but does not return early if this transaction exceeds the limit, but without including it has already surpassed the target.

This PR fixes the block packing bug by returning early here: https://github.com/ava-labs/hypersdk/blob/1ddd2cf7c29b505f8972b97236858b2139e79232/chain/builder.go#L310-L312

Note: the meaning of "target" is unclear in the block builder code. We do not stop building when we hit the target as you'd expect. Instead, we stop building after we've hit the first transaction that cannot be included due to exceeding the limit for dimension D where we have also already surpassed the target consumption for dimension D. Additionally, transactions currently fully specify their maximum multi-dimensional consumption. We may want to consider checking that there's room to pack a transaction before execution. I assume that we do not currently do this because we extract the total units consumed as part of transaction execution and because checking for room before execution would complicate the order we use to claim those units, execute the tx, and check for an error to potentially roll back.