### PR TITLE
Context plumbing in `ActionTest` suite

### DIFF
--- a/chaintest/action_test_helpers.go
+++ b/chaintest/action_test_helpers.go
@@ -66,21 +66,18 @@ type ActionTest struct {
 	Assertion func(*testing.T, state.Mutable)
 }
 
-// Run execute all tests from the test suite and make sure all assertions pass.
-func Run(ctx context.Context, t *testing.T, tests []ActionTest) {
-	for _, test := range tests {
-		t.Run(test.Name, func(t *testing.T) {
-			require := require.New(t)
+// Run executes the [ActionTest] and make sure all assertions pass.
+func (test *ActionTest) Run(ctx context.Context, t *testing.T) {
+	t.Run(test.Name, func(t *testing.T) {
+		require := require.New(t)
 
-			output, err := test.Action.Execute(ctx, test.Rules, test.State, test.Timestamp, test.Actor, test.ActionID)
-			require.NoError(ctx.Err())
+		output, err := test.Action.Execute(ctx, test.Rules, test.State, test.Timestamp, test.Actor, test.ActionID)
 
-			require.ErrorIs(err, test.ExpectedErr)
-			require.Equal(output, test.ExpectedOutputs)
+		require.ErrorIs(err, test.ExpectedErr)
+		require.Equal(output, test.ExpectedOutputs)
 
-			if test.Assertion != nil {
-				test.Assertion(t, test.State)
-			}
-		})
-	}
+		if test.Assertion != nil {
+			test.Assertion(t, test.State)
+		}
+	})
 }

--- a/chaintest/action_test_helpers.go
+++ b/chaintest/action_test_helpers.go
@@ -63,7 +63,7 @@ type ActionTest struct {
 	ExpectedOutputs [][]byte
 	ExpectedErr     error
 
-	Assertion func(*testing.T, state.Mutable)
+	Assertion func(context.Context, *testing.T, state.Mutable)
 }
 
 // Run executes the [ActionTest] and make sure all assertions pass.
@@ -77,7 +77,7 @@ func (test *ActionTest) Run(ctx context.Context, t *testing.T) {
 		require.Equal(output, test.ExpectedOutputs)
 
 		if test.Assertion != nil {
-			test.Assertion(t, test.State)
+			test.Assertion(ctx, t, test.State)
 		}
 	})
 }

--- a/examples/morpheusvm/actions/transfer_test.go
+++ b/examples/morpheusvm/actions/transfer_test.go
@@ -77,9 +77,9 @@ func TestTransferAction(t *testing.T) {
 				keys.Add(string(emptyBalanceKey), state.All)
 				return ts.NewView(keys, store.Storage)
 			}(),
-			Assertion: func(t *testing.T, store state.Mutable) {
+			Assertion: func(ctx context.Context, t *testing.T, store state.Mutable) {
 				require := require.New(t)
-				balance, err := storage.GetBalance(context.Background(), store, codec.EmptyAddress)
+				balance, err := storage.GetBalance(ctx, store, codec.EmptyAddress)
 				require.NoError(err)
 				require.Equal(balance, uint64(1))
 			},
@@ -115,11 +115,11 @@ func TestTransferAction(t *testing.T) {
 				keys.Add(string(storage.BalanceKey(oneAddr)), state.All)
 				return ts.NewView(keys, store.Storage)
 			}(),
-			Assertion: func(t *testing.T, store state.Mutable) {
+			Assertion: func(ctx context.Context, t *testing.T, store state.Mutable) {
 				require := require.New(t)
-				receiverBalance, err := storage.GetBalance(context.Background(), store, oneAddr)
+				receiverBalance, err := storage.GetBalance(ctx, store, oneAddr)
 				require.NoError(err)
-				senderBalance, err := storage.GetBalance(context.Background(), store, codec.EmptyAddress)
+				senderBalance, err := storage.GetBalance(ctx, store, codec.EmptyAddress)
 				require.NoError(err)
 				require.Equal(receiverBalance, uint64(1))
 				require.Equal(senderBalance, uint64(0))

--- a/examples/morpheusvm/actions/transfer_test.go
+++ b/examples/morpheusvm/actions/transfer_test.go
@@ -127,5 +127,7 @@ func TestTransferAction(t *testing.T) {
 		},
 	}
 
-	chaintest.Run(context.Background(), t, tests)
+	for _, tt := range tests {
+		tt.Run(context.Background(), t)
+	}
 }


### PR DESCRIPTION
As you mentioned, the `Context` could be polluted if shared across tests (it's unlikely, but I agree that it's worth avoiding, and it's quite simple). I changed `Run` to a method instead.

Wherever possible, the incoming `Context` is plumbed through to where it's used, if possible/appropriate.