### PR TITLE
Delegate digest generation to the auth module.

### DIFF
--- a/auth/bls.go
+++ b/auth/bls.go
@@ -46,7 +46,12 @@ func (*BLS) ValidRange(chain.Rules) (int64, int64) {
 	return -1, -1
 }
 
-func (b *BLS) Verify(_ context.Context, msg []byte) error {
+func (b *BLS) Verify(_ context.Context, tx *chain.Transaction) error {
+	msg, err := tx.Digest()
+	if err != nil {
+		return err
+	}
+
 	if !bls.Verify(msg, b.Signer, b.Signature) {
 		return crypto.ErrInvalidSignature
 	}
@@ -103,7 +108,12 @@ func NewBLSFactory(priv *bls.PrivateKey) *BLSFactory {
 	return &BLSFactory{priv}
 }
 
-func (b *BLSFactory) Sign(msg []byte) (chain.Auth, error) {
+func (b *BLSFactory) Sign(tx *chain.Transaction) (chain.Auth, error) {
+	msg, err := tx.Digest()
+	if err != nil {
+		return nil, err
+	}
+
 	return &BLS{Signer: bls.PublicFromPrivateKey(b.priv), Signature: bls.Sign(msg, b.priv)}, nil
 }
 

--- a/auth/bls.go
+++ b/auth/bls.go
@@ -46,8 +46,8 @@ func (*BLS) ValidRange(chain.Rules) (int64, int64) {
 	return -1, -1
 }
 
-func (b *BLS) Verify(_ context.Context, tx *chain.Transaction) error {
-	msg, err := tx.Digest()
+func (b *BLS) Verify(_ context.Context, digestProvider chain.DigestProvider) error {
+	msg, err := digestProvider.Digest()
 	if err != nil {
 		return err
 	}
@@ -108,8 +108,8 @@ func NewBLSFactory(priv *bls.PrivateKey) *BLSFactory {
 	return &BLSFactory{priv}
 }
 
-func (b *BLSFactory) Sign(tx *chain.Transaction) (chain.Auth, error) {
-	msg, err := tx.Digest()
+func (b *BLSFactory) Sign(digestProvider chain.DigestProvider) (chain.Auth, error) {
+	msg, err := digestProvider.Digest()
 	if err != nil {
 		return nil, err
 	}

--- a/auth/ed25519.go
+++ b/auth/ed25519.go
@@ -46,7 +46,12 @@ func (*ED25519) ValidRange(chain.Rules) (int64, int64) {
 	return -1, -1
 }
 
-func (d *ED25519) Verify(_ context.Context, msg []byte) error {
+func (d *ED25519) Verify(_ context.Context, tx *chain.Transaction) error {
+	msg, err := tx.Digest()
+	if err != nil {
+		return err
+	}
+
 	if !ed25519.Verify(msg, d.Signer, d.Signature) {
 		return crypto.ErrInvalidSignature
 	}
@@ -89,7 +94,12 @@ type ED25519Factory struct {
 	priv ed25519.PrivateKey
 }
 
-func (d *ED25519Factory) Sign(msg []byte) (chain.Auth, error) {
+func (d *ED25519Factory) Sign(tx *chain.Transaction) (chain.Auth, error) {
+	msg, err := tx.Digest()
+	if err != nil {
+		return nil, err
+	}
+
 	sig := ed25519.Sign(msg, d.priv)
 	return &ED25519{Signer: d.priv.PublicKey(), Signature: sig}, nil
 }
@@ -121,7 +131,12 @@ type ED25519Batch struct {
 	batch        *ed25519.Batch
 }
 
-func (b *ED25519Batch) Add(msg []byte, rauth chain.Auth) func() error {
+func (b *ED25519Batch) Add(tx *chain.Transaction, rauth chain.Auth) func() error {
+	msg, err := tx.Digest()
+	if err != nil {
+		return func() error { return err }
+	}
+
 	auth := rauth.(*ED25519)
 	if b.batch == nil {
 		b.batch = ed25519.NewBatch(b.batchSize)

--- a/auth/ed25519.go
+++ b/auth/ed25519.go
@@ -46,7 +46,7 @@ func (*ED25519) ValidRange(chain.Rules) (int64, int64) {
 	return -1, -1
 }
 
-func (d *ED25519) Verify(_ context.Context, tx *chain.Transaction) error {
+func (d *ED25519) Verify(_ context.Context, tx chain.DigestProvider) error {
 	msg, err := tx.Digest()
 	if err != nil {
 		return err
@@ -94,8 +94,8 @@ type ED25519Factory struct {
 	priv ed25519.PrivateKey
 }
 
-func (d *ED25519Factory) Sign(tx *chain.Transaction) (chain.Auth, error) {
-	msg, err := tx.Digest()
+func (d *ED25519Factory) Sign(digestProvider chain.DigestProvider) (chain.Auth, error) {
+	msg, err := digestProvider.Digest()
 	if err != nil {
 		return nil, err
 	}
@@ -131,8 +131,8 @@ type ED25519Batch struct {
 	batch        *ed25519.Batch
 }
 
-func (b *ED25519Batch) Add(tx *chain.Transaction, rauth chain.Auth) func() error {
-	msg, err := tx.Digest()
+func (b *ED25519Batch) Add(digestProvider chain.DigestProvider, rauth chain.Auth) func() error {
+	msg, err := digestProvider.Digest()
 	if err != nil {
 		return func() error { return err }
 	}

--- a/auth/secp256r1.go
+++ b/auth/secp256r1.go
@@ -46,8 +46,8 @@ func (*SECP256R1) ValidRange(chain.Rules) (int64, int64) {
 	return -1, -1
 }
 
-func (d *SECP256R1) Verify(_ context.Context, tx *chain.Transaction) error {
-	msg, err := tx.Digest()
+func (d *SECP256R1) Verify(_ context.Context, digestProvider chain.DigestProvider) error {
+	msg, err := digestProvider.Digest()
 	if err != nil {
 		return err
 	}
@@ -94,7 +94,7 @@ func NewSECP256R1Factory(priv secp256r1.PrivateKey) *SECP256R1Factory {
 	return &SECP256R1Factory{priv}
 }
 
-func (d *SECP256R1Factory) Sign(tx *chain.Transaction) (chain.Auth, error) {
+func (d *SECP256R1Factory) Sign(tx chain.DigestProvider) (chain.Auth, error) {
 	msg, err := tx.Digest()
 	if err != nil {
 		return nil, err

--- a/auth/secp256r1.go
+++ b/auth/secp256r1.go
@@ -46,7 +46,12 @@ func (*SECP256R1) ValidRange(chain.Rules) (int64, int64) {
 	return -1, -1
 }
 
-func (d *SECP256R1) Verify(_ context.Context, msg []byte) error {
+func (d *SECP256R1) Verify(_ context.Context, tx *chain.Transaction) error {
+	msg, err := tx.Digest()
+	if err != nil {
+		return err
+	}
+
 	if !secp256r1.Verify(msg, d.Signer, d.Signature) {
 		return crypto.ErrInvalidSignature
 	}
@@ -89,7 +94,12 @@ func NewSECP256R1Factory(priv secp256r1.PrivateKey) *SECP256R1Factory {
 	return &SECP256R1Factory{priv}
 }
 
-func (d *SECP256R1Factory) Sign(msg []byte) (chain.Auth, error) {
+func (d *SECP256R1Factory) Sign(tx *chain.Transaction) (chain.Auth, error) {
+	msg, err := tx.Digest()
+	if err != nil {
+		return nil, err
+	}
+
 	sig, err := secp256r1.Sign(msg, d.priv)
 	if err != nil {
 		return nil, err

--- a/chain/auth_batch.go
+++ b/chain/auth_batch.go
@@ -48,15 +48,15 @@ func NewAuthBatch(vm AuthVM, job workers.Job, authTypes map[uint8]int) *AuthBatc
 	return &AuthBatch{vm, job, bvs}
 }
 
-func (a *AuthBatch) Add(digest []byte, auth Auth) {
+func (a *AuthBatch) Add(tx *Transaction, auth Auth) {
 	// If batch doesn't exist for auth, just add verify right to job and start
 	// processing.
 	bv, ok := a.bvs[auth.GetTypeID()]
 	if !ok {
-		a.job.Go(func() error { return auth.Verify(context.TODO(), digest) })
+		a.job.Go(func() error { return auth.Verify(context.TODO(), tx) })
 		return
 	}
-	bv.items <- &authBatchObject{digest, auth}
+	bv.items <- &authBatchObject{tx, auth}
 }
 
 func (a *AuthBatch) Done(f func()) {
@@ -73,8 +73,8 @@ func (a *AuthBatch) Done(f func()) {
 }
 
 type authBatchObject struct {
-	digest []byte
-	auth   Auth
+	tx   *Transaction
+	auth Auth
 }
 
 type authBatchWorker struct {
@@ -89,7 +89,7 @@ func (b *authBatchWorker) start() {
 	defer close(b.done)
 
 	for object := range b.items {
-		if j := b.bv.Add(object.digest, object.auth); j != nil {
+		if j := b.bv.Add(object.tx, object.auth); j != nil {
 			// May finish parts of batch early, let's start computing them as soon as possible
 			b.job.Go(j)
 			b.vm.Logger().Debug("enqueued batch for processing during add")

--- a/chain/block.go
+++ b/chain/block.go
@@ -169,11 +169,7 @@ func (b *StatelessBlock) populateTxs(ctx context.Context) error {
 
 		// Verify signature async
 		if b.vm.GetVerifyAuth() {
-			txDigest, err := tx.Digest()
-			if err != nil {
-				return err
-			}
-			batchVerifier.Add(txDigest, tx.Auth)
+			batchVerifier.Add(tx, tx.Auth)
 		}
 	}
 	return nil

--- a/chain/dependencies.go
+++ b/chain/dependencies.go
@@ -253,7 +253,7 @@ type Auth interface {
 	// Verify is run concurrently during transaction verification. It may not be run by the time
 	// a transaction is executed but will be checked before a [Transaction] is considered successful.
 	// Verify is typically used to perform cryptographic operations.
-	Verify(ctx context.Context, msg []byte) error
+	Verify(ctx context.Context, tx *Transaction) error
 
 	// Actor is the subject of the [Action] signed.
 	//
@@ -275,12 +275,12 @@ type Auth interface {
 }
 
 type AuthBatchVerifier interface {
-	Add([]byte, Auth) func() error
+	Add(*Transaction, Auth) func() error
 	Done() []func() error
 }
 
 type AuthFactory interface {
 	// Sign is used by helpers, auth object should store internally to be ready for marshaling
-	Sign(msg []byte) (Auth, error)
+	Sign(tx *Transaction) (Auth, error)
 	MaxUnits() (bandwidth uint64, compute uint64)
 }

--- a/chain/dependencies.go
+++ b/chain/dependencies.go
@@ -253,7 +253,7 @@ type Auth interface {
 	// Verify is run concurrently during transaction verification. It may not be run by the time
 	// a transaction is executed but will be checked before a [Transaction] is considered successful.
 	// Verify is typically used to perform cryptographic operations.
-	Verify(ctx context.Context, tx *Transaction) error
+	Verify(ctx context.Context, digestProvider DigestProvider) error
 
 	// Actor is the subject of the [Action] signed.
 	//
@@ -274,13 +274,17 @@ type Auth interface {
 	Sponsor() codec.Address
 }
 
+type DigestProvider interface {
+	Digest() ([]byte, error)
+}
+
 type AuthBatchVerifier interface {
-	Add(*Transaction, Auth) func() error
+	Add(DigestProvider, Auth) func() error
 	Done() []func() error
 }
 
 type AuthFactory interface {
 	// Sign is used by helpers, auth object should store internally to be ready for marshaling
-	Sign(tx *Transaction) (Auth, error)
+	Sign(digestProvider DigestProvider) (Auth, error)
 	MaxUnits() (bandwidth uint64, compute uint64)
 }

--- a/chain/transaction.go
+++ b/chain/transaction.go
@@ -69,11 +69,14 @@ func (t *Transaction) Sign(
 	actionRegistry ActionRegistry,
 	authRegistry AuthRegistry,
 ) (*Transaction, error) {
+	// FIXME: We are calling Digest twice here, which is an overhead.
+	// We need to decide what is faster: providing the codec packer with the correct initial size or calling Digest once.
+	// The current implementation calls Digest twice (once here and once in factory.Sign).
 	msg, err := t.Digest()
 	if err != nil {
 		return nil, err
 	}
-	auth, err := factory.Sign(msg)
+	auth, err := factory.Sign(t)
 	if err != nil {
 		return nil, err
 	}

--- a/examples/morpheusvm/tests/integration/integration_test.go
+++ b/examples/morpheusvm/tests/integration/integration_test.go
@@ -393,9 +393,7 @@ var _ = ginkgo.Describe("[Tx Processing]", func() {
 			)
 			// Must do manual construction to avoid `tx.Sign` error (would fail with
 			// 0 timestamp)
-			msg, err := tx.Digest()
-			require.NoError(err)
-			auth, err := factory.Sign(msg)
+			auth, err := factory.Sign(tx)
 			require.NoError(err)
 			tx.Auth = auth
 			p := codec.NewWriter(0, consts.MaxInt) // test codec growth

--- a/examples/tokenvm/tests/integration/integration_test.go
+++ b/examples/tokenvm/tests/integration/integration_test.go
@@ -416,9 +416,7 @@ var _ = ginkgo.Describe("[Tx Processing]", func() {
 			)
 			// Must do manual construction to avoid `tx.Sign` error (would fail with
 			// 0 timestamp)
-			msg, err := tx.Digest()
-			require.NoError(err)
-			auth, err := factory.Sign(msg)
+			auth, err := factory.Sign(tx)
 			require.NoError(err)
 			tx.Auth = auth
 			p := codec.NewWriter(0, consts.MaxInt) // test codec growth
@@ -784,9 +782,7 @@ var _ = ginkgo.Describe("[Tx Processing]", func() {
 		)
 		// Must do manual construction to avoid `tx.Sign` error (would fail with
 		// too large)
-		msg, err := tx.Digest()
-		require.NoError(err)
-		auth, err := factory.Sign(msg)
+		auth, err := factory.Sign(tx)
 		require.NoError(err)
 		tx.Auth = auth
 		p := codec.NewWriter(0, consts.MaxInt) // test codec growth
@@ -845,9 +841,7 @@ var _ = ginkgo.Describe("[Tx Processing]", func() {
 		)
 		// Must do manual construction to avoid `tx.Sign` error (would fail with
 		// too large)
-		msg, err := tx.Digest()
-		require.NoError(err)
-		auth, err := factory.Sign(msg)
+		auth, err := factory.Sign(tx)
 		require.NoError(err)
 		tx.Auth = auth
 		p := codec.NewWriter(0, consts.MaxInt) // test codec growth
@@ -875,9 +869,7 @@ var _ = ginkgo.Describe("[Tx Processing]", func() {
 		)
 		// Must do manual construction to avoid `tx.Sign` error (would fail with
 		// too large)
-		msg, err := tx.Digest()
-		require.NoError(err)
-		auth, err := factory.Sign(msg)
+		auth, err := factory.Sign(tx)
 		require.NoError(err)
 		tx.Auth = auth
 		p := codec.NewWriter(0, consts.MaxInt) // test codec growth
@@ -905,9 +897,7 @@ var _ = ginkgo.Describe("[Tx Processing]", func() {
 		)
 		// Must do manual construction to avoid `tx.Sign` error (would fail with
 		// too large)
-		msg, err := tx.Digest()
-		require.NoError(err)
-		auth, err := factory.Sign(msg)
+		auth, err := factory.Sign(tx)
 		require.NoError(err)
 		tx.Auth = auth
 		p := codec.NewWriter(0, consts.MaxInt) // test codec growth
@@ -1115,9 +1105,7 @@ var _ = ginkgo.Describe("[Tx Processing]", func() {
 		)
 		// Must do manual construction to avoid `tx.Sign` error (would fail with
 		// bad codec)
-		msg, err := tx.Digest()
-		require.NoError(err)
-		auth, err := factory.Sign(msg)
+		auth, err := factory.Sign(tx)
 		require.NoError(err)
 		tx.Auth = auth
 		p := codec.NewWriter(0, consts.MaxInt) // test codec growth
@@ -1186,9 +1174,7 @@ var _ = ginkgo.Describe("[Tx Processing]", func() {
 		)
 		// Must do manual construction to avoid `tx.Sign` error (would fail with
 		// bad codec)
-		msg, err := tx.Digest()
-		require.NoError(err)
-		auth, err := factory.Sign(msg)
+		auth, err := factory.Sign(tx)
 		require.NoError(err)
 		tx.Auth = auth
 		p := codec.NewWriter(0, consts.MaxInt) // test codec growth

--- a/gossiper/proposer.go
+++ b/gossiper/proposer.go
@@ -192,17 +192,7 @@ func (g *Proposer) HandleAppGossip(ctx context.Context, nodeID ids.NodeID, msg [
 	var seen int
 	for _, tx := range txs {
 		// Verify signature async
-		txDigest, err := tx.Digest()
-		if err != nil {
-			g.vm.Logger().Warn(
-				"unable to compute tx digest",
-				zap.Stringer("peerID", nodeID),
-				zap.Error(err),
-			)
-			batchVerifier.Done(nil)
-			return nil
-		}
-		batchVerifier.Add(txDigest, tx.Auth)
+		batchVerifier.Add(tx, tx.Auth)
 
 		// Add incoming txs to the cache to make
 		// sure we never gossip anything we receive (someone

--- a/rpc/jsonrpc_server.go
+++ b/rpc/jsonrpc_server.go
@@ -72,12 +72,7 @@ func (j *JSONRPCServer) SubmitTx(
 	if !rtx.Empty() {
 		return errors.New("tx has extra bytes")
 	}
-	msg, err := tx.Digest()
-	if err != nil {
-		// Should never occur because populated during unmarshal
-		return err
-	}
-	if err := tx.Auth.Verify(ctx, msg); err != nil {
+	if err := tx.Auth.Verify(ctx, tx); err != nil {
 		return err
 	}
 	txID := tx.ID()

--- a/rpc/websocket_server.go
+++ b/rpc/websocket_server.go
@@ -170,12 +170,7 @@ func (w *WebSocketServer) MessageCallback(vm VM) pubsub.Callback {
 
 			// Verify tx
 			if vm.GetVerifyAuth() {
-				msg, err := tx.Digest()
-				if err != nil {
-					// Should never occur because populated during unmarshal
-					return
-				}
-				if err := tx.Auth.Verify(ctx, msg); err != nil {
+				if err := tx.Auth.Verify(ctx, tx); err != nil {
 					log.Error("failed to verify sig",
 						zap.Error(err),
 					)

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -859,13 +859,7 @@ func (vm *VM) Submit(
 
 		// Verify auth if not already verified by caller
 		if verifyAuth && vm.config.VerifyAuth {
-			msg, err := tx.Digest()
-			if err != nil {
-				// Should never fail
-				errs = append(errs, err)
-				continue
-			}
-			if err := tx.Auth.Verify(ctx, msg); err != nil {
+			if err := tx.Auth.Verify(ctx, tx); err != nil {
 				// Failed signature verification is the only safe place to remove
 				// a transaction in listeners. Every other case may still end up with
 				// the transaction in a block.


### PR DESCRIPTION
Current implementation: The transaction calls its `Digest` method, which returns []byte. Then, `chain.AuthFactory.Sign(msg []byte)` signs the resulting bytes of the digest.

Proposal: Change to `chain.AuthFactory.Sign(tx *Transaction)` where `chain.AuthFactory` calls the `Digest` method instead of the transaction.

Similar changes for `chain.AuthBatchVerifier.Add` and `chain.Auth.Verify`.
