### PR TITLE
Non-interactive Morpheus Spam

### DIFF
--- a/cli/spam.go
+++ b/cli/spam.go
@@ -52,6 +52,12 @@ var (
 
 type SpamFlags struct {
 	AccountsNumber int
+	SZipf          float64
+	VZipf          float64
+	TxPerSec       int
+	MinTxsPerSec   int
+	TxPerSecStep   int
+	NumClients     int
 }
 
 func (h *Handler) Spam(sh SpamHelper, flags SpamFlags) error {
@@ -124,29 +130,52 @@ func (h *Handler) Spam(sh SpamHelper, flags SpamFlags) error {
 		return ErrInsufficientAccounts
 	}
 
-	sZipf, err := h.PromptFloat("s (Zipf distribution = [(v+k)^(-s)], Default = 1.01)", consts.MaxFloat64)
-	if err != nil {
-		return err
+	sZipf := flags.SZipf
+	if sZipf == 0 {
+		sZipf, err = h.PromptFloat("s (Zipf distribution = [(v+k)^(-s)], Default = 1.01)", consts.MaxFloat64)
+		if err != nil {
+			return err
+		}
 	}
-	vZipf, err := h.PromptFloat("v (Zipf distribution = [(v+k)^(-s)], Default = 2.7)", consts.MaxFloat64)
-	if err != nil {
-		return err
+
+	vZipf := flags.VZipf
+	if vZipf == 0 {
+		vZipf, err = h.PromptFloat("v (Zipf distribution = [(v+k)^(-s)], Default = 2.7)", consts.MaxFloat64)
+		if err != nil {
+			return err
+		}
 	}
-	txsPerSecond, err := h.PromptInt("txs to try and issue per second", consts.MaxInt)
-	if err != nil {
-		return err
+
+	txsPerSecond := flags.TxPerSec
+	if txsPerSecond == 0 {
+		txsPerSecond, err = h.PromptInt("txs to try and issue per second", consts.MaxInt)
+		if err != nil {
+			return err
+		}
 	}
-	minTxsPerSecond, err := h.PromptInt("minimum txs to issue per second", consts.MaxInt)
-	if err != nil {
-		return err
+
+	minTxsPerSecond := flags.MinTxsPerSec
+	if minTxsPerSecond == 0 {
+		minTxsPerSecond, err = h.PromptInt("minimum txs to issue per second", consts.MaxInt)
+		if err != nil {
+			return err
+		}
 	}
-	txsPerSecondStep, err := h.PromptInt("txs to increase per second", consts.MaxInt)
-	if err != nil {
-		return err
+
+	txsPerSecondStep := flags.TxPerSecStep
+	if txsPerSecondStep == 0 {
+		txsPerSecondStep, err = h.PromptInt("txs to increase per second", consts.MaxInt)
+		if err != nil {
+			return err
+		}
 	}
-	numClients, err := h.PromptInt("number of clients per node", consts.MaxInt)
-	if err != nil {
-		return err
+
+	numClients := flags.NumClients
+	if numClients == 0 {
+		numClients, err = h.PromptInt("number of clients per node", consts.MaxInt)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Log Zipf participants

--- a/cli/spam.go
+++ b/cli/spam.go
@@ -50,7 +50,11 @@ var (
 	sent     atomic.Int64
 )
 
-func (h *Handler) Spam(sh SpamHelper) error {
+type SpamFlags struct {
+	AccountsNumber int
+}
+
+func (h *Handler) Spam(sh SpamHelper, flags SpamFlags) error {
 	ctx := context.Background()
 
 	// Select chain
@@ -109,13 +113,17 @@ func (h *Handler) Spam(sh SpamHelper) error {
 	}
 
 	// Collect parameters
-	numAccounts, err := h.PromptInt("number of accounts", consts.MaxInt)
-	if err != nil {
-		return err
+	numAccounts := flags.AccountsNumber
+	if numAccounts == 0 {
+		numAccounts, err = h.PromptInt("number of accounts", consts.MaxInt)
+		if err != nil {
+			return err
+		}
 	}
 	if numAccounts < 2 {
 		return ErrInsufficientAccounts
 	}
+
 	sZipf, err := h.PromptFloat("s (Zipf distribution = [(v+k)^(-s)], Default = 1.01)", consts.MaxFloat64)
 	if err != nil {
 		return err

--- a/examples/morpheusvm/cmd/morpheus-cli/cmd/root.go
+++ b/examples/morpheusvm/cmd/morpheus-cli/cmd/root.go
@@ -35,6 +35,7 @@ var (
 	prometheusFile        string
 	prometheusData        string
 	startPrometheus       bool
+	accountsNumber        uint32
 
 	rootCmd = &cobra.Command{
 		Use:        "morpheus-cli",
@@ -145,6 +146,12 @@ func init() {
 	)
 
 	// spam
+	runSpamCmd.PersistentFlags().Uint32Var(
+		&accountsNumber,
+		"accounts",
+		0,
+		"number of accounts to create",
+	)
 	spamCmd.AddCommand(
 		runSpamCmd,
 	)

--- a/examples/morpheusvm/cmd/morpheus-cli/cmd/root.go
+++ b/examples/morpheusvm/cmd/morpheus-cli/cmd/root.go
@@ -36,6 +36,12 @@ var (
 	prometheusData        string
 	startPrometheus       bool
 	accountsNumber        uint32
+	sZipf                 float64
+	vZipf                 float64
+	txPerSec              uint32
+	minCapacity           uint32
+	txPerSecStep          uint32
+	numClients            uint32
 
 	rootCmd = &cobra.Command{
 		Use:        "morpheus-cli",
@@ -145,12 +151,48 @@ func init() {
 		transferCmd,
 	)
 
-	// spam
+	// spam run ed25519 --accounts=10000000 --txs-per-second=100000 --min-capacity=15000 --step-size=1000 --s-zipf=1.0001 --v-zipf=2.7
 	runSpamCmd.PersistentFlags().Uint32Var(
 		&accountsNumber,
 		"accounts",
 		0,
 		"number of accounts to create",
+	)
+	runSpamCmd.PersistentFlags().Float64Var(
+		&sZipf,
+		"s-zipf",
+		0,
+		"s-zipf",
+	)
+	runSpamCmd.PersistentFlags().Float64Var(
+		&vZipf,
+		"v-zipf",
+		0,
+		"v-zipf",
+	)
+	runSpamCmd.PersistentFlags().Uint32Var(
+		&txPerSec,
+		"txs-per-second",
+		0,
+		"txs per second",
+	)
+	runSpamCmd.PersistentFlags().Uint32Var(
+		&txPerSecStep,
+		"step-size",
+		0,
+		"step size",
+	)
+	runSpamCmd.PersistentFlags().Uint32Var(
+		&numClients,
+		"conns-per-host",
+		0,
+		"number of clients",
+	)
+	runSpamCmd.PersistentFlags().Uint32Var(
+		&minCapacity,
+		"min-capacity",
+		0,
+		"min capacity",
 	)
 	spamCmd.AddCommand(
 		runSpamCmd,

--- a/examples/morpheusvm/cmd/morpheus-cli/cmd/spam.go
+++ b/examples/morpheusvm/cmd/morpheus-cli/cmd/spam.go
@@ -109,6 +109,12 @@ var runSpamCmd = &cobra.Command{
 			keyType: args[0],
 		}, cli.SpamFlags{
 			AccountsNumber: int(accountsNumber),
+			SZipf:          sZipf,
+			VZipf:          vZipf,
+			TxPerSec:       int(txPerSec),
+			MinTxsPerSec:   int(minCapacity),
+			TxPerSecStep:   int(txPerSecStep),
+			NumClients:     int(numClients),
 		})
 	},
 }

--- a/examples/morpheusvm/cmd/morpheus-cli/cmd/spam.go
+++ b/examples/morpheusvm/cmd/morpheus-cli/cmd/spam.go
@@ -105,6 +105,10 @@ var runSpamCmd = &cobra.Command{
 		return checkKeyType(args[0])
 	},
 	RunE: func(_ *cobra.Command, args []string) error {
-		return handler.Root().Spam(&SpamHelper{keyType: args[0]})
+		return handler.Root().Spam(&SpamHelper{
+			keyType: args[0],
+		}, cli.SpamFlags{
+			AccountsNumber: int(accountsNumber),
+		})
 	},
 }

--- a/examples/morpheusvm/scripts/run.sh
+++ b/examples/morpheusvm/scripts/run.sh
@@ -207,11 +207,12 @@ fi
 
 killall avalanche-network-runner || true
 
+date=$(date +%Y-%m-%d-%H-%M-%S)
 echo "launch avalanche-network-runner in the background"
 $BIN server \
 --log-level=verbo \
 --port=":12352" \
---grpc-gateway-port=":12353" &
+--grpc-gateway-port=":12353" > >(tee "anr-${date}.log") 2>&1 &
 
 ############################
 # By default, it runs all e2e test cases!

--- a/examples/morpheusvm/scripts/spam.sh
+++ b/examples/morpheusvm/scripts/spam.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -exu
+
+go run ./cmd/morpheus-cli/ chain import-anr
+
+go run ./cmd/morpheus-cli/ spam run ed25519 \
+    --accounts=20000 \
+    --txs-per-second=10000 \
+    --min-capacity=1000 \
+    --step-size=50 \
+    --s-zipf=1.01 \
+    --v-zipf=2.7 \
+    --conns-per-host=10

--- a/examples/morpheusvm/scripts/spam.sh
+++ b/examples/morpheusvm/scripts/spam.sh
@@ -1,9 +1,14 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# Copyright (C) 2024, Ava Labs, Inc. All rights reserved.
+# See the file LICENSE for licensing terms.
 
-set -exu
+set -e
 
-go run ./cmd/morpheus-cli/ chain import-anr
+go run ./cmd/morpheus-cli/ chain import-anr; 
 
+date=$(date +%Y-%m-%d-%H-%M-%S)
+
+# Run the command and output to both the log file and console
 go run ./cmd/morpheus-cli/ spam run ed25519 \
     --accounts=20000 \
     --txs-per-second=10000 \
@@ -11,4 +16,4 @@ go run ./cmd/morpheus-cli/ spam run ed25519 \
     --step-size=50 \
     --s-zipf=1.01 \
     --v-zipf=2.7 \
-    --conns-per-host=10
+    --conns-per-host=10 2>&1 | tee "spam-${date}.log"


### PR DESCRIPTION
# Non-interactive Morpheus Spam

I noticed that VRYX branch uses non interactive spam command like this
```
/home/ubuntu/simulator spam run ed25519 --accounts=10000000 --txs-per-second=100000 --min-capacity=15000 --step-size=1000 --s-zipf=1.0001 --v-zipf=2.7 --conns-per-host=10 --cluster-info=/home/ubuntu/clusterInfo.yaml --private-key=323b1d8f4eed5f0da9da93071b034f2dce9d2d22692c172f3cb252a64ddfafd01b057de320297c29ad0c1f589ea216869cf1938d88c9fbd70d6748323dbf2fa7
```
[Code permalink](https://github.com/ava-labs/hypersdk/blob/8b204201359a79bb22db5ea06b33f497de775ab4/examples/morpheusvm/scripts/deploy.devnet.sh#L215C372-L215C730)

I added CLI flags to match VRYX's CLI arguments. Now you can launch the spam like this:

```bash
# Terminal 1
./scripts/run.sh
# Terminal 2
go run ./cmd/morpheus-cli/ chain import-anr
go run ./cmd/morpheus-cli/ spam run ed25519 --accounts=20000 --txs-per-second=10000 --min-capacity=1000 --step-size=100 --s-zipf=1.0001 --v-zipf=2.7 --conns-per-host=10

```