### PR TITLE
Update formatted errors for invalid config values

### DIFF
--- a/vm/vm.go
+++ b/vm/vm.go
@@ -289,11 +289,11 @@ func (vm *VM) Initialize(
 	}
 	acceptorSize := vm.config.AcceptorSize
 	if acceptorSize > MaxAcceptorSize {
-		return fmt.Errorf("AcceptorSize should be less than or equal to %d. Provided: %d", MaxAcceptorSize, acceptorSize)
+		return fmt.Errorf("AcceptorSize (%d) must be <= MaxAcceptorSize (%d)", acceptorSize, MaxAcceptorSize)
 	}
 	acceptedBlockWindow := vm.config.AcceptedBlockWindow
-	if acceptedBlockWindow < 1024 {
-		return fmt.Errorf("AcceptedBlockWindow should be greater than or equal to %d. Provided: %d", MinAcceptedBlockWindow, acceptedBlockWindow)
+	if acceptedBlockWindow < MinAcceptedBlockWindow {
+		return fmt.Errorf("AcceptedBlockWindow (%d) must be >= to MinAcceptedBlockWindow (%d)", acceptedBlockWindow, MinAcceptedBlockWindow)
 	}
 	vm.acceptedQueue = make(chan *chain.StatelessBlock, vm.config.AcceptorSize)
 	vm.acceptorDone = make(chan struct{})


### PR DESCRIPTION
This PR updates the formatted error strings for `MaxAcceptorSize` and `MinAcceptedBlockWindow` values and makes sure that we are using the constant value instead of hardcoding to 1024 in the check for going over the `MinAcceptedBlockWindow.