### PR TITLE
Start e2e test refactor with workload logic decoupled from test decla…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,6 +53,7 @@ require (
 	github.com/getsentry/sentry-go v0.18.0 // indirect
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/golang/snappy v0.0.5-0.20220116011046-fa5810519dcb // indirect
@@ -84,6 +85,7 @@ require (
 	golang.org/x/sys v0.18.0 // indirect
 	golang.org/x/term v0.18.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
+	golang.org/x/tools v0.17.0 // indirect
 	gonum.org/v1/gonum v0.11.0 // indirect
 	google.golang.org/genproto v0.0.0-20240123012728-ef4313101c80 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240123012728-ef4313101c80 // indirect

--- a/go.sum
+++ b/go.sum
@@ -326,6 +326,7 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=

--- a/tests/e2e/e2e.go
+++ b/tests/e2e/e2e.go
@@ -1,0 +1,32 @@
+// Copyright (C) 2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package e2e
+
+import (
+	"context"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/hypersdk/tests/workload"
+)
+
+var network workload.Network
+
+func SetNetwork(n workload.Network) {
+	network = n
+}
+
+var _ = ginkgo.Describe("[HyperSDK APIs]", func() {
+	ctx := context.Background()
+	require := require.New(ginkgo.GinkgoT())
+
+	ginkgo.It("Ping", func() {
+		workload.Ping(ctx, require, network)
+	})
+
+	ginkgo.It("GetNetwork", func() {
+		workload.GetNetwork(ctx, require, network)
+	})
+})

--- a/tests/workload/dependencies.go
+++ b/tests/workload/dependencies.go
@@ -1,0 +1,16 @@
+// Copyright (C) 2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package workload
+
+import "github.com/ava-labs/avalanchego/ids"
+
+type Description struct {
+	NetworkID uint32
+	ChainID   ids.ID
+}
+
+type Network interface {
+	URIs() []string
+	Description() Description
+}

--- a/tests/workload/simple.go
+++ b/tests/workload/simple.go
@@ -1,0 +1,37 @@
+// Copyright (C) 2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package workload
+
+import (
+	"context"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/hypersdk/rpc"
+	"github.com/ava-labs/hypersdk/utils"
+)
+
+func Ping(ctx context.Context, require *require.Assertions, network Network) {
+	clients := utils.Map(rpc.NewJSONRPCClient, network.URIs())
+
+	utils.ForEach(func(client *rpc.JSONRPCClient) {
+		ok, err := client.Ping(ctx)
+		require.NoError(err)
+		require.True(ok)
+	}, clients)
+}
+
+func GetNetwork(ctx context.Context, require *require.Assertions, network Network) {
+	clients := utils.Map(rpc.NewJSONRPCClient, network.URIs())
+
+	description := network.Description()
+	expectedNetworkID := description.NetworkID
+	expectedChainID := description.ChainID
+	utils.ForEach(func(client *rpc.JSONRPCClient) {
+		networkID, _, chainID, err := client.Network(ctx)
+		require.NoError(err)
+		require.Equal(expectedNetworkID, networkID)
+		require.Equal(expectedChainID, chainID)
+	}, clients)
+}

--- a/utils/map.go
+++ b/utils/map.go
@@ -1,0 +1,18 @@
+// Copyright (C) 2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package utils
+
+func Map[T any, R any](f func(T) R, a []T) []R {
+	b := make([]R, len(a))
+	for i, v := range a {
+		b[i] = f(v)
+	}
+	return b
+}
+
+func ForEach[T any](f func(T), a []T) {
+	for _, v := range a {
+		f(v)
+	}
+}


### PR DESCRIPTION
This PR takes the opposite approach of https://github.com/ava-labs/hypersdk/pull/1167/ and starts the e2e test refactor from scratch migrating over the simplest tests first.

Migrating the e2e tests wholesale resulted in more errors and headache than expected including some bugs that seem to have existed in previous tests and were avoided via an extra sleep, but were not triggered in other cases:

- Extra sleep to avoid test failure: https://github.com/ava-labs/hypersdk/blob/0057e63cca029b5523b8eae618566fafcf2bca2a/examples/morpheusvm/tests/e2e/e2e_test.go#L334
- no extra sleep https://github.com/ava-labs/hypersdk/blob/0057e63cca029b5523b8eae618566fafcf2bca2a/examples/morpheusvm/tests/e2e/e2e_test.go#L533, 

This approach should be easier to review as well.