### PR TITLE
Panic on go build fail

### DIFF
--- a/x/programs/cmd/simulator/build.rs
+++ b/x/programs/cmd/simulator/build.rs
@@ -54,6 +54,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         for line in String::from_utf8_lossy(&go_build_output.stderr).lines() {
             println!("cargo:warning={line}");
         }
+
+        panic!("simulator build failed");
     }
 
     println!("cargo:rustc-env=SIMULATOR_PATH={simulator_path}");


### PR DESCRIPTION
Closes https://github.com/ava-labs/hypersdk/issues/1174

See https://internals.rust-lang.org/t/clearer-display-of-build-script-errors-in-cargo/14222 for more context, but it doesn't seem to be possible to have better error messages here if some underlying error happens that should make the build fail (here the go build fail of the simulator), cargo is to blame.

The build script now just panics after having written the error message from the output of the `go build` command. It's way too verbose, but at least we understand more easily that the go build failed.

```sh
   Compiling simulator v0.1.0 (/Users/user/hypersdk/x/programs/cmd/simulator)
The following warnings were emitted during compilation:

warning: simulator@0.1.0: go build stdout:
warning: simulator@0.1.0: go build stderr:
warning: simulator@0.1.0: cmd/root.go:14:6: expected ';', found h

error: failed to run custom build command for `simulator v0.1.0 (/Users/user/hypersdk/x/programs/cmd/simulator)`

Caused by:
  process didn't exit successfully: `/Users/user/hypersdk/target/debug/build/simulator-0748c961929c88aa/build-script-build` (exit status: 101)
  --- stdout
  cargo:rerun-if-changed=build.rs
  cargo:rerun-if-changed=simulator.go
  cargo:rerun-if-changed=cmd/
  cargo:rerun-if-changed=../runtime
  cargo:warning=go build stdout:
  cargo:warning=go build stderr:
  cargo:warning=cmd/root.go:14:6: expected ';', found h

  --- stderr
  thread 'main' panicked at x/programs/cmd/simulator/build.rs:58:9:
  simulator build failed
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```