### PR TITLE
Refactor `vm.Config` out of `vm.Controller`

### DIFF
--- a/examples/morpheusvm/config/config.go
+++ b/examples/morpheusvm/config/config.go
@@ -10,7 +10,6 @@ import (
 )
 
 type Config struct {
-	// Misc
 	StoreTransactions bool          `json:"storeTransactions"`
 	TestMode          bool          `json:"testMode"` // makes gossip/building manual
 	LogLevel          logging.Level `json:"logLevel"`

--- a/examples/morpheusvm/config/config.go
+++ b/examples/morpheusvm/config/config.go
@@ -5,137 +5,28 @@ package config
 
 import (
 	"encoding/json"
-	"fmt"
-	"strings"
-	"time"
 
-	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/logging"
-	"github.com/ava-labs/avalanchego/utils/profiler"
-
-	"github.com/ava-labs/hypersdk/codec"
-	"github.com/ava-labs/hypersdk/examples/morpheusvm/consts"
-	"github.com/ava-labs/hypersdk/examples/morpheusvm/version"
-	"github.com/ava-labs/hypersdk/trace"
-	"github.com/ava-labs/hypersdk/vm"
-)
-
-const (
-	defaultContinuousProfilerFrequency = 1 * time.Minute
-	defaultContinuousProfilerMaxFiles  = 10
-	defaultStoreTransactions           = true
 )
 
 type Config struct {
-	vm.Config
-
-	// Concurrency
-	AuthVerificationCores     int `json:"authVerificationCores"`
-	RootGenerationCores       int `json:"rootGenerationCores"`
-	TransactionExecutionCores int `json:"transactionExecutionCores"`
-	StateFetchConcurrency     int `json:"stateFetchConcurrency"`
-
-	// Tracing
-	TraceEnabled    bool    `json:"traceEnabled"`
-	TraceSampleRate float64 `json:"traceSampleRate"`
-
-	// Profiling
-	ContinuousProfilerDir string `json:"continuousProfilerDir"` // "*" is replaced with rand int
-
-	// Streaming settings
-	StreamingBacklogSize int `json:"streamingBacklogSize"`
-
-	// Mempool
-	MempoolSize           int      `json:"mempoolSize"`
-	MempoolSponsorSize    int      `json:"mempoolSponsorSize"`
-	MempoolExemptSponsors []string `json:"mempoolExemptSponsors"`
-
 	// Misc
-	VerifyAuth        bool          `json:"verifyAuth"`
 	StoreTransactions bool          `json:"storeTransactions"`
 	TestMode          bool          `json:"testMode"` // makes gossip/building manual
 	LogLevel          logging.Level `json:"logLevel"`
-
-	// State Sync
-	StateSyncServerDelay time.Duration `json:"stateSyncServerDelay"` // for testing
-
-	loaded               bool
-	nodeID               ids.NodeID
-	parsedExemptSponsors []codec.Address
 }
 
-func New(nodeID ids.NodeID, b []byte) (*Config, error) {
-	c := &Config{nodeID: nodeID}
-	c.setDefault()
+func New(b []byte) (*Config, error) {
+	c := &Config{
+		StoreTransactions: true,
+		LogLevel:          logging.Info,
+	}
+
 	if len(b) > 0 {
 		if err := json.Unmarshal(b, c); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal config %s: %w", string(b), err)
-		}
-		c.loaded = true
-	}
-
-	// Parse any exempt sponsors (usually used when a single account is
-	// broadcasting many txs at once)
-	c.parsedExemptSponsors = make([]codec.Address, len(c.MempoolExemptSponsors))
-	for i, sponsor := range c.MempoolExemptSponsors {
-		p, err := codec.ParseAddressBech32(consts.HRP, sponsor)
-		if err != nil {
 			return nil, err
 		}
-		c.parsedExemptSponsors[i] = p
 	}
+
 	return c, nil
 }
-
-func (c *Config) setDefault() {
-	c.Config = vm.NewConfig()
-	c.LogLevel = logging.Info
-	c.AuthVerificationCores = c.Config.AuthVerificationCores
-	c.RootGenerationCores = c.Config.RootGenerationCores
-	c.TransactionExecutionCores = c.Config.TransactionExecutionCores
-	c.StateFetchConcurrency = c.Config.StateFetchConcurrency
-	c.MempoolSize = c.Config.MempoolSize
-	c.MempoolSponsorSize = c.Config.MempoolSponsorSize
-	c.StateSyncServerDelay = c.Config.StateSyncServerDelay
-	c.StreamingBacklogSize = c.Config.StreamingBacklogSize
-	c.VerifyAuth = c.Config.VerifyAuth
-	c.StoreTransactions = defaultStoreTransactions
-}
-
-func (c *Config) GetLogLevel() logging.Level                { return c.LogLevel }
-func (c *Config) GetTestMode() bool                         { return c.TestMode }
-func (c *Config) GetAuthVerificationCores() int             { return c.AuthVerificationCores }
-func (c *Config) GetRootGenerationCores() int               { return c.RootGenerationCores }
-func (c *Config) GetTransactionExecutionCores() int         { return c.TransactionExecutionCores }
-func (c *Config) GetStateFetchConcurrency() int             { return c.StateFetchConcurrency }
-func (c *Config) GetMempoolSize() int                       { return c.MempoolSize }
-func (c *Config) GetMempoolSponsorSize() int                { return c.MempoolSponsorSize }
-func (c *Config) GetMempoolExemptSponsors() []codec.Address { return c.parsedExemptSponsors }
-func (c *Config) GetTraceConfig() *trace.Config {
-	return &trace.Config{
-		Enabled:         c.TraceEnabled,
-		TraceSampleRate: c.TraceSampleRate,
-		AppName:         consts.Name,
-		Agent:           c.nodeID.String(),
-		Version:         version.Version.String(),
-	}
-}
-func (c *Config) GetStateSyncServerDelay() time.Duration { return c.StateSyncServerDelay }
-func (c *Config) GetStreamingBacklogSize() int           { return c.StreamingBacklogSize }
-func (c *Config) GetContinuousProfilerConfig() *profiler.Config {
-	if len(c.ContinuousProfilerDir) == 0 {
-		return &profiler.Config{Enabled: false}
-	}
-	// Replace all instances of "*" with nodeID. This is useful when
-	// running multiple instances of morpheusvm on the same machine.
-	c.ContinuousProfilerDir = strings.ReplaceAll(c.ContinuousProfilerDir, "*", c.nodeID.String())
-	return &profiler.Config{
-		Enabled:     true,
-		Dir:         c.ContinuousProfilerDir,
-		Freq:        defaultContinuousProfilerFrequency,
-		MaxNumFiles: defaultContinuousProfilerMaxFiles,
-	}
-}
-func (c *Config) GetVerifyAuth() bool        { return c.VerifyAuth }
-func (c *Config) GetStoreTransactions() bool { return c.StoreTransactions }
-func (c *Config) Loaded() bool               { return c.loaded }

--- a/examples/morpheusvm/controller/controller.go
+++ b/examples/morpheusvm/controller/controller.go
@@ -27,7 +27,6 @@ import (
 	"github.com/ava-labs/hypersdk/vm"
 
 	ametrics "github.com/ava-labs/avalanchego/api/metrics"
-
 	hrpc "github.com/ava-labs/hypersdk/rpc"
 	hstorage "github.com/ava-labs/hypersdk/storage"
 )

--- a/examples/morpheusvm/controller/controller.go
+++ b/examples/morpheusvm/controller/controller.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ava-labs/hypersdk/vm"
 
 	ametrics "github.com/ava-labs/avalanchego/api/metrics"
+
 	hrpc "github.com/ava-labs/hypersdk/rpc"
 	hstorage "github.com/ava-labs/hypersdk/storage"
 )
@@ -58,7 +59,6 @@ func (c *Controller) Initialize(
 	upgradeBytes []byte, // subnets to allow for AWM
 	configBytes []byte,
 ) (
-	vm.Config,
 	vm.Genesis,
 	builder.Builder,
 	gossiper.Gossiper,
@@ -76,20 +76,21 @@ func (c *Controller) Initialize(
 	var err error
 	c.metrics, err = newMetrics(gatherer)
 	if err != nil {
-		return vm.Config{}, nil, nil, nil, nil, nil, nil, nil, err
+		return nil, nil, nil, nil, nil, nil, nil, err
 	}
 
 	// Load config and genesis
-	c.config, err = config.New(c.snowCtx.NodeID, configBytes)
+	c.config, err = config.New(configBytes)
 	if err != nil {
-		return vm.Config{}, nil, nil, nil, nil, nil, nil, nil, err
+		return nil, nil, nil, nil, nil, nil, nil, err
 	}
-	c.snowCtx.Log.SetLevel(c.config.GetLogLevel())
-	snowCtx.Log.Info("initialized config", zap.Bool("loaded", c.config.Loaded()), zap.Any("contents", c.config))
+
+	c.snowCtx.Log.SetLevel(c.config.LogLevel)
+	snowCtx.Log.Info("initialized config", zap.Any("contents", c.config))
 
 	c.genesis, err = genesis.New(genesisBytes, upgradeBytes)
 	if err != nil {
-		return vm.Config{}, nil, nil, nil, nil, nil, nil, nil, fmt.Errorf(
+		return nil, nil, nil, nil, nil, nil, nil, fmt.Errorf(
 			"unable to read genesis: %w",
 			err,
 		)
@@ -98,7 +99,7 @@ func (c *Controller) Initialize(
 
 	c.db, err = hstorage.New(pebble.NewDefaultConfig(), snowCtx.ChainDataDir, "db", gatherer)
 	if err != nil {
-		return vm.Config{}, nil, nil, nil, nil, nil, nil, nil, err
+		return nil, nil, nil, nil, nil, nil, nil, err
 	}
 
 	// Create handlers
@@ -111,7 +112,7 @@ func (c *Controller) Initialize(
 		rpc.NewJSONRPCServer(c),
 	)
 	if err != nil {
-		return vm.Config{}, nil, nil, nil, nil, nil, nil, nil, err
+		return nil, nil, nil, nil, nil, nil, nil, err
 	}
 	apis[rpc.JSONRPCEndpoint] = jsonRPCHandler
 
@@ -129,10 +130,10 @@ func (c *Controller) Initialize(
 		gcfg := gossiper.DefaultProposerConfig()
 		gossip, err = gossiper.NewProposer(inner, gcfg)
 		if err != nil {
-			return vm.Config{}, nil, nil, nil, nil, nil, nil, nil, err
+			return nil, nil, nil, nil, nil, nil, nil, err
 		}
 	}
-	return c.config.Config, c.genesis, build, gossip, apis, consts.ActionRegistry, consts.AuthRegistry, auth.Engines(), nil
+	return c.genesis, build, gossip, apis, consts.ActionRegistry, consts.AuthRegistry, auth.Engines(), nil
 }
 
 func (c *Controller) Rules(t int64) chain.Rules {
@@ -151,7 +152,7 @@ func (c *Controller) Accepted(ctx context.Context, blk *chain.StatelessBlock) er
 	results := blk.Results()
 	for i, tx := range blk.Txs {
 		result := results[i]
-		if c.config.GetStoreTransactions() {
+		if c.config.StoreTransactions {
 			err := storage.StoreTransaction(
 				ctx,
 				batch,

--- a/examples/morpheusvm/tests/integration/integration_test.go
+++ b/examples/morpheusvm/tests/integration/integration_test.go
@@ -221,7 +221,13 @@ var _ = ginkgo.BeforeSuite(func() {
 			genesisBytes,
 			nil,
 			[]byte(
-				`{"parallelism":3, "testMode":true, "logLevel":"debug"}`,
+				`{
+				  "config": {
+				    "parallelism":3,
+				    "testMode":true,
+				    "logLevel":"debug"
+				  }
+				}`,
 			),
 			toEngine,
 			nil,

--- a/examples/tokenvm/config/config.go
+++ b/examples/tokenvm/config/config.go
@@ -5,59 +5,19 @@ package config
 
 import (
 	"encoding/json"
-	"fmt"
-	"strings"
-	"time"
 
-	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/logging"
-	"github.com/ava-labs/avalanchego/utils/profiler"
 
-	"github.com/ava-labs/hypersdk/codec"
-	"github.com/ava-labs/hypersdk/examples/tokenvm/consts"
-	"github.com/ava-labs/hypersdk/examples/tokenvm/version"
 	"github.com/ava-labs/hypersdk/gossiper"
-	"github.com/ava-labs/hypersdk/trace"
-	"github.com/ava-labs/hypersdk/vm"
-)
-
-const (
-	defaultContinuousProfilerFrequency = 1 * time.Minute
-	defaultContinuousProfilerMaxFiles  = 10
-	defaultStoreTransactions           = true
-	defaultMaxOrdersPerPair            = 1024
 )
 
 type Config struct {
-	vm.Config
-
-	// Concurrency
-	AuthVerificationCores     int `json:"authVerificationCores"`
-	RootGenerationCores       int `json:"rootGenerationCores"`
-	TransactionExecutionCores int `json:"transactionExecutionCores"`
-	StateFetchConcurrency     int `json:"stateFetchConcurrency"`
-
 	// Gossip
 	GossipMaxSize       int   `json:"gossipMaxSize"`
 	GossipProposerDiff  int   `json:"gossipProposerDiff"`
 	GossipProposerDepth int   `json:"gossipProposerDepth"`
 	NoGossipBuilderDiff int   `json:"noGossipBuilderDiff"`
 	VerifyTimeout       int64 `json:"verifyTimeout"`
-
-	// Tracing
-	TraceEnabled    bool    `json:"traceEnabled"`
-	TraceSampleRate float64 `json:"traceSampleRate"`
-
-	// Profiling
-	ContinuousProfilerDir string `json:"continuousProfilerDir"` // "*" is replaced with rand int
-
-	// Streaming settings
-	StreamingBacklogSize int `json:"streamingBacklogSize"`
-
-	// Mempool
-	MempoolSize           int      `json:"mempoolSize"`
-	MempoolSponsorSize    int      `json:"mempoolSponsorSize"`
-	MempoolExemptSponsors []string `json:"mempoolExemptSponsors"`
 
 	// Order Book
 	//
@@ -66,98 +26,29 @@ type Config struct {
 	TrackedPairs     []string `json:"trackedPairs"` // which asset ID pairs we care about
 
 	// Misc
-	VerifyAuth        bool          `json:"verifyAuth"`
 	StoreTransactions bool          `json:"storeTransactions"`
 	TestMode          bool          `json:"testMode"` // makes gossip/building manual
 	LogLevel          logging.Level `json:"logLevel"`
-
-	// State Sync
-	StateSyncServerDelay time.Duration `json:"stateSyncServerDelay"` // for testing
-
-	loaded               bool
-	nodeID               ids.NodeID
-	parsedExemptSponsors []codec.Address
 }
 
-func New(nodeID ids.NodeID, b []byte) (*Config, error) {
-	c := &Config{nodeID: nodeID}
-	c.setDefault()
+func New(b []byte) (*Config, error) {
+	gcfg := gossiper.DefaultProposerConfig()
+	c := &Config{
+		LogLevel:            logging.Info,
+		GossipMaxSize:       gcfg.GossipMaxSize,
+		GossipProposerDiff:  gcfg.GossipProposerDiff,
+		GossipProposerDepth: gcfg.GossipProposerDepth,
+		NoGossipBuilderDiff: gcfg.NoGossipBuilderDiff,
+		VerifyTimeout:       gcfg.VerifyTimeout,
+		StoreTransactions:   true,
+		MaxOrdersPerPair:    1024,
+	}
+
 	if len(b) > 0 {
 		if err := json.Unmarshal(b, c); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal config %s: %w", string(b), err)
-		}
-		c.loaded = true
-	}
-
-	// Parse any exempt sponsors (usually used when a single account is
-	// broadcasting many txs at once)
-	c.parsedExemptSponsors = make([]codec.Address, len(c.MempoolExemptSponsors))
-	for i, sponsor := range c.MempoolExemptSponsors {
-		p, err := codec.ParseAddressBech32(consts.HRP, sponsor)
-		if err != nil {
 			return nil, err
 		}
-		c.parsedExemptSponsors[i] = p
 	}
+
 	return c, nil
 }
-
-func (c *Config) setDefault() {
-	c.Config = vm.NewConfig()
-	c.LogLevel = logging.Info
-	gcfg := gossiper.DefaultProposerConfig()
-	c.GossipMaxSize = gcfg.GossipMaxSize
-	c.GossipProposerDiff = gcfg.GossipProposerDiff
-	c.GossipProposerDepth = gcfg.GossipProposerDepth
-	c.NoGossipBuilderDiff = gcfg.NoGossipBuilderDiff
-	c.VerifyTimeout = gcfg.VerifyTimeout
-	c.AuthVerificationCores = c.Config.AuthVerificationCores
-	c.RootGenerationCores = c.Config.RootGenerationCores
-	c.TransactionExecutionCores = c.Config.TransactionExecutionCores
-	c.StateFetchConcurrency = c.Config.StateFetchConcurrency
-	c.MempoolSize = c.Config.MempoolSize
-	c.MempoolSponsorSize = c.Config.MempoolSponsorSize
-	c.StateSyncServerDelay = c.Config.StateSyncServerDelay
-	c.StreamingBacklogSize = c.Config.StreamingBacklogSize
-	c.VerifyAuth = c.Config.VerifyAuth
-	c.StoreTransactions = defaultStoreTransactions
-	c.MaxOrdersPerPair = defaultMaxOrdersPerPair
-}
-
-func (c *Config) GetLogLevel() logging.Level                { return c.LogLevel }
-func (c *Config) GetTestMode() bool                         { return c.TestMode }
-func (c *Config) GetAuthVerificationCores() int             { return c.AuthVerificationCores }
-func (c *Config) GetRootGenerationCores() int               { return c.RootGenerationCores }
-func (c *Config) GetTransactionExecutionCores() int         { return c.TransactionExecutionCores }
-func (c *Config) GetStateFetchConcurrency() int             { return c.StateFetchConcurrency }
-func (c *Config) GetMempoolSize() int                       { return c.MempoolSize }
-func (c *Config) GetMempoolSponsorSize() int                { return c.MempoolSponsorSize }
-func (c *Config) GetMempoolExemptSponsors() []codec.Address { return c.parsedExemptSponsors }
-func (c *Config) GetTraceConfig() *trace.Config {
-	return &trace.Config{
-		Enabled:         c.TraceEnabled,
-		TraceSampleRate: c.TraceSampleRate,
-		AppName:         consts.Name,
-		Agent:           c.nodeID.String(),
-		Version:         version.Version.String(),
-	}
-}
-func (c *Config) GetStateSyncServerDelay() time.Duration { return c.StateSyncServerDelay }
-func (c *Config) GetStreamingBacklogSize() int           { return c.StreamingBacklogSize }
-func (c *Config) GetContinuousProfilerConfig() *profiler.Config {
-	if len(c.ContinuousProfilerDir) == 0 {
-		return &profiler.Config{Enabled: false}
-	}
-	// Replace all instances of "*" with nodeID. This is useful when
-	// running multiple instances of tokenvm on the same machine.
-	c.ContinuousProfilerDir = strings.ReplaceAll(c.ContinuousProfilerDir, "*", c.nodeID.String())
-	return &profiler.Config{
-		Enabled:     true,
-		Dir:         c.ContinuousProfilerDir,
-		Freq:        defaultContinuousProfilerFrequency,
-		MaxNumFiles: defaultContinuousProfilerMaxFiles,
-	}
-}
-func (c *Config) GetVerifyAuth() bool        { return c.VerifyAuth }
-func (c *Config) GetStoreTransactions() bool { return c.StoreTransactions }
-func (c *Config) Loaded() bool               { return c.loaded }

--- a/examples/tokenvm/controller/controller.go
+++ b/examples/tokenvm/controller/controller.go
@@ -28,7 +28,6 @@ import (
 	"github.com/ava-labs/hypersdk/vm"
 
 	ametrics "github.com/ava-labs/avalanchego/api/metrics"
-
 	hrpc "github.com/ava-labs/hypersdk/rpc"
 	hstorage "github.com/ava-labs/hypersdk/storage"
 )

--- a/examples/tokenvm/tests/integration/integration_test.go
+++ b/examples/tokenvm/tests/integration/integration_test.go
@@ -242,7 +242,14 @@ var _ = ginkgo.BeforeSuite(func() {
 			genesisBytes,
 			nil,
 			[]byte(
-				`{"parallelism":3, "testMode":true, "logLevel":"debug", "trackedPairs":["*"]}`,
+				`{
+				  "config": {
+				    "parallelism":3,
+				    "testMode":true,
+				    "logLevel":"debug",
+				    "trackedPairs":["*"]
+				  }
+				}`,
 			),
 			toEngine,
 			nil,

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -55,7 +55,7 @@ func TestMempool(t *testing.T) {
 
 	ctx := context.TODO()
 	tracer, _ := trace.New(&trace.Config{Enabled: false})
-	txm := New[*TestItem](tracer, 3, 16, nil)
+	txm := New[*TestItem](tracer, 3, 16)
 
 	for _, i := range []int64{100, 200, 300, 400} {
 		item := GenerateTestItem(testSponsor, i)
@@ -75,7 +75,7 @@ func TestMempoolAddDuplicates(t *testing.T) {
 	defer ctrl.Finish()
 	ctx := context.TODO()
 	tracer, _ := trace.New(&trace.Config{Enabled: false})
-	txm := New[*TestItem](tracer, 3, 16, nil)
+	txm := New[*TestItem](tracer, 3, 16)
 	// Generate item
 	item := GenerateTestItem(testSponsor, 300)
 	items := []*TestItem{item}
@@ -97,20 +97,16 @@ func TestMempoolAddExceedMaxSponsorSize(t *testing.T) {
 	defer ctrl.Finish()
 	ctx := context.TODO()
 	tracer, _ := trace.New(&trace.Config{Enabled: false})
-	exemptSponsor := codec.CreateAddress(99, ids.GenerateTestID())
 	sponsor := codec.CreateAddress(4, ids.GenerateTestID())
 	// Non exempt sponsors max of 4
-	txm := New[*TestItem](tracer, 20, 4, []codec.Address{exemptSponsor})
+	txm := New[*TestItem](tracer, 20, 4)
 	// Add 6 transactions for each sponsor
 	for i := int64(0); i <= 5; i++ {
 		itemSponsor := GenerateTestItem(sponsor, i)
-		itemExempt := GenerateTestItem(exemptSponsor, i)
-		items := []*TestItem{itemSponsor, itemExempt}
-		txm.Add(ctx, items)
+		txm.Add(ctx, []*TestItem{itemSponsor})
 	}
-	require.Equal(10, txm.Len(ctx), "Mempool has incorrect txs.")
+	require.Equal(4, txm.Len(ctx), "Mempool has incorrect txs.")
 	require.Equal(4, txm.owned[sponsor], "Sponsor has incorrect txs.")
-	require.Equal(6, txm.owned[exemptSponsor], "Sponsor has incorrect txs.")
 }
 
 func TestMempoolAddExceedMaxSize(t *testing.T) {
@@ -120,7 +116,7 @@ func TestMempoolAddExceedMaxSize(t *testing.T) {
 	ctx := context.TODO()
 	tracer, _ := trace.New(&trace.Config{Enabled: false})
 
-	txm := New[*TestItem](tracer, 3, 20, nil)
+	txm := New[*TestItem](tracer, 3, 20)
 	// Add more tx's than txm.maxSize
 	for i := int64(0); i < 10; i++ {
 		item := GenerateTestItem(testSponsor, i)
@@ -150,7 +146,7 @@ func TestMempoolRemoveTxs(t *testing.T) {
 	ctx := context.TODO()
 	tracer, _ := trace.New(&trace.Config{Enabled: false})
 
-	txm := New[*TestItem](tracer, 3, 20, nil)
+	txm := New[*TestItem](tracer, 3, 20)
 	// Add
 	item := GenerateTestItem(testSponsor, 10)
 	items := []*TestItem{item}
@@ -170,7 +166,7 @@ func TestMempoolSetMinTimestamp(t *testing.T) {
 	ctx := context.TODO()
 	tracer, _ := trace.New(&trace.Config{Enabled: false})
 
-	txm := New[*TestItem](tracer, 20, 20, nil)
+	txm := New[*TestItem](tracer, 20, 20)
 	// Add more tx's than txm.maxSize
 	for i := int64(0); i < 10; i++ {
 		item := GenerateTestItem(testSponsor, i)

--- a/vm/dependencies.go
+++ b/vm/dependencies.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/ava-labs/hypersdk/builder"
 	"github.com/ava-labs/hypersdk/chain"
-	"github.com/ava-labs/hypersdk/codec"
 	"github.com/ava-labs/hypersdk/gossiper"
 	"github.com/ava-labs/hypersdk/state"
 	"github.com/ava-labs/hypersdk/trace"
@@ -27,33 +26,34 @@ import (
 type Handlers map[string]http.Handler
 
 type Config struct {
-	TraceConfig                      trace.Config
-	MempoolSize                      int
-	AuthVerificationCores            int
-	VerifyAuth                       bool
-	RootGenerationCores              int
-	TransactionExecutionCores        int
-	StateFetchConcurrency            int
-	MempoolSponsorSize               int
-	MempoolExemptSponsors            []codec.Address
-	StreamingBacklogSize             int
-	StateHistoryLength               int // how many roots back of data to keep to serve state queries
-	IntermediateNodeCacheSize        int // how many bytes to keep in intermediate cache
-	StateIntermediateWriteBufferSize int // how many bytes to keep unwritten in intermediate cache
-	StateIntermediateWriteBatchSize  int // how many bytes to write from intermediate cache at once
-	ValueNodeCacheSize               int // how many bytes to keep in value cache
-	AcceptorSize                     int // how far back we can fall in processing accepted blocks
-	StateSyncParallelism             int
-	StateSyncMinBlocks               uint64
-	StateSyncServerDelay             time.Duration
-	ParsedBlockCacheSize             int
-	AcceptedBlockWindow              int
-	AcceptedBlockWindowCache         int
-	ContinuousProfilerConfig         profiler.Config
-	TargetBuildDuration              time.Duration
-	ProcessingBuildSkip              int
-	TargetGossipDuration             time.Duration
-	BlockCompactionFrequency         int
+	TraceConfig                      trace.Config    `json:"traceConfig"`
+	MempoolSize                      int             `json:"mempoolSize"`
+	AuthVerificationCores            int             `json:"authVerificationCores"`
+	VerifyAuth                       bool            `json:"verifyAuth"`
+	RootGenerationCores              int             `json:"rootGenerationCores"`
+	TransactionExecutionCores        int             `json:"transactionExecutionCores"`
+	StateFetchConcurrency            int             `json:"stateFetchConcurrency"`
+	MempoolSponsorSize               int             `json:"mempoolSponsorSize"`
+	StreamingBacklogSize             int             `json:"streamingBacklogSize"`
+	StateHistoryLength               int             `json:"stateHistoryLength"`               // how many roots back of data to keep to serve state queries
+	IntermediateNodeCacheSize        int             `json:"intermediateNodeCacheSize"`        // how many bytes to keep in intermediate cache
+	StateIntermediateWriteBufferSize int             `json:"stateIntermediateWriteBufferSize"` // how many bytes to keep unwritten in intermediate cache
+	StateIntermediateWriteBatchSize  int             `json:"stateIntermediateWriteBatchSize"`  // how many bytes to write from intermediate cache at once
+	ValueNodeCacheSize               int             `json:"valueNodeCacheSize"`               // how many bytes to keep in value cache
+	AcceptorSize                     int             `json:"acceptorSize"`                     // how far back we can fall in processing accepted blocks
+	StateSyncParallelism             int             `json:"stateSyncParallelism"`
+	StateSyncMinBlocks               uint64          `json:"stateSyncMinBlocks"`
+	StateSyncServerDelay             time.Duration   `json:"stateSyncServerDelay"`
+	ParsedBlockCacheSize             int             `json:"parsedBlockCacheSize"`
+	AcceptedBlockWindow              int             `json:"acceptedBlockWindow"`
+	AcceptedBlockWindowCache         int             `json:"acceptedBlockWindowCache"`
+	ContinuousProfilerConfig         profiler.Config `json:"continuousProfilerConfig"`
+	TargetBuildDuration              time.Duration   `json:"targetBuildDuration"`
+	ProcessingBuildSkip              int             `json:"processingBuildSkip"`
+	TargetGossipDuration             time.Duration   `json:"targetGossipDuration"`
+	BlockCompactionFrequency         int             `json:"blockCompactionFrequency"`
+	// Config is defined by the Controller
+	Config map[string]any `json:"config"`
 }
 
 func NewConfig() Config {
@@ -66,8 +66,6 @@ func NewConfig() Config {
 		TransactionExecutionCores:        1,
 		StateFetchConcurrency:            1,
 		MempoolSponsorSize:               32,
-		MempoolExemptSponsors:            nil,
-		StreamingBacklogSize:             1_024,
 		StateHistoryLength:               256,
 		IntermediateNodeCacheSize:        4 * units.GiB,
 		StateIntermediateWriteBufferSize: 32 * units.MiB,
@@ -108,7 +106,6 @@ type Controller interface {
 		upgradeBytes []byte,
 		configBytes []byte,
 	) (
-		config Config,
 		genesis Genesis,
 		builder builder.Builder,
 		gossiper gossiper.Gossiper,

--- a/vm/mock_controller.go
+++ b/vm/mock_controller.go
@@ -62,19 +62,18 @@ func (mr *MockControllerMockRecorder) Accepted(arg0, arg1 any) *gomock.Call {
 }
 
 // Initialize mocks base method.
-func (m *MockController) Initialize(arg0 *VM, arg1 *snow.Context, arg2 metrics.MultiGatherer, arg3, arg4, arg5 []byte) (Config, Genesis, builder.Builder, gossiper.Gossiper, Handlers, chain.ActionRegistry, chain.AuthRegistry, map[byte]AuthEngine, error) {
+func (m *MockController) Initialize(arg0 *VM, arg1 *snow.Context, arg2 metrics.MultiGatherer, arg3, arg4, arg5 []byte) (Genesis, builder.Builder, gossiper.Gossiper, Handlers, chain.ActionRegistry, chain.AuthRegistry, map[byte]AuthEngine, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Initialize", arg0, arg1, arg2, arg3, arg4, arg5)
-	ret0, _ := ret[0].(Config)
-	ret1, _ := ret[1].(Genesis)
-	ret2, _ := ret[2].(builder.Builder)
-	ret3, _ := ret[3].(gossiper.Gossiper)
-	ret4, _ := ret[4].(Handlers)
-	ret5, _ := ret[5].(chain.ActionRegistry)
-	ret6, _ := ret[6].(chain.AuthRegistry)
-	ret7, _ := ret[7].(map[byte]AuthEngine)
-	ret8, _ := ret[8].(error)
-	return ret0, ret1, ret2, ret3, ret4, ret5, ret6, ret7, ret8
+	ret0, _ := ret[0].(Genesis)
+	ret1, _ := ret[1].(builder.Builder)
+	ret2, _ := ret[2].(gossiper.Gossiper)
+	ret3, _ := ret[3].(Handlers)
+	ret4, _ := ret[4].(chain.ActionRegistry)
+	ret5, _ := ret[5].(chain.AuthRegistry)
+	ret6, _ := ret[6].(map[byte]AuthEngine)
+	ret7, _ := ret[7].(error)
+	return ret0, ret1, ret2, ret3, ret4, ret5, ret6, ret7
 }
 
 // Initialize indicates an expected call of Initialize.

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -6,6 +6,7 @@ package vm
 import (
 	"context"
 	"encoding/binary"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"path/filepath"
@@ -129,7 +130,11 @@ type VM struct {
 }
 
 func New(c Controller, v *version.Semantic) *VM {
-	return &VM{c: c, v: v}
+	return &VM{
+		c:      c,
+		v:      v,
+		config: NewConfig(),
+	}
 }
 
 // implements "block.ChainVM.common.VM"
@@ -200,14 +205,23 @@ func (vm *VM) Initialize(
 		ChainDataDir:   filepath.Join(vm.snowCtx.ChainDataDir, vmDataDir),
 	}
 
+	if err := json.Unmarshal(configBytes, &vm.config); err != nil {
+		return fmt.Errorf("failed to unmarshal config: %w", err)
+	}
+
+	controllerConfigBytes, err := json.Marshal(vm.config.Config)
+	if err != nil {
+		return fmt.Errorf("failed to marshal controller config: %w", err)
+	}
+
 	// Always initialize implementation first
-	vm.config, vm.genesis, vm.builder, vm.gossiper, vm.handlers, vm.actionRegistry, vm.authRegistry, vm.authEngine, err = vm.c.Initialize(
+	vm.genesis, vm.builder, vm.gossiper, vm.handlers, vm.actionRegistry, vm.authRegistry, vm.authEngine, err = vm.c.Initialize(
 		vm,
 		controllerContext,
 		controllerContext.Metrics,
 		genesisBytes,
 		upgradeBytes,
-		configBytes,
+		controllerConfigBytes,
 	)
 	if err != nil {
 		return fmt.Errorf("implementation initialization failed: %w", err)
@@ -272,12 +286,7 @@ func (vm *VM) Initialize(
 	vm.acceptedQueue = make(chan *chain.StatelessBlock, vm.config.AcceptorSize)
 	vm.acceptorDone = make(chan struct{})
 
-	vm.mempool = mempool.New[*chain.Transaction](
-		vm.tracer,
-		vm.config.MempoolSize,
-		vm.config.MempoolSponsorSize,
-		vm.config.MempoolExemptSponsors,
-	)
+	vm.mempool = mempool.New[*chain.Transaction](vm.tracer, vm.config.MempoolSize, vm.config.MempoolSponsorSize)
 
 	// Try to load last accepted
 	has, err := vm.HasLastAccepted()

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -51,7 +51,7 @@ func TestBlockCache(t *testing.T) {
 
 		verifiedBlocks: make(map[ids.ID]*chain.StatelessBlock),
 		seen:           emap.NewEMap[*chain.Transaction](),
-		mempool:        mempool.New[*chain.Transaction](tracer, 100, 32, nil),
+		mempool:        mempool.New[*chain.Transaction](tracer, 100, 32),
 		acceptedQueue:  make(chan *chain.StatelessBlock, 1024), // don't block on queue
 		c:              controller,
 	}


### PR DESCRIPTION
`Controller` implementations are supposed to parse the provided config bytes upon initialization into a hypersdk config. This PR parses the config in the hypersdk, and supplies the remaining bytes to the controller to reduce boilerplate code in the implementation.