### PR TITLE
Fix macros, typos, and convenience

### DIFF
--- a/x/programs/cmd/simulator/src/lib.rs
+++ b/x/programs/cmd/simulator/src/lib.rs
@@ -340,8 +340,7 @@ impl ClientBuilder<'_> {
         let Child { stdin, stdout, .. } = Command::new(self.path)
             .arg("interpreter")
             .arg("--cleanup")
-            .arg("--log-level")
-            .arg("error")
+            .args(["--log-level", "error"])
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .spawn()?;

--- a/x/programs/rust/sdk-macros/src/lib.rs
+++ b/x/programs/rust/sdk-macros/src/lib.rs
@@ -267,9 +267,12 @@ pub fn state_keys(_attr: TokenStream, item: TokenStream) -> TokenStream {
     const MAX_VARIANTS: usize = u8::MAX as usize + 1;
 
     if variants.len() > MAX_VARIANTS {
-        return Error::new(variants[MAX_VARIANTS].span(), "Cannot exceed 256 variants")
-            .into_compile_error()
-            .into();
+        return Error::new(
+            variants[MAX_VARIANTS].span(),
+            format!("Cannot exceed {} variants", MAX_VARIANTS),
+        )
+        .into_compile_error()
+        .into();
     }
 
     let match_arms: Result<Vec<_>, _> = variants

--- a/x/programs/rust/sdk-macros/src/lib.rs
+++ b/x/programs/rust/sdk-macros/src/lib.rs
@@ -56,25 +56,25 @@ pub fn public(_: TokenStream, item: TokenStream) -> TokenStream {
 
             arg => {
                 let err = match arg {
-                Some(FnArg::Typed(PatType { ty, .. })) => {
-                    Error::new(
-                        ty.span(),
-                        format!("The first paramter of a function with the `#[public]` attribute must be of type `{CONTEXT_TYPE}`"),
-                    )
-                }
-                Some(_) => {
-                    Error::new(
-                        arg.span(),
-                        format!("The first paramter of a function with the `#[public]` attribute must be of type `{CONTEXT_TYPE}`"),
-                    )
-                }
-                None => {
-                    Error::new(
-                        input.sig.paren_token.span.join(),
-                        format!("Functions with the `#[public]` attribute must have at least one parameter and the first parameter must be of type `{CONTEXT_TYPE}`"),
-                    )
-                }
-            };
+                    Some(FnArg::Typed(PatType { ty, .. })) => {
+                        Error::new(
+                            ty.span(),
+                            format!("The first parameter of a function with the `#[public]` attribute must be of type `{CONTEXT_TYPE}`"),
+                        )
+                    }
+                    Some(_) => {
+                        Error::new(
+                            arg.span(),
+                            format!("The first parameter of a function with the `#[public]` attribute must be of type `{CONTEXT_TYPE}`"),
+                        )
+                    }
+                    None => {
+                        Error::new(
+                            input.sig.paren_token.span.join(),
+                            format!("Functions with the `#[public]` attribute must have at least one parameter and the first parameter must be of type `{CONTEXT_TYPE}`"),
+                        )
+                    }
+                };
 
                 Some(err)
             }
@@ -267,12 +267,9 @@ pub fn state_keys(_attr: TokenStream, item: TokenStream) -> TokenStream {
     const MAX_VARIANTS: usize = u8::MAX as usize + 1;
 
     if variants.len() > MAX_VARIANTS {
-        return Error::new(
-            variants[MAX_VARIANTS].span(),
-            "Cannot exceed `u8::MAX` variants",
-        )
-        .into_compile_error()
-        .into();
+        return Error::new(variants[MAX_VARIANTS].span(), "Cannot exceed 256 variants")
+            .into_compile_error()
+            .into();
     }
 
     let match_arms: Result<Vec<_>, _> = variants

--- a/x/programs/rust/sdk-macros/tests/ui/fail/first-param.stderr
+++ b/x/programs/rust/sdk-macros/tests/ui/fail/first-param.stderr
@@ -1,4 +1,4 @@
-error: The first paramter of a function with the `#[public]` attribute must be of type `wasmlanche_sdk::Context`
+error: The first parameter of a function with the `#[public]` attribute must be of type `wasmlanche_sdk::Context`
  --> tests/ui/fail/first-param.rs:4:16
   |
 4 | pub fn test(a: u32) {}

--- a/x/programs/rust/sdk-macros/tests/ui/fail/receiver.stderr
+++ b/x/programs/rust/sdk-macros/tests/ui/fail/receiver.stderr
@@ -1,4 +1,4 @@
-error: The first paramter of a function with the `#[public]` attribute must be of type `wasmlanche_sdk::Context`
+error: The first parameter of a function with the `#[public]` attribute must be of type `wasmlanche_sdk::Context`
  --> tests/ui/fail/receiver.rs:7:17
   |
 7 |     pub fn test(&self) {}

--- a/x/programs/rust/sdk-macros/tests/ui/fail/too-many-state-key-variants.stderr
+++ b/x/programs/rust/sdk-macros/tests/ui/fail/too-many-state-key-variants.stderr
@@ -1,4 +1,4 @@
-error: Cannot exceed `u8::MAX` variants
+error: Cannot exceed 256 variants
   --> tests/ui/fail/too-many-state-key-variants.rs:10:9
    |
 10 |         Variant256,

--- a/x/programs/rust/wasmlanche-sdk/src/memory.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/memory.rs
@@ -81,7 +81,7 @@ pub extern "C" fn alloc(len: usize) -> HostPtr {
 
     ALLOCATIONS.with_borrow_mut(|s| s.insert(ptr, len));
 
-    HostPtr(ptr.cast_const())
+    HostPtr(ptr)
 }
 
 #[cfg(test)]
@@ -114,20 +114,4 @@ mod tests {
         // see https://doc.rust-lang.org/1.77.2/std/alloc/struct.Layout.html#method.array
         alloc(isize::MAX as usize + 1);
     }
-
-    // TODO these two tests make the code abort and not panic, it's hard to write an assertion here
-    // #[test]
-    // #[should_panic]
-    // fn two_big_allocation_fails() {
-    //     // see https://doc.rust-lang.org/1.77.2/std/alloc/struct.Layout.html#method.array
-    //     alloc((isize::MAX / 2) as usize + 1);
-    //     alloc((isize::MAX / 2) as usize + 1);
-    // }
-
-    //     #[test]
-    //     #[should_panic]
-    //     fn null_pointer_allocation() {
-    //         // see https://doc.rust-lang.org/1.77.2/std/alloc/struct.Layout.html#method.array
-    //         alloc(isize::MAX as usize);
-    //     }
 }


### PR DESCRIPTION
- Fix some typos
- Fix indentation
- Wrong error message on state keys max length exceeded
- Remove redundant call to `cast_const()`