### PR TITLE
Fix fee window roll for < 1s block intervals

### DIFF
--- a/chain/block.go
+++ b/chain/block.go
@@ -413,7 +413,7 @@ func (b *StatelessBlock) innerVerify(ctx context.Context, vctx VerifyContext) er
 		return err
 	}
 	parentFeeManager := fees.NewManager(feeRaw)
-	feeManager, err := parentFeeManager.ComputeNext(parentTimestamp, b.Tmstmp, r)
+	feeManager, err := parentFeeManager.ComputeNext(b.Tmstmp, r)
 	if err != nil {
 		return err
 	}

--- a/chain/builder.go
+++ b/chain/builder.go
@@ -100,7 +100,7 @@ func BuildBlock(
 		return nil, err
 	}
 	parentFeeManager := fees.NewManager(feeRaw)
-	feeManager, err := parentFeeManager.ComputeNext(parent.Tmstmp, nextTime, r)
+	feeManager, err := parentFeeManager.ComputeNext(nextTime, r)
 	if err != nil {
 		return nil, err
 	}

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -778,7 +778,7 @@ func (vm *VM) Submit(
 	feeManager := fees.NewManager(feeRaw)
 	now := time.Now().UnixMilli()
 	r := vm.c.Rules(now)
-	nextFeeManager, err := feeManager.ComputeNext(blk.Tmstmp, now, r)
+	nextFeeManager, err := feeManager.ComputeNext(now, r)
 	if err != nil {
 		return []error{err}
 	}

--- a/window/window.go
+++ b/window/window.go
@@ -16,6 +16,7 @@ const (
 	WindowSliceSize = WindowSize * consts.Uint64Len
 )
 
+// TODO: how does this handle many consecutive updates of < 1s?
 type Window [WindowSliceSize]byte
 
 // Roll rolls the uint64s within [consumptionWindow] over by [roll] places.
@@ -34,7 +35,7 @@ type Window [WindowSliceSize]byte
 // Roll >= 4
 // [0, 0, 0, 0]
 // Assumes that [roll] is greater than or equal to 0
-func Roll(w Window, roll int) (Window, error) {
+func Roll(w Window, roll uint64) (Window, error) {
 	// Note: make allocates a zeroed array, so we are guaranteed
 	// that what we do not copy into, will be set to 0
 	res := [WindowSliceSize]byte{}


### PR DESCRIPTION
This PR migrates a bug fix from https://github.com/ava-labs/hypersdk/pull/1091 / https://github.com/ava-labs/hypersdk/commit/0a6a97a63807e0bc4b787df1bf12527adaeb0599

This fixes a bug where block timestamps are measured in milliseconds, but the fee manager only rolls the multi-dimensional consumption windows in 1s increments. This means that if blocks are produced < 1s apart, the fee manager observes each of these blocks as occurring 0s apart (rounding down).

This means that a sequence of N blocks each occurring < 1s apart, the fee manager will continue counting the consumption as occurring within the same interval since it uses the parent and current block timestamps as its only points of reference.