### PR TITLE
Fix bug in calculating transaction usage

### DIFF
--- a/chain/transaction.go
+++ b/chain/transaction.go
@@ -217,7 +217,7 @@ func EstimateUnits(r Rules, actions []Action, authFactory AuthFactory) (fees.Dim
 	}
 
 	// Estimate storage costs
-	for maxChunks := range stateKeysMaxChunks {
+	for _, maxChunks := range stateKeysMaxChunks {
 		// Compute key costs
 		readsOp.Add(r.GetStorageKeyReadUnits())
 		allocatesOp.Add(r.GetStorageKeyAllocateUnits())


### PR DESCRIPTION
The amount being added should be the recorded max chunks rather than the index of the max chunks