### PR TITLE
[ci] Sync lint config from avalanchego

### DIFF
--- a/.github/workflows/hypersdk-ci.yml
+++ b/.github/workflows/hypersdk-ci.yml
@@ -46,7 +46,7 @@ jobs:
         uses: ./.github/actions/install-go
       - name: Run static analysis tests
         shell: bash
-        run: scripts/tests.lint.sh
+        run: scripts/lint.sh
       - name: Run shellcheck
         shell: bash
         run: scripts/tests.shellcheck.sh
@@ -115,7 +115,7 @@ jobs:
       - name: Run static analysis tests
         working-directory: ./examples/morpheusvm
         shell: bash
-        run: scripts/tests.lint.sh
+        run: scripts/lint.sh
       - name: Build vm, cli
         working-directory: ./examples/morpheusvm
         shell: bash

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,11 +2,6 @@
 run:
   timeout: 10m
 
-  # Enables skipping of directories:
-  # - vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
-  # Default: true
-  skip-dirs-use-default: false
-
   # If set we pass it to "go list -mod={option}". From "go help modules":
   # If invoked with -mod=readonly, the go command is disallowed from the implicit
   # automatic updating of go.mod described above. Instead, it fails when any changes
@@ -36,6 +31,11 @@ issues:
   # Default: 3
   max-same-issues: 0
 
+  # Enables skipping of directories:
+  # - vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
+  # Default: true
+  exclude-dirs-use-default: false
+
 linters:
   disable-all: true
   enable:
@@ -63,6 +63,7 @@ linters:
     # - lll
     - misspell
     - nakedret
+    - nilerr
     - noctx
     - nolintlint
     - perfsprint
@@ -86,12 +87,14 @@ linters-settings:
     rules:
       packages:
         deny:
-          - pkg: "io/ioutil"
-            desc: io/ioutil is deprecated. Use package io or os instead.
-          - pkg: "github.com/stretchr/testify/assert"
-            desc: github.com/stretchr/testify/require should be used instead.
+          - pkg: "container/list"
+            desc: github.com/ava-labs/avalanchego/utils/linked should be used instead.
           - pkg: "github.com/golang/mock/gomock"
             desc: go.uber.org/mock/gomock should be used instead.
+          - pkg: "github.com/stretchr/testify/assert"
+            desc: github.com/stretchr/testify/require should be used instead.
+          - pkg: "io/ioutil"
+            desc: io/ioutil is deprecated. Use package io or os instead.
   errorlint:
     # Check for plain type assertions and type switches.
     asserts: false
@@ -154,7 +157,14 @@ linters-settings:
       - name: string-format
         disabled: false
         arguments:
+        - ["b.Logf[0]", "/.*%.*/", "no format directive, use b.Log instead"]
         - ["fmt.Errorf[0]", "/.*%.*/", "no format directive, use errors.New instead"]
+        - ["fmt.Fprintf[1]", "/.*%.*/", "no format directive, use fmt.Fprint instead"]
+        - ["fmt.Printf[0]", "/.*%.*/", "no format directive, use fmt.Print instead"]
+        - ["fmt.Sprintf[0]", "/.*%.*/", "no format directive, use fmt.Sprint instead"]
+        - ["log.Fatalf[0]", "/.*%.*/", "no format directive, use log.Fatal instead"]
+        - ["log.Printf[0]", "/.*%.*/", "no format directive, use log.Print instead"]
+        - ["t.Logf[0]", "/.*%.*/", "no format directive, use t.Log instead"]
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#struct-tag
       - name: struct-tag
         disabled: false
@@ -167,6 +177,7 @@ linters-settings:
         arguments:
           - "fmt\\.Fprint"
           - "fmt\\.Fprintf"
+          - "fmt\\.Fprintln"
           - "fmt\\.Print"
           - "fmt\\.Printf"
           - "fmt\\.Println"
@@ -197,6 +208,8 @@ linters-settings:
     align: true
     sort: true
     strict: true
+    order:
+      - serialize
   testifylint:
     # Enable all checkers (https://github.com/Antonboom/testifylint#checkers).
     # Default: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ This will build and run all tests for the project.
 To run the linters, simply run:
 
 ```go
-./scripts/tests.lint.sh
+./scripts/lint.sh
 ```
 
 This will run the linters on all code in the project.

--- a/auth/consts.go
+++ b/auth/consts.go
@@ -3,9 +3,7 @@
 
 package auth
 
-import (
-	"github.com/ava-labs/hypersdk/vm"
-)
+import "github.com/ava-labs/hypersdk/vm"
 
 // Note: Registry will error during initialization if a duplicate ID is assigned. We explicitly assign IDs to avoid accidental remapping.
 const (

--- a/chain/block.go
+++ b/chain/block.go
@@ -29,8 +29,8 @@ import (
 )
 
 var (
-	_ snowman.Block      = &StatelessBlock{}
-	_ block.StateSummary = &SyncableBlock{}
+	_ snowman.Block      = (*StatelessBlock)(nil)
+	_ block.StateSummary = (*SyncableBlock)(nil)
 )
 
 type StatefulBlock struct {

--- a/codec/packer_test.go
+++ b/codec/packer_test.go
@@ -30,7 +30,8 @@ func TestNewWriter(t *testing.T) {
 	// Pack past limit
 	wr.PackFixedBytes(bytes)
 	require.Len(wr.Bytes(), 2, "Bytes overpacked.")
-	require.ErrorIs(wr.Err(), wrappers.ErrInsufficientLength)
+	err := wr.Err()
+	require.ErrorIs(err, wrappers.ErrInsufficientLength)
 }
 
 func TestPackerID(t *testing.T) {
@@ -59,7 +60,8 @@ func TestPackerID(t *testing.T) {
 		unpackedID = ids.Empty
 		rp.UnpackID(true, &unpackedID)
 		require.Equal(ids.Empty, unpackedID, "UnpackID unpacked incorrectly.")
-		require.ErrorIs(rp.Err(), wrappers.ErrInsufficientLength)
+		err := rp.Err()
+		require.ErrorIs(err, wrappers.ErrInsufficientLength)
 	})
 }
 
@@ -87,7 +89,8 @@ func TestPackerWindow(t *testing.T) {
 		require.NoError(rp.Err(), "UnpackWindow set an error.")
 		// Unpacking again should error
 		rp.UnpackWindow(&unpackedWindow)
-		require.ErrorIs(rp.Err(), wrappers.ErrInsufficientLength)
+		err := rp.Err()
+		require.ErrorIs(err, wrappers.ErrInsufficientLength)
 	})
 }
 
@@ -133,5 +136,6 @@ func TestNewReader(t *testing.T) {
 	require.NoError(rp.Err(), "Reader set error during unpack.")
 	// Unpacked not packed with required
 	require.Zero(rp.UnpackUint64(true), "Reader unpacked correctly.")
-	require.ErrorIs(rp.Err(), wrappers.ErrInsufficientLength)
+	err := rp.Err()
+	require.ErrorIs(err, wrappers.ErrInsufficientLength)
 }

--- a/codec/type_parser.go
+++ b/codec/type_parser.go
@@ -3,9 +3,7 @@
 
 package codec
 
-import (
-	"github.com/ava-labs/hypersdk/consts"
-)
+import "github.com/ava-labs/hypersdk/consts"
 
 type decoder[T any] struct {
 	f func(*Packer) (T, error)

--- a/codec/type_parser_test.go
+++ b/codec/type_parser_test.go
@@ -72,7 +72,8 @@ func TestTypeParser(t *testing.T) {
 
 	t.Run("duplicate item", func(t *testing.T) {
 		require := require.New(t)
-		require.ErrorIs(tp.Register((&Blah1{}).GetTypeID(), nil), ErrDuplicateItem)
+		err := tp.Register((&Blah1{}).GetTypeID(), nil)
+		require.ErrorIs(err, ErrDuplicateItem)
 	})
 
 	t.Run("too many items", func(t *testing.T) {
@@ -83,6 +84,7 @@ func TestTypeParser(t *testing.T) {
 			require.NoError(tp.Register(uint8(index+2), nil))
 		}
 		// all possible uint8 value should already be store, using any return ErrTooManyItems
-		require.ErrorIs(tp.Register(uint8(4), nil), ErrTooManyItems)
+		err := tp.Register(uint8(4), nil)
+		require.ErrorIs(err, ErrTooManyItems)
 	})
 }

--- a/crypto/bls/signature.go
+++ b/crypto/bls/signature.go
@@ -3,9 +3,7 @@
 
 package bls
 
-import (
-	"github.com/ava-labs/avalanchego/utils/crypto/bls"
-)
+import "github.com/ava-labs/avalanchego/utils/crypto/bls"
 
 const SignatureLen = bls.SignatureLen
 

--- a/examples/morpheusvm/factory.go
+++ b/examples/morpheusvm/factory.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ava-labs/hypersdk/examples/morpheusvm/controller"
 )
 
-var _ vms.Factory = &Factory{}
+var _ vms.Factory = (*Factory)(nil)
 
 type Factory struct{}
 

--- a/examples/morpheusvm/scripts/lint.sh
+++ b/examples/morpheusvm/scripts/lint.sh
@@ -6,7 +6,7 @@ set -o errexit
 set -o pipefail
 set -e
 
-if ! [[ "$0" =~ scripts/tests.lint.sh ]]; then
+if ! [[ "$0" =~ scripts/lint.sh ]]; then
   echo "must be run from morpheusvm root"
   exit 255
 fi
@@ -14,4 +14,4 @@ fi
 # Specify the version of golangci-lint. Should be upgraded after linting issues are resolved.
 export GOLANGCI_LINT_VERSION="v1.51.2"
 
-../../scripts/tests.lint.sh
+../../scripts/lint.sh

--- a/examples/morpheusvm/tests/integration/integration_test.go
+++ b/examples/morpheusvm/tests/integration/integration_test.go
@@ -214,7 +214,7 @@ var _ = ginkgo.BeforeSuite(func() {
 		db := memdb.New()
 
 		v := controller.New()
-		err = v.Initialize(
+		require.NoError(v.Initialize(
 			context.TODO(),
 			snowCtx,
 			db,
@@ -231,8 +231,7 @@ var _ = ginkgo.BeforeSuite(func() {
 			toEngine,
 			nil,
 			app,
-		)
-		require.NoError(err)
+		))
 
 		var hd map[string]http.Handler
 		hd, err = v.CreateHandlers(context.TODO())
@@ -286,8 +285,7 @@ var _ = ginkgo.AfterSuite(func() {
 		iv.JSONRPCServer.Close()
 		iv.BaseJSONRPCServer.Close()
 		iv.WebSocketServer.Close()
-		err := iv.vm.Shutdown(context.TODO())
-		require.NoError(err)
+		require.NoError(iv.vm.Shutdown(context.TODO()))
 	}
 })
 
@@ -375,8 +373,7 @@ var _ = ginkgo.Describe("[Tx Processing]", func() {
 		})
 
 		ginkgo.By("send gossip from node 0 to 1", func() {
-			err := instances[0].vm.Gossiper().Force(context.TODO())
-			require.NoError(err)
+			require.NoError(instances[0].vm.Gossiper().Force(context.TODO()))
 		})
 
 		ginkgo.By("skip invalid time", func() {
@@ -429,8 +426,7 @@ var _ = ginkgo.Describe("[Tx Processing]", func() {
 			require.NoError(blk.Verify(ctx))
 			require.Equal(blk.Status(), choices.Processing)
 
-			err = instances[1].vm.SetPreference(ctx, blk.ID())
-			require.NoError(err)
+			require.NoError(instances[1].vm.SetPreference(ctx, blk.ID()))
 
 			require.NoError(blk.Accept(ctx))
 			require.Equal(blk.Status(), choices.Accepted)
@@ -619,8 +615,7 @@ var _ = ginkgo.Describe("[Tx Processing]", func() {
 			require.NoError(err)
 			require.NoError(submit(context.Background()))
 
-			err = instances[1].vm.Gossiper().Force(context.TODO())
-			require.NoError(err)
+			require.NoError(instances[1].vm.Gossiper().Force(context.TODO()))
 
 			// mempool in 0 should be 1 (old amount), since gossip/submit failed
 			require.Equal(instances[0].vm.Mempool().Len(context.TODO()), 1)
@@ -636,8 +631,7 @@ var _ = ginkgo.Describe("[Tx Processing]", func() {
 			n := instances[2]
 			blk1, err := n.vm.ParseBlock(ctx, blocks[0].Bytes())
 			require.NoError(err)
-			err = blk1.Verify(ctx)
-			require.NoError(err)
+			require.NoError(blk1.Verify(ctx))
 
 			// Parse tip
 			blk2, err := n.vm.ParseBlock(ctx, blocks[1].Bytes())
@@ -646,26 +640,19 @@ var _ = ginkgo.Describe("[Tx Processing]", func() {
 			require.NoError(err)
 
 			// Verify tip
-			err = blk2.Verify(ctx)
-			require.NoError(err)
-			err = blk3.Verify(ctx)
-			require.NoError(err)
+			require.NoError(blk2.Verify(ctx))
+			require.NoError(blk3.Verify(ctx))
 
 			// Accept tip
-			err = blk1.Accept(ctx)
-			require.NoError(err)
-			err = blk2.Accept(ctx)
-			require.NoError(err)
-			err = blk3.Accept(ctx)
-			require.NoError(err)
+			require.NoError(blk1.Accept(ctx))
+			require.NoError(blk2.Accept(ctx))
+			require.NoError(blk3.Accept(ctx))
 
 			// Parse another
 			blk4, err := n.vm.ParseBlock(ctx, blocks[3].Bytes())
 			require.NoError(err)
-			err = blk4.Verify(ctx)
-			require.NoError(err)
-			err = blk4.Accept(ctx)
-			require.NoError(err)
+			require.NoError(blk4.Verify(ctx))
+			require.NoError(blk4.Accept(ctx))
 			require.NoError(n.vm.SetPreference(ctx, blk4.ID()))
 		})
 	})
@@ -706,7 +693,6 @@ var _ = ginkgo.Describe("[Tx Processing]", func() {
 		require.NoError(err)
 		require.NoError(submit(context.Background()))
 
-		require.NoError(err)
 		accept = expectBlk(instances[0])
 		results := accept(false)
 		require.Len(results, 1)
@@ -764,7 +750,6 @@ var _ = ginkgo.Describe("[Tx Processing]", func() {
 			hutils.Outf("{{yellow}}waiting for mempool to return non-zero txs{{/}}\n")
 			time.Sleep(500 * time.Millisecond)
 		}
-		require.NoError(err)
 		accept := expectBlk(instances[0])
 		results := accept(false)
 		require.Len(results, 1)
@@ -917,8 +902,7 @@ func expectBlk(i instance) func(bool) []*chain.Result {
 	require.NoError(blk.Verify(ctx))
 	require.Equal(blk.Status(), choices.Processing)
 
-	err = i.vm.SetPreference(ctx, blk.ID())
-	require.NoError(err)
+	require.NoError(i.vm.SetPreference(ctx, blk.ID()))
 
 	return func(add bool) []*chain.Result {
 		require.NoError(blk.Accept(ctx))

--- a/examples/morpheusvm/tests/integration/integration_test.go
+++ b/examples/morpheusvm/tests/integration/integration_test.go
@@ -935,7 +935,7 @@ func expectBlk(i instance) func(bool) []*chain.Result {
 	}
 }
 
-var _ common.AppSender = &appSender{}
+var _ common.AppSender = (*appSender)(nil)
 
 type appSender struct {
 	next      int

--- a/fetcher/fetcher_test.go
+++ b/fetcher/fetcher_test.go
@@ -20,7 +20,7 @@ import (
 const keyBase = "blah" // key must be long enough to be valid
 
 // Setup parent immutable state
-var _ state.Immutable = &testDB{}
+var _ state.Immutable = (*testDB)(nil)
 
 type testDB struct {
 	storage map[string][]byte

--- a/list/list.go
+++ b/list/list.go
@@ -3,9 +3,7 @@
 
 package list
 
-import (
-	"github.com/ava-labs/avalanchego/ids"
-)
+import "github.com/ava-labs/avalanchego/ids"
 
 // Item defines an interface accepted by [List].
 //

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -2,12 +2,10 @@
 # Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 # See the file LICENSE for licensing terms.
 
-set -o errexit
-set -o pipefail
-set -u
+set -euo pipefail
 
-if ! [[ "$0" =~ scripts/tests.lint.sh ]]; then
-  echo "must be run from hypersdk root"
+if ! [[ "$0" =~ scripts/lint.sh ]]; then
+  echo "must be run from repository root"
   exit 255
 fi
 
@@ -21,6 +19,16 @@ HYPERSDK_PATH=$(
 # shellcheck source=/scripts/common/utils.sh
 source "$HYPERSDK_PATH"/scripts/common/utils.sh
 
+# The -P option is not supported by the grep version installed by
+# default on macos. Since `-o errexit` is ignored in an if
+# conditional, triggering the problem here ensures script failure when
+# using an unsupported version of grep.
+grep -P 'lint.sh' scripts/lint.sh &> /dev/null || (\
+  >&2 echo "error: This script requires a recent version of gnu grep.";\
+  >&2 echo "       On macos, gnu grep can be installed with 'brew install grep'.";\
+  >&2 echo "       It will also be necessary to ensure that gnu grep is available in the path.";\
+  exit 255 )
+
 if [ "$#" -eq 0 ]; then
   # by default, check all source code
   # to test only "mempool" package
@@ -33,45 +41,70 @@ fi
 # by default, "./scripts/lint.sh" runs all lint tests
 # to run only "license_header" test
 # TESTS='license_header' ./scripts/lint.sh
-TESTS=${TESTS:-"golangci_lint license_header"}
+TESTS=${TESTS:-"golangci_lint license_header require_error_is_no_funcs_as_params single_import interface_compliance_nil require_no_error_inline_func"}
 
 # https://github.com/golangci/golangci-lint/releases
 function test_golangci_lint {
   go install -v github.com/golangci/golangci-lint/cmd/golangci-lint@"$GOLANGCI_LINT_VERSION"
-  
+
   # alert the user if they do not have $GOPATH properly configured
   check_command golangci-lint
 
   golangci-lint run --config .golangci.yml
 }
 
-# find_go_files [package]
-# all go files except generated ones
-function find_go_files {
-  local target="${1}"
-  go fmt -n "${target}"  | grep -Eo "([^ ]*)$" | grep -vE "(\\.pb\\.go|\\.pb\\.gw.go)"
-}
-
 # automatically checks license headers
 # to modify the file headers (if missing), remove "--verify" flag
-# TESTS='license_header' ADDLICENSE_FLAGS="--verify --debug" ./scripts/tests.lint.sh
+# TESTS='license_header' ADDLICENSE_FLAGS="--verify --debug" ./scripts/lint.sh
 _addlicense_flags=${ADDLICENSE_FLAGS:-"--verify --debug"}
 function test_license_header {
-  go install -v github.com/palantir/go-license@latest
+  go install -v github.com/palantir/go-license@v1.25.0
 
   # alert the user if they do not have $GOPATH properly configured
   check_command go-license
 
-  local target="${1}"
   local files=()
   while IFS= read -r line; do files+=("$line"); done < <(find . -type f -name '*.go' ! -name '*.pb.go' ! -name 'mock_*.go')
 
-  # Provision of the list of flags requires word splitting, so disable the shellcheck
   # shellcheck disable=SC2086
   go-license \
   --config ./license.yml \
   ${_addlicense_flags} \
   "${files[@]}"
+}
+
+function test_single_import {
+  if grep -R -zo -P 'import \(\n\t".*"\n\)' .; then
+    echo ""
+    return 1
+  fi
+}
+
+function test_require_error_is_no_funcs_as_params {
+  if grep -R -zo -P 'require.ErrorIs\(.+?\)[^\n]*\)\n' .; then
+    echo ""
+    return 1
+  fi
+}
+
+function test_require_no_error_inline_func {
+  if grep -R -zo -P '\t+err :?= ((?!require|if).|\n)*require\.NoError\((t, )?err\)' .; then
+    echo ""
+    echo "Checking that a function with a single error return doesn't error should be done in-line."
+    echo ""
+    return 1
+  fi
+}
+
+# Ref: https://go.dev/doc/effective_go#blank_implements
+function test_interface_compliance_nil {
+  if grep -R -o -P '_ .+? = &.+?\{\}' .; then
+    echo ""
+    echo "Interface compliance checks need to be of the form:"
+    echo "  var _ json.Marshaler = (*RawMessage)(nil)"
+    echo ""
+    return 1
+  fi
 }
 
 function run {

--- a/tstate/tstate_test.go
+++ b/tstate/tstate_test.go
@@ -70,8 +70,10 @@ func TestScope(t *testing.T) {
 	val, err := tsv.GetValue(ctx, testKey)
 	require.ErrorIs(ErrInvalidKeyOrPermission, err)
 	require.Nil(val)
-	require.ErrorIs(ErrInvalidKeyOrPermission, tsv.Insert(ctx, testKey, testVal))
-	require.ErrorIs(ErrInvalidKeyOrPermission, tsv.Remove(ctx, testKey))
+	err = tsv.Insert(ctx, testKey, testVal)
+	require.ErrorIs(err, ErrInvalidKeyOrPermission)
+	err = tsv.Remove(ctx, testKey)
+	require.ErrorIs(err, ErrInvalidKeyOrPermission)
 }
 
 func TestGetValue(t *testing.T) {
@@ -144,10 +146,11 @@ func TestInsertInvalid(t *testing.T) {
 	tsv := ts.NewView(state.Keys{string(key): state.Read | state.Write}, map[string][]byte{})
 
 	// Insert key
-	require.ErrorIs(tsv.Insert(ctx, key, []byte("cool")), ErrInvalidKeyValue)
+	err := tsv.Insert(ctx, key, []byte("cool"))
+	require.ErrorIs(err, ErrInvalidKeyValue)
 
 	// Get key value
-	_, err := tsv.GetValue(ctx, key)
+	_, err = tsv.GetValue(ctx, key)
 	require.ErrorIs(err, database.ErrNotFound)
 }
 
@@ -904,7 +907,8 @@ func TestInsertAllocate(t *testing.T) {
 
 			// Try to update key
 			if tt.shouldFail {
-				require.ErrorIs(tsv.Insert(ctx, []byte(tt.key), testVal), ErrInvalidKeyOrPermission)
+				err := tsv.Insert(ctx, []byte(tt.key), testVal)
+				require.ErrorIs(err, ErrInvalidKeyOrPermission)
 			} else {
 				require.NoError(tsv.Insert(ctx, []byte(tt.key), testVal))
 			}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -43,10 +43,8 @@ func TestLoadBytesIncorrectLength(t *testing.T) {
 	f, err := os.CreateTemp("", "TestLoadBytes*")
 	require.NoError(err)
 	fileName := f.Name()
-	err = os.WriteFile(fileName, invalidBytes, 0o600)
-	require.NoError(err, "Error writing using OS during tests")
-	err = f.Close()
-	require.NoError(err, "Error closing file during tests")
+	require.NoError(os.WriteFile(fileName, invalidBytes, 0o600), "Error writing using OS during tests")
+	require.NoError(f.Close(), "Error closing file during tests")
 
 	// Validate
 	_, err = LoadBytes(fileName, ids.IDLen)
@@ -74,8 +72,7 @@ func TestLoadBytes(t *testing.T) {
 	id := ids.GenerateTestID()
 	_, err = f.Write(id[:])
 	require.NoError(err)
-	err = f.Close()
-	require.NoError(err)
+	require.NoError(f.Close())
 
 	// Validate
 	lid, err := LoadBytes(fileName, ids.IDLen)

--- a/vm/errors.go
+++ b/vm/errors.go
@@ -3,9 +3,7 @@
 
 package vm
 
-import (
-	"errors"
-)
+import "errors"
 
 var (
 	ErrNotAdded            = errors.New("not added")

--- a/workers/parallel_workers.go
+++ b/workers/parallel_workers.go
@@ -3,9 +3,7 @@
 
 package workers
 
-import (
-	"sync"
-)
+import "sync"
 
 var (
 	_ Workers = (*ParallelWorkers)(nil)

--- a/workers/parallel_workers_test.go
+++ b/workers/parallel_workers_test.go
@@ -176,7 +176,8 @@ func TestJobGo(t *testing.T) {
 		if n == 1 {
 			require.NoError(response(), "Incorrect error message.")
 		} else {
-			require.ErrorIs(testError, response(), "Incorrect error message.")
+			err := response()
+			require.ErrorIs(err, testError, "Incorrect error message.")
 		}
 		n += 1
 	}

--- a/x/programs/runtime/import_program.go
+++ b/x/programs/runtime/import_program.go
@@ -66,7 +66,7 @@ func NewProgramModule(r *WasmRuntime) *ImportModule {
 				newInfo := *callInfo
 
 				if err := callInfo.ConsumeFuel(input.Fuel); err != nil {
-					return Err[RawBytes, ProgramCallErrorCode](OutOfFuel), nil
+					return Err[RawBytes, ProgramCallErrorCode](OutOfFuel), nil //nolint:nilerr
 				}
 
 				newInfo.Actor = callInfo.Program

--- a/x/programs/runtime/serialization_test.go
+++ b/x/programs/runtime/serialization_test.go
@@ -18,8 +18,7 @@ func TestSerializationRawBytes(t *testing.T) {
 	require.Equal(([]byte)(testBytes), serializedBytes)
 
 	b := new(bytes.Buffer)
-	err = testBytes.customSerialize(b)
-	require.NoError(err)
+	require.NoError(testBytes.customSerialize(b))
 	require.Equal(([]byte)(testBytes), b.Bytes())
 
 	deserialized, err := RawBytes{}.customDeserialize(b.Bytes())
@@ -40,8 +39,7 @@ func TestSerializationResult(t *testing.T) {
 	require.Equal([]byte{1, 1}, serializedBytes)
 
 	b := new(bytes.Buffer)
-	err = testResult.customSerialize(b)
-	require.NoError(err)
+	require.NoError(testResult.customSerialize(b))
 	require.Equal([]byte{1, 1}, b.Bytes())
 
 	deserialized, err := Result[byte, byte]{}.customDeserialize(b.Bytes())
@@ -62,8 +60,7 @@ func TestSerializationOption(t *testing.T) {
 	require.Equal([]byte{optionSomePrefix, 1}, serializedBytes)
 
 	b := new(bytes.Buffer)
-	err = testOption.customSerialize(b)
-	require.NoError(err)
+	require.NoError(testOption.customSerialize(b))
 	require.Equal([]byte{optionSomePrefix, 1}, b.Bytes())
 
 	deserialized, err := Option[byte]{}.customDeserialize(b.Bytes())

--- a/x/programs/test/testdb.go
+++ b/x/programs/test/testdb.go
@@ -12,8 +12,8 @@ import (
 )
 
 var (
-	_ state.Mutable   = &DB{}
-	_ state.Immutable = &DB{}
+	_ state.Mutable   = (*DB)(nil)
+	_ state.Immutable = (*DB)(nil)
 )
 
 func NewTestDB() *DB {


### PR DESCRIPTION
- Updates the lint script and configuration from avalanchego. Where possible, local changes were dropped to simplify future syncs.

- Renames `scripts/tests.lint.sh` to `scripts/lint.sh` for consistency with avalanchego to simplify future syncs. Renaming of other scripts that are sourced from avalanchego is left for future PRs.

- The changes to comply with new linting rules are in their own commits to allow easy removal in the event that hypersdk does not want to adopt them. 

- morpheusvm is currently [relying on an old version of golangci-lint](https://github.com/ava-labs/hypersdk/blob/main/examples/morpheusvm/scripts/tests.lint.sh#L14) and will need to be updated for compatibility with the latest version before the `structcheck` and `interfacer` linters can run.