### PR TITLE
Manually implement `BorshSerialize` for `DeferDeserialize`

### DIFF
--- a/x/programs/rust/wasmlanche-sdk/src/program.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/program.rs
@@ -17,7 +17,7 @@ pub struct DeferDeserialize(Vec<u8>);
 impl BorshSerialize for DeferDeserialize {
     /// # Errors
     /// Returns a [`std::io::Error`] if there was an issue writing
-    fn serialize<W: std::io::prelude::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+    fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
         writer.write_all(&self.0)?;
         Ok(())
     }

--- a/x/programs/rust/wasmlanche-sdk/src/program.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/program.rs
@@ -18,8 +18,7 @@ impl BorshSerialize for DeferDeserialize {
     /// # Errors
     /// Returns a [`std::io::Error`] if there was an issue writing
     fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
-        writer.write_all(&self.0)?;
-        Ok(())
+        writer.write_all(&self.0)
     }
 }
 

--- a/x/programs/rust/wasmlanche-sdk/src/program.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/program.rs
@@ -16,7 +16,7 @@ pub struct DeferDeserialize(Vec<u8>);
 
 impl BorshSerialize for DeferDeserialize {
     /// # Errors
-    /// Returns a [`std::io::Error`] if there was an issue serializing the value
+    /// Returns a [`std::io::Error`] if there was an issue writing
     fn serialize<W: std::io::prelude::Write>(&self, writer: &mut W) -> std::io::Result<()> {
         writer.write_all(&self.0)?;
         Ok(())

--- a/x/programs/rust/wasmlanche-sdk/src/program.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/program.rs
@@ -14,6 +14,15 @@ use thiserror::Error;
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub struct DeferDeserialize(Vec<u8>);
 
+impl BorshSerialize for DeferDeserialize {
+    /// # Errors
+    /// Returns a [`std::io::Error`] if there was an issue serializing the value
+    fn serialize<W: std::io::prelude::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        writer.write_all(&self.0)?;
+        Ok(())
+    }
+}
+
 impl DeferDeserialize {
     /// # Errors
     /// Returns a [`std::io::Error`] if there was an issue deserializing the value


### PR DESCRIPTION
Closes https://github.com/ava-labs/hypersdk/issues/1123

Implement `BorshSerialize` for `DeferDeserialize` such that it doesn't encode the length. This is useful when `DeferDeserialize` is returned from functions such as ones that execute an arbitrary call and return the raw bytes as returned by the called function.