### PR TITLE
remove unused parallelism key from test configs

### DIFF
--- a/examples/morpheusvm/tests/integration/integration_test.go
+++ b/examples/morpheusvm/tests/integration/integration_test.go
@@ -223,7 +223,6 @@ var _ = ginkgo.BeforeSuite(func() {
 			[]byte(
 				`{
 				  "config": {
-				    "parallelism":3,
 				    "testMode":true,
 				    "logLevel":"debug"
 				  }

--- a/examples/tokenvm/tests/integration/integration_test.go
+++ b/examples/tokenvm/tests/integration/integration_test.go
@@ -244,7 +244,6 @@ var _ = ginkgo.BeforeSuite(func() {
 			[]byte(
 				`{
 				  "config": {
-				    "parallelism":3,
 				    "testMode":true,
 				    "logLevel":"debug",
 				    "trackedPairs":["*"]


### PR DESCRIPTION
Key seems to be an artifact of early code. This config doesn't exist anymore.