### PR TITLE
Make sure to run rust integration tests

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -68,4 +68,4 @@ jobs:
         with:
           targets: wasm32-unknown-unknown
       - name: Run unit tests
-        run: cargo test --all-features --all
+        run: cargo test --all-features --all --tests


### PR DESCRIPTION
We need the `--tests` flag to make sure the integration tests are run

