### PR TITLE
Add Balance Interface to Simulator

### DIFF
--- a/x/programs/simulator/ffi/ffi.go
+++ b/x/programs/simulator/ffi/ffi.go
@@ -165,7 +165,7 @@ func GetBalance(db *C.Mutable, address *C.Address) C.uint64_t {
 
 	state := simState.NewSimulatorState(unsafe.Pointer(db))
 	pState := simState.NewProgramStateManager(state)
-	account := C.GoBytes(unsafe.Pointer(address), codec.AddressLen) //nolint:all
+	account := C.GoBytes(unsafe.Pointer(address), codec.AddressLen)
 
 	balance, err := pState.GetBalance(SimContext, codec.Address(account))
 	if err != nil {
@@ -186,7 +186,7 @@ func SetBalance(db *C.Mutable, address *C.Address, balance C.uint64_t) {
 
 	state := simState.NewSimulatorState(unsafe.Pointer(db))
 	pState := simState.NewProgramStateManager(state)
-	account := C.GoBytes(unsafe.Pointer(address), codec.AddressLen) //nolint:all
+	account := C.GoBytes(unsafe.Pointer(address), codec.AddressLen)
 
 	err := pState.SetBalance(SimContext, codec.Address(account), uint64(balance))
 	if err != nil {

--- a/x/programs/simulator/ffi/ffi.go
+++ b/x/programs/simulator/ffi/ffi.go
@@ -154,6 +154,9 @@ func newCallProgramResponse(result []byte, fuel uint64, err error) C.CallProgram
 	}
 }
 
+// getBalance returns the balance of [account].
+// Panics if there is an error.
+//
 //export GetBalance
 func GetBalance(db *C.Mutable, address *C.Address) C.uint64_t {
 	if db == nil || address == nil {
@@ -162,7 +165,7 @@ func GetBalance(db *C.Mutable, address *C.Address) C.uint64_t {
 
 	state := simState.NewSimulatorState(unsafe.Pointer(db))
 	pState := simState.NewProgramStateManager(state)
-	account := C.GoBytes(unsafe.Pointer(address), codec.AddressLen)     //nolint:all
+	account := C.GoBytes(unsafe.Pointer(address), codec.AddressLen) //nolint:all
 
 	balance, err := pState.GetBalance(SimContext, codec.Address(account))
 	if err != nil {
@@ -174,6 +177,7 @@ func GetBalance(db *C.Mutable, address *C.Address) C.uint64_t {
 
 // SetBalance sets the balance of [account] to [balance].
 // Panics if there is an error.
+//
 //export SetBalance
 func SetBalance(db *C.Mutable, address *C.Address, balance C.uint64_t) {
 	if db == nil || address == nil {

--- a/x/programs/simulator/ffi/ffi.go
+++ b/x/programs/simulator/ffi/ffi.go
@@ -154,4 +154,40 @@ func newCallProgramResponse(result []byte, fuel uint64, err error) C.CallProgram
 	}
 }
 
+//export GetBalance
+func GetBalance(db *C.Mutable, address *C.Address) C.uint64_t {
+	if db == nil || address == nil {
+		panic(ErrInvalidParam)
+	}
+
+	state := simState.NewSimulatorState(unsafe.Pointer(db))
+	pState := simState.NewProgramStateManager(state)
+	account := C.GoBytes(unsafe.Pointer(address), codec.AddressLen)     //nolint:all
+
+	balance, err := pState.GetBalance(SimContext, codec.Address(account))
+	if err != nil {
+		panic(err)
+	}
+
+	return C.uint64_t(balance)
+}
+
+// SetBalance sets the balance of [account] to [balance].
+// Panics if there is an error.
+//export SetBalance
+func SetBalance(db *C.Mutable, address *C.Address, balance C.uint64_t) {
+	if db == nil || address == nil {
+		panic(ErrInvalidParam)
+	}
+
+	state := simState.NewSimulatorState(unsafe.Pointer(db))
+	pState := simState.NewProgramStateManager(state)
+	account := C.GoBytes(unsafe.Pointer(address), codec.AddressLen) //nolint:all
+
+	err := pState.SetBalance(SimContext, codec.Address(account), uint64(balance))
+	if err != nil {
+		panic(err)
+	}
+}
+
 func main() {}

--- a/x/programs/simulator/src/lib.rs
+++ b/x/programs/simulator/src/lib.rs
@@ -37,6 +37,8 @@ mod bindings {
 
 mod simulator;
 mod state;
+
+#[cfg(test)]
 mod tests;
 
 pub use simulator::Simulator;

--- a/x/programs/simulator/src/lib.rs
+++ b/x/programs/simulator/src/lib.rs
@@ -37,6 +37,7 @@ mod bindings {
 
 mod simulator;
 mod state;
+mod tests;
 
 pub use simulator::Simulator;
 pub use state::SimpleState;

--- a/x/programs/simulator/src/simulator.rs
+++ b/x/programs/simulator/src/simulator.rs
@@ -36,6 +36,12 @@ extern "C" {
 
     #[link_name = "CallProgram"]
     fn call_program(db: usize, ctx: *const SimulatorCallContext) -> CallProgramResponse;
+
+    #[link_name = "GetBalance"]
+    fn get_balance(db: usize, account: Address) -> u64;
+
+    #[link_name = "SetBalance"]
+    fn set_balance(db: usize, account: Address, balance: u64);
 }
 
 pub struct Simulator<'a> {
@@ -76,6 +82,20 @@ impl<'a> Simulator<'a> {
 
     pub fn set_actor(&mut self, actor: Address) {
         self.actor = actor;
+    }
+
+    pub fn get_balance(&self, account: Address) -> u64 {
+        let state_addr = &self.state as *const _ as usize;
+        unsafe { get_balance(state_addr, account) }
+    }
+
+    pub fn set_balance(&mut self, account: Address, balance: u64) {
+        let state_addr = &self.state as *const _ as usize;
+        unsafe { set_balance(state_addr, account, balance) }
+    }
+
+    pub fn get_actor(&self) -> Address {
+        self.actor
     }
 }
 

--- a/x/programs/simulator/src/tests.rs
+++ b/x/programs/simulator/src/tests.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 #[cfg(test)]
 mod tests {
     use wasmlanche_sdk::Address;

--- a/x/programs/simulator/src/tests.rs
+++ b/x/programs/simulator/src/tests.rs
@@ -1,24 +1,21 @@
 // Copyright (C) 2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-#[cfg(test)]
-mod tests {
-    use wasmlanche_sdk::Address;
+use wasmlanche_sdk::Address;
 
-    use crate::simulator::Simulator;
-    use crate::state::SimpleState;
+use crate::simulator::Simulator;
+use crate::state::SimpleState;
 
-    #[test]
-    fn set_balance() {
-        let mut state = SimpleState::new();
-        let mut simulator = Simulator::new(&mut state);
-        let alice = Address::new([1; 33]);
+#[test]
+fn set_balance() {
+    let mut state = SimpleState::new();
+    let mut simulator = Simulator::new(&mut state);
+    let alice = Address::new([1; 33]);
 
-        let bal = simulator.get_balance(alice);
-        assert_eq!(bal, 0);
+    let bal = simulator.get_balance(alice);
+    assert_eq!(bal, 0);
 
-        simulator.set_balance(alice, 100);
-        let bal = simulator.get_balance(alice);
-        assert_eq!(bal, 100);
-    }
+    simulator.set_balance(alice, 100);
+    let bal = simulator.get_balance(alice);
+    assert_eq!(bal, 100);
 }

--- a/x/programs/simulator/src/tests.rs
+++ b/x/programs/simulator/src/tests.rs
@@ -1,0 +1,21 @@
+#[cfg(test)]
+mod tests {
+    use wasmlanche_sdk::Address;
+
+    use crate::simulator::Simulator;
+    use crate::state::SimpleState;
+
+    #[test]
+    fn set_balance() {
+        let mut state = SimpleState::new();
+        let mut simulator = Simulator::new(&mut state);
+        let alice = Address::new([1; 33]);
+
+        let bal = simulator.get_balance(alice);
+        assert_eq!(bal, 0);
+
+        simulator.set_balance(alice, 100);
+        let bal = simulator.get_balance(alice);
+        assert_eq!(bal, 100);
+    }
+}

--- a/x/programs/simulator/state/manager.go
+++ b/x/programs/simulator/state/manager.go
@@ -50,6 +50,10 @@ func (p *ProgramStateManager) GetBalance(ctx context.Context, address codec.Addr
 	return p.getAccountBalance(ctx, address)
 }
 
+func (p *ProgramStateManager) SetBalance(ctx context.Context, address codec.Address, amount uint64) error {
+	return p.setAccountBalance(ctx, address, amount)
+}
+
 func (p *ProgramStateManager) TransferBalance(ctx context.Context, from codec.Address, to codec.Address, amount uint64) error {
 	fromBalance, err := p.getAccountBalance(ctx, from)
 	if err != nil {


### PR DESCRIPTION
allows the simulator to set/get the balances of accounts.

decided to expose FFI functions instead of directly setting/getting in rust as to not duplicate the state logic. 