### PR TITLE
Remove optimization profile from specific repo

### DIFF
--- a/x/programs/rust/examples/automated-market-maker/Cargo.toml
+++ b/x/programs/rust/examples/automated-market-maker/Cargo.toml
@@ -16,6 +16,3 @@ simulator = { workspace = true }
 
 [build-dependencies]
 wasmlanche-sdk = { workspace = true, features = ["build"] }
-
-[profile.release]
-overflow-checks = true


### PR DESCRIPTION
This is already configured in the project route, I don't think we need it redundantly (I keep getting warnings)

