### PR TITLE
Remove return of `bool` from token functions

### DIFF
--- a/x/programs/rust/examples/automated-market-maker/src/lib.rs
+++ b/x/programs/rust/examples/automated-market-maker/src/lib.rs
@@ -30,14 +30,9 @@ pub fn init(context: &mut Context, token_x: Program, token_y: Program, liquidity
 
     let liquidity_context = ExternalCallContext::new(liquidity_token, MAX_GAS, 0);
 
-    let transfer_reuslt =
-        token::transfer_ownership(&liquidity_context, *context.program().account());
     // TODO: the init function should spin up a new token contract instead
     // of requiring the caller to pass in the liquidity token
-    assert!(
-        transfer_reuslt,
-        "failed to transfer ownership of the liquidity token"
-    );
+    token::transfer_ownership(&liquidity_context, *context.program().account());
 }
 
 /// Swaps 'amount' of `token_program_in` with the other token in the pool
@@ -77,11 +72,7 @@ pub fn swap(context: &mut Context, token_program_in: Program, amount: Units) -> 
     token::transfer_from(&token_out, account, actor, amount_out);
 
     // update the allowance for token_in
-    let token_approved = token::approve(&token_in, account, reserve_token_in + amount);
-    assert!(
-        token_approved,
-        "failed to update the allowance for the token"
-    );
+    token::approve(&token_in, account, reserve_token_in + amount);
 
     amount_out
 }
@@ -133,9 +124,8 @@ pub fn add_liquidity(context: &mut Context, amount_x: Units, amount_y: Units) ->
     token::mint(&lp_token, actor, shares);
 
     // update the amm's allowances
-    let approved = token::approve(&token_x, account, reserve_x + amount_x)
-        && token::approve(&token_y, account, reserve_y + amount_y);
-    assert!(approved, "failed to update the allowances for the tokens");
+    token::approve(&token_x, account, reserve_x + amount_x);
+    token::approve(&token_y, account, reserve_y + amount_y);
 
     shares
 }

--- a/x/programs/rust/examples/token/src/lib.rs
+++ b/x/programs/rust/examples/token/src/lib.rs
@@ -47,7 +47,7 @@ pub fn total_supply(context: &mut Context) -> Units {
 
 /// Transfers balance from the token owner to the recipient.
 #[public]
-pub fn mint(context: &mut Context, recipient: Address, amount: Units) -> bool {
+pub fn mint(context: &mut Context, recipient: Address, amount: Units) {
     let actor = context.actor();
 
     check_owner(context, actor);
@@ -61,8 +61,6 @@ pub fn mint(context: &mut Context, recipient: Address, amount: Units) -> bool {
             (TotalSupply, (total_supply + amount)),
         ))
         .expect("failed to store balance");
-
-    true
 }
 
 /// Burn the token from the recipient.
@@ -104,37 +102,27 @@ pub fn allowance(context: &mut Context, owner: Address, spender: Address) -> Uni
 }
 
 /// Approves the spender to spend the owner's tokens.
-/// Returns true if the approval was successful.
 #[public]
-pub fn approve(context: &mut Context, spender: Address, amount: Units) -> bool {
+pub fn approve(context: &mut Context, spender: Address, amount: Units) {
     let actor = context.actor();
 
     context
         .store_by_key(Allowance(actor, spender), amount)
         .expect("failed to store allowance");
-
-    true
 }
 
 /// Transfers balance from the sender to the the recipient.
 #[public]
-pub fn transfer(context: &mut Context, recipient: Address, amount: Units) -> bool {
+pub fn transfer(context: &mut Context, recipient: Address, amount: Units) {
     let sender = context.actor();
 
     internal::transfer(context, sender, recipient, amount);
-
-    true
 }
 
 /// Transfers balance from the sender to the recipient.
 /// The caller must have an allowance to spend the senders tokens.
 #[public]
-pub fn transfer_from(
-    context: &mut Context,
-    sender: Address,
-    recipient: Address,
-    amount: Units,
-) -> bool {
+pub fn transfer_from(context: &mut Context, sender: Address, recipient: Address, amount: Units) {
     assert_ne!(sender, recipient, "sender and recipient must be different");
 
     let actor = context.actor();
@@ -147,19 +135,15 @@ pub fn transfer_from(
         .expect("failed to store allowance");
 
     internal::transfer(context, sender, recipient, amount);
-
-    true
 }
 
 #[public]
-pub fn transfer_ownership(context: &mut Context, new_owner: Address) -> bool {
+pub fn transfer_ownership(context: &mut Context, new_owner: Address) {
     check_owner(context, context.actor());
 
     context
         .store_by_key(Owner, new_owner)
         .expect("failed to store owner");
-
-    true
 }
 
 #[public]


### PR DESCRIPTION
We should probably just assume that if the called function fails for whatever reason, it would panic and it would just revert the execution. This bool return was not checked everywhere, for instance in the `transfer_from` calls in the AMM.

Closes https://github.com/ava-labs/hypersdk/issues/1216