### PR TITLE
Handle wildcard in public function arguments

### DIFF
--- a/x/programs/rust/sdk-macros/tests/ui/pass/wildcard-param.rs
+++ b/x/programs/rust/sdk-macros/tests/ui/pass/wildcard-param.rs
@@ -1,0 +1,8 @@
+use wasmlanche_sdk::{public, Context};
+
+#[public]
+pub fn always_true(_: &mut Context, _: bool) -> bool {
+    true
+}
+
+fn main() {}


### PR DESCRIPTION
Once we have upgrades, this will likely be more relevant. If someone wants to set an API but they don't know what they want to do with a particular parameter yet, they should be able to use wildcards

