### PR TITLE
Expose state functions from context

### DIFF
--- a/x/programs/cmd/simulator/src/lib.rs
+++ b/x/programs/cmd/simulator/src/lib.rs
@@ -12,7 +12,7 @@ use std::{
     process::{Child, Command, Stdio},
 };
 use thiserror::Error;
-use wasmlanche_sdk::{types::Address, ExternalCallError};
+use wasmlanche_sdk::{Address, ExternalCallError};
 
 mod id;
 

--- a/x/programs/cmd/simulator/test/context_injection/src/lib.rs
+++ b/x/programs/cmd/simulator/test/context_injection/src/lib.rs
@@ -1,4 +1,4 @@
-use wasmlanche_sdk::{public, types::Address, Context};
+use wasmlanche_sdk::{public, Address, Context};
 
 #[public]
 pub fn get_timestamp(context: Context) -> u64 {
@@ -18,7 +18,7 @@ pub fn get_actor(context: Context) -> Address {
 #[cfg(test)]
 mod tests {
     use simulator::{ClientBuilder, Endpoint, Key, Step, TestContext};
-    use wasmlanche_sdk::types::Address;
+    use wasmlanche_sdk::Address;
 
     const PROGRAM_PATH: &str = env!("PROGRAM_PATH");
 

--- a/x/programs/rust/examples/automated-market-maker/src/lib.rs
+++ b/x/programs/rust/examples/automated-market-maker/src/lib.rs
@@ -1,4 +1,4 @@
-use wasmlanche_sdk::{public, state_keys, Context, Program};
+use wasmlanche_sdk::{public, state_keys, Context};
 
 #[state_keys]
 pub enum StateKeys {
@@ -12,13 +12,12 @@ pub enum StateKeys {
 
 #[public]
 pub fn add_liquidity(context: Context<StateKeys>, amount_x: u64, amount_y: u64) -> u64 {
-    let program = context.program();
-    let total_supply = total_supply(program);
+    let total_supply = total_supply(&context);
     // tokens    | shares
     // -------------------------
     // amount_x  | minted
     // reserve_x | total_supply
-    let (reserve_x, reserve_y) = reserves(program);
+    let (reserve_x, reserve_y) = reserves(&context);
     let minted = if total_supply == 0 {
         let minted = amount_x;
         assert_eq!(minted, amount_y);
@@ -29,8 +28,7 @@ pub fn add_liquidity(context: Context<StateKeys>, amount_x: u64, amount_y: u64) 
         minted
     };
 
-    program
-        .state()
+    context
         .store([
             (StateKeys::ReserveX, &(reserve_x + amount_x)),
             (StateKeys::ReserveY, &(reserve_y + amount_y)),
@@ -43,16 +41,14 @@ pub fn add_liquidity(context: Context<StateKeys>, amount_x: u64, amount_y: u64) 
 
 #[public]
 pub fn remove_liquidity(context: Context<StateKeys>, shares: u64) -> (u64, u64) {
-    let program = context.program();
-    let total_supply = total_supply(program);
-    let (reserve_x, reserve_y) = reserves(program);
+    let total_supply = total_supply(&context);
+    let (reserve_x, reserve_y) = reserves(&context);
     let (amount_x, amount_y) = (
         shares * reserve_x / total_supply,
         shares * reserve_y / total_supply,
     );
 
-    program
-        .state()
+    context
         .store([
             (StateKeys::ReserveX, &(reserve_x - amount_x)),
             (StateKeys::ReserveY, &(reserve_y - amount_y)),
@@ -65,8 +61,7 @@ pub fn remove_liquidity(context: Context<StateKeys>, shares: u64) -> (u64, u64) 
 
 #[public]
 pub fn swap(context: Context<StateKeys>, amount_in: u64, x_to_y: bool) -> u64 {
-    let program = context.program();
-    let total_supply = total_supply(program);
+    let total_supply = total_supply(&context);
     assert!(total_supply > 0, "no liquidity");
     // x * y = constant
     // x' = x + dx
@@ -76,7 +71,7 @@ pub fn swap(context: Context<StateKeys>, amount_in: u64, x_to_y: bool) -> u64 {
     // dy = ((x * y) / (x + dx)) - y
     // skip a few steps
     // -dy = y * dx / (x + dx)
-    let (reserve_x, reserve_y) = reserves(context.program());
+    let (reserve_x, reserve_y) = reserves(&context);
     let (reserve_x, reserve_y, out) = if x_to_y {
         let dy = (reserve_y * amount_in) / (reserve_x + amount_in);
         (reserve_x + amount_in, reserve_y - dy, dy)
@@ -85,8 +80,7 @@ pub fn swap(context: Context<StateKeys>, amount_in: u64, x_to_y: bool) -> u64 {
         (reserve_x - dx, reserve_y + amount_in, dx)
     };
 
-    program
-        .state()
+    context
         .store([
             (StateKeys::ReserveX, &reserve_x),
             (StateKeys::ReserveY, &reserve_y),
@@ -96,23 +90,20 @@ pub fn swap(context: Context<StateKeys>, amount_in: u64, x_to_y: bool) -> u64 {
     out
 }
 
-fn total_supply(program: &Program<StateKeys>) -> u64 {
-    program
-        .state()
+fn total_supply(context: &Context<StateKeys>) -> u64 {
+    context
         .get(StateKeys::TotalySupply)
         .unwrap()
         .unwrap_or_default()
 }
 
-fn reserves(program: &Program<StateKeys>) -> (u64, u64) {
+fn reserves(context: &Context<StateKeys>) -> (u64, u64) {
     (
-        program
-            .state()
+        context
             .get(StateKeys::ReserveX)
             .unwrap()
             .unwrap_or_default(),
-        program
-            .state()
+        context
             .get(StateKeys::ReserveY)
             .unwrap()
             .unwrap_or_default(),

--- a/x/programs/rust/examples/counter-external/src/lib.rs
+++ b/x/programs/rust/examples/counter-external/src/lib.rs
@@ -1,4 +1,4 @@
-use wasmlanche_sdk::{public, types::Address, Context, ExternalCallContext, Program};
+use wasmlanche_sdk::{public, Address, Context, ExternalCallContext, Program};
 
 #[public]
 pub fn inc(_: Context, external: Program, address: Address) {

--- a/x/programs/rust/examples/counter/src/lib.rs
+++ b/x/programs/rust/examples/counter/src/lib.rs
@@ -1,6 +1,6 @@
 #[cfg(not(feature = "bindings"))]
 use wasmlanche_sdk::Context;
-use wasmlanche_sdk::{public, state_keys, types::Address};
+use wasmlanche_sdk::{public, state_keys, Address};
 
 #[state_keys]
 pub enum StateKeys {
@@ -16,8 +16,6 @@ pub fn inc(context: Context<StateKeys>, to: Address, amount: Count) -> bool {
     let counter = amount + get_value_internal(&context, to);
 
     context
-        .program()
-        .state()
         .store_by_key(StateKeys::Counter(to), &counter)
         .expect("failed to store counter");
 
@@ -33,8 +31,6 @@ pub fn get_value(context: Context<StateKeys>, of: Address) -> Count {
 #[cfg(not(feature = "bindings"))]
 fn get_value_internal(context: &Context<StateKeys>, of: Address) -> Count {
     context
-        .program()
-        .state()
         .get(StateKeys::Counter(of))
         .expect("state corrupt")
         .unwrap_or_default()

--- a/x/programs/rust/examples/token/src/lib.rs
+++ b/x/programs/rust/examples/token/src/lib.rs
@@ -1,6 +1,5 @@
-#[cfg(not(feature = "bindings"))]
 use wasmlanche_sdk::Context;
-use wasmlanche_sdk::{public, state_keys, types::Address, Program};
+use wasmlanche_sdk::{public, state_keys, Address};
 
 /// The program state keys.
 #[state_keys]
@@ -19,33 +18,16 @@ pub enum StateKeys {
     Owner,
 }
 
-// Returns the owner of the token
-pub fn get_owner(program: &Program<StateKeys>) -> Address {
-    program
-        .state()
-        .get::<Address>(StateKeys::Owner)
-        .expect("failed to get owner")
-        .expect("owner not initialized")
-}
-
-// Checks if the caller is the owner of the token
-// If the caller is not the owner, the program will panic
-pub fn check_owner(program: &Program<StateKeys>, actor: Address) {
-    assert_eq!(get_owner(program), actor, "caller is required to be owner")
-}
-
 /// Initializes the program with a name, symbol, and total supply.
 #[public]
 pub fn init(context: Context<StateKeys>, name: String, symbol: String) {
-    let program = context.program();
     let actor = context.actor();
 
-    program
-        .state()
+    context
         .store_by_key(StateKeys::Owner, &actor)
         .expect("failed to store owner");
-    program
-        .state()
+
+    context
         .store([(StateKeys::Name, &name), (StateKeys::Symbol, &symbol)])
         .expect("failed to store owner");
 }
@@ -53,29 +35,18 @@ pub fn init(context: Context<StateKeys>, name: String, symbol: String) {
 /// Returns the total supply of the token.
 #[public]
 pub fn total_supply(context: Context<StateKeys>) -> u64 {
-    let program = context.program();
-    _total_supply(program)
-}
-
-fn _total_supply(program: &Program<StateKeys>) -> u64 {
-    program
-        .state()
-        .get(StateKeys::TotalSupply)
-        .expect("failed to get total supply")
-        .unwrap_or_default()
+    _total_supply(&context)
 }
 
 /// Transfers balance from the token owner to the recipient.
 #[public]
 pub fn mint(context: Context<StateKeys>, recipient: Address, amount: u64) -> bool {
-    let program = context.program();
     let actor = context.actor();
 
-    check_owner(program, actor);
-    let balance = _balance_of(program, recipient);
-    let total_supply = _total_supply(program);
-    program
-        .state()
+    check_owner(&context, actor);
+    let balance = _balance_of(&context, recipient);
+    let total_supply = _total_supply(&context);
+    context
         .store([
             (StateKeys::Balance(recipient), &(balance + amount)),
             (StateKeys::TotalSupply, &(total_supply + amount)),
@@ -88,17 +59,15 @@ pub fn mint(context: Context<StateKeys>, recipient: Address, amount: u64) -> boo
 /// Burn the token from the recipient.
 #[public]
 pub fn burn(context: Context<StateKeys>, recipient: Address, value: u64) -> u64 {
-    let program = context.program();
     let actor = context.actor();
 
-    check_owner(program, actor);
-    let total = _balance_of(program, recipient);
+    check_owner(&context, actor);
+    let total = _balance_of(&context, recipient);
 
     assert!(value <= total, "address doesn't have enough tokens to burn");
     let new_amount = total - value;
 
-    program
-        .state()
+    context
         .store_by_key::<u64>(StateKeys::Balance(recipient), &new_amount)
         .expect("failed to burn recipient tokens");
 
@@ -108,13 +77,11 @@ pub fn burn(context: Context<StateKeys>, recipient: Address, value: u64) -> u64 
 /// Gets the balance of the recipient.
 #[public]
 pub fn balance_of(context: Context<StateKeys>, account: Address) -> u64 {
-    let program = context.program();
-    _balance_of(program, account)
+    _balance_of(&context, account)
 }
 
-fn _balance_of(program: &Program<StateKeys>, account: Address) -> u64 {
-    program
-        .state()
+fn _balance_of(context: &Context<StateKeys>, account: Address) -> u64 {
+    context
         .get(StateKeys::Balance(account))
         .expect("failed to get balance")
         .unwrap_or_default()
@@ -123,27 +90,16 @@ fn _balance_of(program: &Program<StateKeys>, account: Address) -> u64 {
 /// Returns the allowance of the spender for the owner's tokens.
 #[public]
 pub fn allowance(context: Context<StateKeys>, owner: Address, spender: Address) -> u64 {
-    let program = context.program();
-    _allowance(program, owner, spender)
-}
-
-pub fn _allowance(program: &Program<StateKeys>, owner: Address, spender: Address) -> u64 {
-    program
-        .state()
-        .get::<u64>(StateKeys::Allowance(owner, spender))
-        .expect("failed to get allowance")
-        .unwrap_or_default()
+    _allowance(&context, owner, spender)
 }
 
 /// Approves the spender to spend the owner's tokens.
 /// Returns true if the approval was successful.
 #[public]
 pub fn approve(context: Context<StateKeys>, spender: Address, amount: u64) -> bool {
-    let program = context.program();
     let actor = context.actor();
 
-    program
-        .state()
+    context
         .store_by_key(StateKeys::Allowance(actor, spender), &amount)
         .expect("failed to store allowance");
     true
@@ -152,36 +108,8 @@ pub fn approve(context: Context<StateKeys>, spender: Address, amount: u64) -> bo
 /// Transfers balance from the sender to the the recipient.
 #[public]
 pub fn transfer(context: Context<StateKeys>, recipient: Address, amount: u64) -> bool {
-    let program = context.program();
     let actor = context.actor();
-    _transfer(program, actor, recipient, amount)
-}
-
-fn _transfer(
-    program: &Program<StateKeys>,
-    sender: Address,
-    recipient: Address,
-    amount: u64,
-) -> bool {
-    assert_ne!(sender, recipient, "sender and recipient must be different");
-
-    // ensure the sender has adequate balance
-    let sender_balance = _balance_of(program, sender);
-
-    assert!(sender_balance >= amount, "sender has insufficient balance");
-
-    let recipient_balance = _balance_of(program, recipient);
-
-    // update balances
-    program
-        .state()
-        .store([
-            (StateKeys::Balance(sender), &(sender_balance - amount)),
-            (StateKeys::Balance(recipient), &(recipient_balance + amount)),
-        ])
-        .expect("failed to update balances");
-
-    true
+    _transfer(&context, actor, recipient, amount)
 }
 
 /// Transfers balance from the sender to the recipient.
@@ -195,42 +123,37 @@ pub fn transfer_from(
 ) -> bool {
     assert_ne!(sender, recipient, "sender and recipient must be different");
 
-    let program = context.program();
     let actor = context.actor();
 
-    let total_allowance = _allowance(program, sender, actor);
+    let total_allowance = _allowance(&context, sender, actor);
     assert!(total_allowance >= amount, "insufficient allowance");
 
-    program
-        .state()
+    context
         .store_by_key(
             StateKeys::Allowance(sender, actor),
             &(total_allowance - amount),
         )
         .expect("failed to store allowance");
 
-    _transfer(program, sender, recipient, amount)
+    _transfer(&context, sender, recipient, amount)
 }
 
 #[public]
 pub fn transfer_ownership(context: Context<StateKeys>, new_owner: Address) -> bool {
-    let program = context.program();
     let actor = context.actor();
 
-    check_owner(program, actor);
-    program
-        .state()
+    check_owner(&context, actor);
+    context
         .store_by_key(StateKeys::Owner, &new_owner)
         .expect("failed to store owner");
+
     true
 }
 
 #[public]
 // grab the symbol of the token
 pub fn symbol(context: Context<StateKeys>) -> String {
-    let program = context.program();
-    program
-        .state()
+    context
         .get::<String>(StateKeys::Symbol)
         .expect("failed to get symbol")
         .expect("symbol not initialized")
@@ -239,12 +162,66 @@ pub fn symbol(context: Context<StateKeys>) -> String {
 #[public]
 // grab the name of the token
 pub fn name(context: Context<StateKeys>) -> String {
-    let program = context.program();
-    program
-        .state()
+    context
         .get::<String>(StateKeys::Name)
         .expect("failed to get name")
         .expect("name not initialized")
+}
+
+// Checks if the caller is the owner of the token
+// If the caller is not the owner, the program will panic
+#[cfg(not(feature = "bindings"))]
+fn check_owner(context: &Context<StateKeys>, actor: Address) {
+    assert_eq!(get_owner(context), actor, "caller is required to be owner")
+}
+
+// Returns the owner of the token
+#[cfg(not(feature = "bindings"))]
+fn get_owner(context: &Context<StateKeys>) -> Address {
+    context
+        .get::<Address>(StateKeys::Owner)
+        .expect("failed to get owner")
+        .expect("owner not initialized")
+}
+
+fn _transfer(
+    context: &Context<StateKeys>,
+    sender: Address,
+    recipient: Address,
+    amount: u64,
+) -> bool {
+    assert_ne!(sender, recipient, "sender and recipient must be different");
+
+    // ensure the sender has adequate balance
+    let sender_balance = _balance_of(context, sender);
+
+    assert!(sender_balance >= amount, "sender has insufficient balance");
+
+    let recipient_balance = _balance_of(context, recipient);
+
+    // update balances
+    context
+        .store([
+            (StateKeys::Balance(sender), &(sender_balance - amount)),
+            (StateKeys::Balance(recipient), &(recipient_balance + amount)),
+        ])
+        .expect("failed to update balances");
+
+    true
+}
+
+pub fn _allowance(context: &Context<StateKeys>, owner: Address, spender: Address) -> u64 {
+    context
+        .get::<u64>(StateKeys::Allowance(owner, spender))
+        .expect("failed to get allowance")
+        .unwrap_or_default()
+}
+
+fn _total_supply(context: &Context<StateKeys>) -> u64 {
+    context
+        .get(StateKeys::TotalSupply)
+        .expect("failed to get total supply")
+        .unwrap_or_default()
 }
 
 #[cfg(test)]

--- a/x/programs/rust/sdk-macros/tests/ui/fail/user-defined-context-type.stderr
+++ b/x/programs/rust/sdk-macros/tests/ui/fail/user-defined-context-type.stderr
@@ -14,7 +14,7 @@ note: `Context` is defined in the current crate
 5 | struct Context;
   | ^^^^^^^^^^^^^^
 note: `wasmlanche_sdk::Context` is defined in crate `wasmlanche_sdk`
- --> $WORKSPACE/x/programs/rust/wasmlanche-sdk/src/lib.rs
+ --> $WORKSPACE/x/programs/rust/wasmlanche-sdk/src/context.rs
   |
   | pub struct Context<K = ()> {
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/x/programs/rust/wasmlanche-sdk/src/context.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/context.rs
@@ -1,0 +1,129 @@
+use crate::{
+    state::{Error, Key, State},
+    types::Address,
+    Gas, Id, Program,
+};
+use borsh::{BorshDeserialize, BorshSerialize};
+use std::{cell::RefCell, collections::HashMap};
+
+/// Representation of the context that is passed to programs at runtime.
+#[cfg_attr(feature = "debug", derive(Debug))]
+pub struct Context<K = ()> {
+    program: Program,
+    actor: Address,
+    height: u64,
+    timestamp: u64,
+    action_id: Id,
+    state_cache: RefCell<HashMap<K, Option<Vec<u8>>>>,
+}
+
+impl<K> BorshDeserialize for Context<K> {
+    fn deserialize_reader<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
+        let program = Program::deserialize_reader(reader)?;
+        let actor = Address::deserialize_reader(reader)?;
+        let height = u64::deserialize_reader(reader)?;
+        let timestamp = u64::deserialize_reader(reader)?;
+        let action_id = Id::deserialize_reader(reader)?;
+
+        Ok(Self {
+            program,
+            actor,
+            height,
+            timestamp,
+            action_id,
+            state_cache: RefCell::new(HashMap::new()),
+        })
+    }
+}
+
+impl<K> Context<K> {
+    pub fn program(&self) -> &Program {
+        &self.program
+    }
+
+    pub fn actor(&self) -> Address {
+        self.actor
+    }
+
+    pub fn height(&self) -> u64 {
+        self.height
+    }
+
+    pub fn timestamp(&self) -> u64 {
+        self.timestamp
+    }
+
+    pub fn action_id(&self) -> Id {
+        self.action_id
+    }
+}
+
+impl<K: Key> Context<K> {
+    /// See [`State::get`].
+    /// # Errors
+    /// See [`State::get`].
+    pub fn get<V: BorshDeserialize>(&self, key: K) -> Result<Option<V>, crate::state::Error> {
+        State::new(&self.state_cache).get(key)
+    }
+
+    /// See [`State::store_by_key`].
+    /// # Errors
+    /// See [`State::store_by_key`].
+    pub fn store_by_key<V>(&self, key: K, value: &V) -> Result<(), crate::state::Error>
+    where
+        V: BorshSerialize,
+    {
+        State::new(&self.state_cache).store_by_key(key, value)
+    }
+
+    /// See [`State::store`].
+    /// # Errors
+    /// See [`State::store`].    
+    pub fn store<'b, V: BorshSerialize + 'b, Pairs: IntoIterator<Item = (K, &'b V)>>(
+        &self,
+        pairs: Pairs,
+    ) -> Result<(), Error> {
+        State::new(&self.state_cache).store(pairs)
+    }
+
+    /// See [`State::delete`].
+    /// # Errors
+    /// See [`State::delete`].
+    pub fn delete<V: BorshDeserialize>(&self, key: K) -> Result<Option<V>, Error> {
+        State::new(&self.state_cache).delete(key)
+    }
+}
+
+/// Special context that is passed to external programs.
+#[allow(clippy::module_name_repetitions)]
+pub struct ExternalCallContext {
+    program: Program,
+    max_units: Gas,
+    value: u64,
+}
+
+impl ExternalCallContext {
+    #[must_use]
+    pub fn new(program: Program, max_units: Gas, value: u64) -> Self {
+        Self {
+            program,
+            max_units,
+            value,
+        }
+    }
+
+    #[must_use]
+    pub fn program(&self) -> &Program {
+        &self.program
+    }
+
+    #[must_use]
+    pub fn max_units(&self) -> Gas {
+        self.max_units
+    }
+
+    #[must_use]
+    pub fn value(&self) -> u64 {
+        self.value
+    }
+}

--- a/x/programs/rust/wasmlanche-sdk/src/lib.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/lib.rs
@@ -1,120 +1,21 @@
 #![deny(clippy::pedantic)]
 
+#[cfg(feature = "build")]
+pub mod build;
 /// State-related operations in programs.
 pub mod state;
-/// Program types.
-pub mod types;
 
+mod context;
 mod logging;
 mod memory;
 mod program;
+mod types;
 
 pub use self::{
+    context::{Context, ExternalCallContext},
     logging::{log, register_panic},
     memory::HostPtr,
     program::{send, DeferDeserialize, ExternalCallError, Program},
+    types::{Address, Gas, Id, ID_LEN},
 };
-use crate::types::{Gas, Id};
-
-#[cfg(feature = "build")]
-pub mod build;
-
-use borsh::{BorshDeserialize, BorshSerialize};
 pub use sdk_macros::{public, state_keys};
-use types::Address;
-
-/// Representation of the context that is passed to programs at runtime.
-#[cfg_attr(feature = "debug", derive(Debug))]
-pub struct Context<K = ()> {
-    program: Program<K>,
-    actor: Address,
-    height: u64,
-    timestamp: u64,
-    action_id: Id,
-}
-
-impl<K> Context<K> {
-    pub fn program(&self) -> &Program<K> {
-        &self.program
-    }
-
-    pub fn actor(&self) -> Address {
-        self.actor
-    }
-
-    pub fn height(&self) -> u64 {
-        self.height
-    }
-
-    pub fn timestamp(&self) -> u64 {
-        self.timestamp
-    }
-
-    pub fn action_id(&self) -> Id {
-        self.action_id
-    }
-}
-
-impl<K> BorshSerialize for Context<K> {
-    fn serialize<W: std::io::prelude::Write>(&self, writer: &mut W) -> std::io::Result<()> {
-        let Self {
-            program,
-            actor,
-            height,
-            timestamp,
-            action_id,
-        } = self;
-        BorshSerialize::serialize(program, writer)?;
-        BorshSerialize::serialize(actor, writer)?;
-        BorshSerialize::serialize(height, writer)?;
-        BorshSerialize::serialize(timestamp, writer)?;
-        BorshSerialize::serialize(action_id, writer)?;
-        Ok(())
-    }
-}
-
-impl<K> BorshDeserialize for Context<K> {
-    fn deserialize_reader<R: std::io::prelude::Read>(reader: &mut R) -> std::io::Result<Self> {
-        let program = BorshDeserialize::deserialize_reader(reader)?;
-        let actor = BorshDeserialize::deserialize_reader(reader)?;
-        let height = BorshDeserialize::deserialize_reader(reader)?;
-        let timestamp = BorshDeserialize::deserialize_reader(reader)?;
-        let action_id = BorshDeserialize::deserialize_reader(reader)?;
-        Ok(Self {
-            program,
-            actor,
-            height,
-            timestamp,
-            action_id,
-        })
-    }
-}
-
-/// Special context that is passed to external programs.
-pub struct ExternalCallContext {
-    program: Program,
-    max_units: Gas,
-    value: u64,
-}
-
-impl ExternalCallContext {
-    pub fn new(program: Program, max_units: Gas, value: u64) -> Self {
-        Self {
-            program,
-            max_units,
-            value,
-        }
-    }
-
-    pub fn program(&self) -> &Program {
-        &self.program
-    }
-
-    pub fn max_units(&self) -> Gas {
-        self.max_units
-    }
-
-    pub fn value(&self) -> u64 {
-        self.value
-    }
-}

--- a/x/programs/rust/wasmlanche-sdk/tests/public_function.rs
+++ b/x/programs/rust/wasmlanche-sdk/tests/public_function.rs
@@ -2,7 +2,7 @@ use std::{
     path::{Path, PathBuf},
     process::Command,
 };
-use wasmlanche_sdk::types::{Address, ID_LEN};
+use wasmlanche_sdk::{Address, ID_LEN};
 use wasmtime::{Caller, Extern, Func, Instance, Module, Store, TypedFunc};
 
 const WASM_TARGET: &str = "wasm32-unknown-unknown";

--- a/x/programs/test/programs/balance/src/lib.rs
+++ b/x/programs/test/programs/balance/src/lib.rs
@@ -1,6 +1,4 @@
-use wasmlanche_sdk::{
-    public, send, state::get_balance, types::Address, types::Gas, Context, Program,
-};
+use wasmlanche_sdk::{public, send, state::get_balance, Address, Context, Gas, Program};
 
 #[public]
 pub fn balance(ctx: Context) -> u64 {

--- a/x/programs/test/programs/call_program/src/lib.rs
+++ b/x/programs/test/programs/call_program/src/lib.rs
@@ -1,8 +1,4 @@
-use wasmlanche_sdk::{
-    public,
-    types::{Address, Gas},
-    Context, Program,
-};
+use wasmlanche_sdk::{public, Address, Context, Gas, Program};
 
 #[public]
 pub fn simple_call(_: Context) -> i64 {

--- a/x/programs/test/programs/deploy_program/src/lib.rs
+++ b/x/programs/test/programs/deploy_program/src/lib.rs
@@ -1,4 +1,4 @@
-use wasmlanche_sdk::{public, types::Address, types::Id, Context};
+use wasmlanche_sdk::{public, Address, Context, Id};
 
 #[public]
 pub fn deploy(ctx: Context, program_id: Id) -> Address {

--- a/x/programs/test/programs/return_complex_type/src/lib.rs
+++ b/x/programs/test/programs/return_complex_type/src/lib.rs
@@ -1,5 +1,5 @@
 use borsh::BorshSerialize;
-use wasmlanche_sdk::{public, types::Address, types::Gas, Context};
+use wasmlanche_sdk::{public, Address, Context, Gas};
 
 #[derive(BorshSerialize)]
 pub struct ComplexReturn {

--- a/x/programs/test/programs/state_access/src/lib.rs
+++ b/x/programs/test/programs/state_access/src/lib.rs
@@ -10,8 +10,6 @@ pub enum StateKeys {
 #[public]
 pub fn put(context: Context<StateKeys>, value: i64) {
     context
-        .program()
-        .state()
         .store_by_key(StateKeys::State, &value)
         .expect("failed to store state");
 }
@@ -19,8 +17,6 @@ pub fn put(context: Context<StateKeys>, value: i64) {
 #[public]
 pub fn get(context: Context<StateKeys>) -> Option<i64> {
     context
-        .program()
-        .state()
         .get::<i64>(StateKeys::State)
         .expect("failed to get state")
 }
@@ -28,8 +24,6 @@ pub fn get(context: Context<StateKeys>) -> Option<i64> {
 #[public]
 pub fn delete(context: Context<StateKeys>) -> Option<i64> {
     context
-        .program()
-        .state()
         .delete(StateKeys::State)
         .expect("failed to get state")
 }


### PR DESCRIPTION
@dboehm-avalabs suggested that we just put the state functions on the `Context` directly and I agreed

