### PR TITLE
Remove reference to `snow.Context` to Controller

### DIFF
--- a/vm/dependencies.go
+++ b/vm/dependencies.go
@@ -8,7 +8,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/ava-labs/avalanchego/snow"
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/profiler"
 	"github.com/ava-labs/avalanchego/utils/units"
 	"github.com/ava-labs/avalanchego/x/merkledb"
@@ -100,7 +101,10 @@ type AuthEngine interface {
 type ControllerFactory interface {
 	New(
 		inner *VM, // hypersdk VM
-		snowCtx *snow.Context,
+		log logging.Logger,
+		networkID uint32,
+		chainID ids.ID,
+		chainDataDir string,
 		gatherer avametrics.MultiGatherer,
 		genesisBytes []byte,
 		upgradeBytes []byte,

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -221,7 +221,10 @@ func (vm *VM) Initialize(
 	// Always initialize implementation first
 	vm.c, vm.genesis, vm.builder, vm.gossiper, vm.handlers, vm.actionRegistry, vm.authRegistry, vm.authEngine, err = vm.factory.New(
 		vm,
-		controllerContext,
+		controllerContext.Log,
+		controllerContext.NetworkID,
+		controllerContext.ChainID,
+		controllerContext.ChainDataDir,
 		controllerContext.Metrics,
 		genesisBytes,
 		upgradeBytes,


### PR DESCRIPTION
`snow.Context` exposes too much irrelevant stuff to the implementation (e.g consensus lock, atomic memory, ...). If we need to give the controller more information we can just update the `New` signature with a new parameter.