### PR TITLE
Drop the context before setting the call-result

### DIFF
--- a/x/programs/rust/sdk-macros/src/lib.rs
+++ b/x/programs/rust/sdk-macros/src/lib.rs
@@ -170,12 +170,14 @@ pub fn public(_: TokenStream, item: TokenStream) -> TokenStream {
             unsafe extern "C" fn #name(args: wasmlanche_sdk::HostPtr) {
                 wasmlanche_sdk::register_panic();
 
-                let args: Args = wasmlanche_sdk::borsh::from_slice(&args).expect("error fetching serialized args");
+                let result = {
+                    let args: Args = wasmlanche_sdk::borsh::from_slice(&args).expect("error fetching serialized args");
 
-                let Args { mut ctx, #(#args_names),* } = args;
+                    let Args { mut ctx, #(#args_names),* } = args;
 
-                let result = super::#name(&mut ctx, #(#args_names_2),*);
-                let result = wasmlanche_sdk::borsh::to_vec(&result).expect("error serializing result");
+                    let result = super::#name(&mut ctx, #(#args_names_2),*);
+                    wasmlanche_sdk::borsh::to_vec(&result).expect("error serializing result")
+                };
 
                 unsafe { set_call_result(result.as_ptr(), result.len()) };
             }


### PR DESCRIPTION
Not strictly necessary with the current implementation of `set_call_result`, but this will just protect us in the future in case of any changes. The `set_call_result` implementation *shoudn't* be doing anything with state, but we can't make that guarantee.

