### PR TITLE
Add test for context generics

### DIFF
--- a/x/programs/rust/sdk-macros/src/lib.rs
+++ b/x/programs/rust/sdk-macros/src/lib.rs
@@ -44,22 +44,6 @@ pub fn public(_: TokenStream, item: TokenStream) -> TokenStream {
 
                 if let (Type::Reference(context_type), Type::Reference(ty)) = types {
                     context_type.lifetime = ty.lifetime.clone();
-
-                    let args = [context_type, ty].map(|type_path| {
-                        if let Type::Path(type_path) = type_path.elem.as_mut() {
-                            type_path
-                                .path
-                                .segments
-                                .last_mut()
-                                .map(|segment| &mut segment.arguments)
-                        } else {
-                            None
-                        }
-                    });
-
-                    if let [Some(context_type_args), Some(ty_args)] = args {
-                        *context_type_args = ty_args.clone();
-                    }
                 }
 
                 std::mem::swap(&mut context_type, ty);

--- a/x/programs/rust/sdk-macros/tests/ui/fail/generic-context-args.rs
+++ b/x/programs/rust/sdk-macros/tests/ui/fail/generic-context-args.rs
@@ -1,0 +1,12 @@
+use wasmlanche_sdk::{borsh::BorshDeserialize, public};
+
+#[derive(BorshDeserialize)]
+#[borsh(crate = "wasmlanche_sdk::borsh")]
+pub struct Context<T>(T);
+
+#[public]
+pub fn always_true(_: &mut Context<u8>) -> bool {
+    true
+}
+
+fn main() {}

--- a/x/programs/rust/sdk-macros/tests/ui/fail/generic-context-args.stderr
+++ b/x/programs/rust/sdk-macros/tests/ui/fail/generic-context-args.stderr
@@ -1,0 +1,28 @@
+error[E0308]: mismatched types
+ --> tests/ui/fail/generic-context-args.rs:7:1
+  |
+7 | #[public]
+  | ^^^^^^^^^
+  | |
+  | expected `&mut Context`, found `&mut Context<u8>`
+  | arguments to this function are incorrect
+  |
+  = note: `Context<u8>` and `wasmlanche_sdk::Context` have similar names, but are actually distinct types
+note: `Context<u8>` is defined in the current crate
+ --> tests/ui/fail/generic-context-args.rs:5:1
+  |
+5 | pub struct Context<T>(T);
+  | ^^^^^^^^^^^^^^^^^^^^^
+note: `wasmlanche_sdk::Context` is defined in crate `wasmlanche_sdk`
+ --> $WORKSPACE/x/programs/rust/wasmlanche-sdk/src/context.rs
+  |
+  | pub struct Context {
+  | ^^^^^^^^^^^^^^^^^^
+note: function defined here
+ --> tests/ui/fail/generic-context-args.rs:8:8
+  |
+7 | #[public]
+  | ---------
+8 | pub fn always_true(_: &mut Context<u8>) -> bool {
+  |        ^^^^^^^^^^^
+  = note: this error originates in the attribute macro `public` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
Not sure this is the best test, but it'll act as a sort of regression test in case we add generics back to the `Context`. 

