### PR TITLE
Update bytemuck so we can derive NoUninit

### DIFF
--- a/x/programs/rust/sdk-macros/src/lib.rs
+++ b/x/programs/rust/sdk-macros/src/lib.rs
@@ -316,7 +316,7 @@ pub fn state_schema(input: TokenStream) -> TokenStream {
 
                 token_stream.extend(Some(quote! {
                     #(#key_comments)*
-                    #[derive(Copy, Clone, wasmlanche_sdk::bytemuck::Pod, wasmlanche_sdk::bytemuck::Zeroable)]
+                    #[derive(Copy, Clone, wasmlanche_sdk::bytemuck::NoUninit)]
                     #[bytemuck(crate = "wasmlanche_sdk::bytemuck")]
                     #[repr(C)]
                     #key_vis struct #key_type_name #key_fields;

--- a/x/programs/rust/wasmlanche-sdk/Cargo.toml
+++ b/x/programs/rust/wasmlanche-sdk/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 borsh = { version = "1.5.1", features = ["derive"] }
-bytemuck = { version = "1.16.1", features = ["derive"] }
+bytemuck = { version = "1.16.3", features = ["derive"] }
 sdk-macros = { workspace = true }
 thiserror = { workspace = true }
 


### PR DESCRIPTION
`Pod` and `Zeroable` are more strict than `NoUninit` and we don't actually require that level of strictness but we couldn't specify the crate path before a recent release. 

