### PR TITLE
Add compose-dev.yaml to git-ignore for docker-dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,4 @@ x/programs/cmd/simulator/simulator
 x/programs/runtime/debug
 x/programs/runtime/wasm32-unknown-unknown
 x/programs/runtime/.rustc_info.json
+compose-dev.yaml


### PR DESCRIPTION
Docker dev-environments creates a compose-file that we definitely don't want to check into source-control

