### PR TITLE
Replace Controller Initialize with Factory initialization

### DIFF
--- a/examples/morpheusvm/controller/controller.go
+++ b/examples/morpheusvm/controller/controller.go
@@ -31,28 +31,14 @@ import (
 	hstorage "github.com/ava-labs/hypersdk/storage"
 )
 
-var _ vm.Controller = (*Controller)(nil)
+var (
+	_ vm.Controller        = (*Controller)(nil)
+	_ vm.ControllerFactory = (*factory)(nil)
+)
 
-type Controller struct {
-	inner *vm.VM
+type factory struct{}
 
-	snowCtx      *snow.Context
-	genesis      *genesis.Genesis
-	config       *config.Config
-	stateManager *storage.StateManager
-
-	metrics *metrics
-
-	txDB               database.Database
-	txIndexer          indexer.TxIndexer
-	acceptedSubscriber indexer.AcceptedSubscriber
-}
-
-func New() *vm.VM {
-	return vm.New(&Controller{}, version.Version)
-}
-
-func (c *Controller) Initialize(
+func (f *factory) New(
 	inner *vm.VM,
 	snowCtx *snow.Context,
 	gatherer ametrics.MultiGatherer,
@@ -60,6 +46,7 @@ func (c *Controller) Initialize(
 	upgradeBytes []byte, // subnets to allow for AWM
 	configBytes []byte,
 ) (
+	vm.Controller,
 	vm.Genesis,
 	builder.Builder,
 	gossiper.Gossiper,
@@ -69,6 +56,7 @@ func (c *Controller) Initialize(
 	map[uint8]vm.AuthEngine,
 	error,
 ) {
+	c := &Controller{}
 	c.inner = inner
 	c.snowCtx = snowCtx
 	c.stateManager = &storage.StateManager{}
@@ -77,13 +65,13 @@ func (c *Controller) Initialize(
 	var err error
 	c.metrics, err = newMetrics(gatherer)
 	if err != nil {
-		return nil, nil, nil, nil, nil, nil, nil, err
+		return nil, nil, nil, nil, nil, nil, nil, nil, err
 	}
 
 	// Load config and genesis
 	c.config, err = config.New(configBytes)
 	if err != nil {
-		return nil, nil, nil, nil, nil, nil, nil, err
+		return nil, nil, nil, nil, nil, nil, nil, nil, err
 	}
 
 	c.snowCtx.Log.SetLevel(c.config.LogLevel)
@@ -91,7 +79,7 @@ func (c *Controller) Initialize(
 
 	c.genesis, err = genesis.New(genesisBytes, upgradeBytes)
 	if err != nil {
-		return nil, nil, nil, nil, nil, nil, nil, fmt.Errorf(
+		return nil, nil, nil, nil, nil, nil, nil, nil, fmt.Errorf(
 			"unable to read genesis: %w",
 			err,
 		)
@@ -100,7 +88,7 @@ func (c *Controller) Initialize(
 
 	c.txDB, err = hstorage.New(pebble.NewDefaultConfig(), snowCtx.ChainDataDir, "db", gatherer)
 	if err != nil {
-		return nil, nil, nil, nil, nil, nil, nil, err
+		return nil, nil, nil, nil, nil, nil, nil, nil, err
 	}
 	acceptedSubscribers := []indexer.AcceptedSubscriber{
 		indexer.NewSuccessfulTxSubscriber(&actionHandler{c: c}),
@@ -123,7 +111,7 @@ func (c *Controller) Initialize(
 		rpc.NewJSONRPCServer(c),
 	)
 	if err != nil {
-		return nil, nil, nil, nil, nil, nil, nil, err
+		return nil, nil, nil, nil, nil, nil, nil, nil, err
 	}
 	apis[rpc.JSONRPCEndpoint] = jsonRPCHandler
 
@@ -141,10 +129,29 @@ func (c *Controller) Initialize(
 		gcfg := gossiper.DefaultProposerConfig()
 		gossip, err = gossiper.NewProposer(inner, gcfg)
 		if err != nil {
-			return nil, nil, nil, nil, nil, nil, nil, err
+			return nil, nil, nil, nil, nil, nil, nil, nil, err
 		}
 	}
-	return c.genesis, build, gossip, apis, consts.ActionRegistry, consts.AuthRegistry, auth.Engines(), nil
+	return c, c.genesis, build, gossip, apis, consts.ActionRegistry, consts.AuthRegistry, auth.Engines(), nil
+}
+
+type Controller struct {
+	inner *vm.VM
+
+	snowCtx      *snow.Context
+	genesis      *genesis.Genesis
+	config       *config.Config
+	stateManager *storage.StateManager
+
+	metrics *metrics
+
+	txDB               database.Database
+	txIndexer          indexer.TxIndexer
+	acceptedSubscriber indexer.AcceptedSubscriber
+}
+
+func New() *vm.VM {
+	return vm.New(&factory{}, version.Version)
 }
 
 func (c *Controller) Rules(t int64) chain.Rules {

--- a/examples/morpheusvm/controller/controller.go
+++ b/examples/morpheusvm/controller/controller.go
@@ -36,6 +36,10 @@ var (
 	_ vm.ControllerFactory = (*factory)(nil)
 )
 
+func New() *vm.VM {
+	return vm.New(&factory{}, version.Version)
+}
+
 type factory struct{}
 
 func (*factory) New(
@@ -148,10 +152,6 @@ type Controller struct {
 	txDB               database.Database
 	txIndexer          indexer.TxIndexer
 	acceptedSubscriber indexer.AcceptedSubscriber
-}
-
-func New() *vm.VM {
-	return vm.New(&factory{}, version.Version)
 }
 
 func (c *Controller) Rules(t int64) chain.Rules {

--- a/examples/morpheusvm/controller/controller.go
+++ b/examples/morpheusvm/controller/controller.go
@@ -38,7 +38,7 @@ var (
 
 type factory struct{}
 
-func (f *factory) New(
+func (*factory) New(
 	inner *vm.VM,
 	snowCtx *snow.Context,
 	gatherer ametrics.MultiGatherer,

--- a/vm/dependencies.go
+++ b/vm/dependencies.go
@@ -97,8 +97,8 @@ type AuthEngine interface {
 	Cache(auth chain.Auth)
 }
 
-type Controller interface {
-	Initialize(
+type ControllerFactory interface {
+	New(
 		inner *VM, // hypersdk VM
 		snowCtx *snow.Context,
 		gatherer avametrics.MultiGatherer,
@@ -106,16 +106,19 @@ type Controller interface {
 		upgradeBytes []byte,
 		configBytes []byte,
 	) (
-		genesis Genesis,
-		builder builder.Builder,
-		gossiper gossiper.Gossiper,
-		handler Handlers,
-		actionRegistry chain.ActionRegistry,
-		authRegistry chain.AuthRegistry,
-		authEngines map[uint8]AuthEngine,
-		err error,
+		Controller,
+		Genesis,
+		builder.Builder,
+		gossiper.Gossiper,
+		Handlers,
+		chain.ActionRegistry,
+		chain.AuthRegistry,
+		map[uint8]AuthEngine,
+		error,
 	)
+}
 
+type Controller interface {
 	Rules(t int64) chain.Rules // ms
 
 	// StateManager is used by the VM to request keys to store required

--- a/vm/mock_controller.go
+++ b/vm/mock_controller.go
@@ -16,11 +16,7 @@ import (
 	context "context"
 	reflect "reflect"
 
-	metrics "github.com/ava-labs/avalanchego/api/metrics"
-	snow "github.com/ava-labs/avalanchego/snow"
-	builder "github.com/ava-labs/hypersdk/builder"
 	chain "github.com/ava-labs/hypersdk/chain"
-	gossiper "github.com/ava-labs/hypersdk/gossiper"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -59,27 +55,6 @@ func (m *MockController) Accepted(arg0 context.Context, arg1 *chain.StatelessBlo
 func (mr *MockControllerMockRecorder) Accepted(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Accepted", reflect.TypeOf((*MockController)(nil).Accepted), arg0, arg1)
-}
-
-// Initialize mocks base method.
-func (m *MockController) Initialize(arg0 *VM, arg1 *snow.Context, arg2 metrics.MultiGatherer, arg3, arg4, arg5 []byte) (Genesis, builder.Builder, gossiper.Gossiper, Handlers, chain.ActionRegistry, chain.AuthRegistry, map[byte]AuthEngine, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Initialize", arg0, arg1, arg2, arg3, arg4, arg5)
-	ret0, _ := ret[0].(Genesis)
-	ret1, _ := ret[1].(builder.Builder)
-	ret2, _ := ret[2].(gossiper.Gossiper)
-	ret3, _ := ret[3].(Handlers)
-	ret4, _ := ret[4].(chain.ActionRegistry)
-	ret5, _ := ret[5].(chain.AuthRegistry)
-	ret6, _ := ret[6].(map[byte]AuthEngine)
-	ret7, _ := ret[7].(error)
-	return ret0, ret1, ret2, ret3, ret4, ret5, ret6, ret7
-}
-
-// Initialize indicates an expected call of Initialize.
-func (mr *MockControllerMockRecorder) Initialize(arg0, arg1, arg2, arg3, arg4, arg5 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Initialize", reflect.TypeOf((*MockController)(nil).Initialize), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // Rules mocks base method.

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -56,8 +56,9 @@ const (
 )
 
 type VM struct {
-	c Controller
-	v *version.Semantic
+	factory ControllerFactory
+	c       Controller
+	v       *version.Semantic
 
 	snowCtx         *snow.Context
 	pkBytes         []byte
@@ -129,11 +130,11 @@ type VM struct {
 	stop  chan struct{}
 }
 
-func New(c Controller, v *version.Semantic) *VM {
+func New(factory ControllerFactory, v *version.Semantic) *VM {
 	return &VM{
-		c:      c,
-		v:      v,
-		config: NewConfig(),
+		factory: factory,
+		v:       v,
+		config:  NewConfig(),
 	}
 }
 
@@ -215,7 +216,7 @@ func (vm *VM) Initialize(
 	}
 
 	// Always initialize implementation first
-	vm.genesis, vm.builder, vm.gossiper, vm.handlers, vm.actionRegistry, vm.authRegistry, vm.authEngine, err = vm.c.Initialize(
+	vm.c, vm.genesis, vm.builder, vm.gossiper, vm.handlers, vm.actionRegistry, vm.authRegistry, vm.authEngine, err = vm.factory.New(
 		vm,
 		controllerContext,
 		controllerContext.Metrics,


### PR DESCRIPTION
Removes usage of `Initialize` to use a factory pattern to create VMs.