### PR TITLE
Fix local usage of shellcheck

### DIFF
--- a/scripts/tests.shellcheck.sh
+++ b/scripts/tests.shellcheck.sh
@@ -52,4 +52,4 @@ fi
 # compatible with both macos and linux (unlike the use of -printf).
 #
 # shellcheck disable=SC2035
-find * -name "*.sh" -type f -print0 | xargs -0 "${SHELLCHECK}" "${@}"
+find * -name "*.sh" -type f -print0 | xargs -0 "${SHELLCHECK}" "$@"


### PR DESCRIPTION
This PR fixes a previous bug in `scripts/tests.shellcheck.sh` where running the script locally would cause it to fail. In particular, this PR removes the expansion brackets which wrapped the `$@` parameter that caused the bug.