### PR TITLE
Fix Balance Method Ptrs

### DIFF
--- a/x/programs/rust/examples/find-out/build.rs
+++ b/x/programs/rust/examples/find-out/build.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 fn main() {
     wasmlanche_sdk::build::build_wasm_on_test();
 }

--- a/x/programs/rust/examples/find-out/src/lib.rs
+++ b/x/programs/rust/examples/find-out/src/lib.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 // Here, we import the `public` attribute-macro, the `state_schema` macro,
 // and the `Address` and `Context` types
 use wasmlanche_sdk::{public, state_schema, Address, Context};

--- a/x/programs/simulator/ffi/ffi.go
+++ b/x/programs/simulator/ffi/ffi.go
@@ -157,14 +157,14 @@ func newCallProgramResponse(result []byte, fuel uint64, err error) C.CallProgram
 // Panics if there is an error.
 //
 //export GetBalance
-func GetBalance(db *C.Mutable, address *C.Address) C.uint64_t {
-	if db == nil || address == nil {
+func GetBalance(db *C.Mutable, address C.Address) C.uint64_t {
+	if db == nil {
 		panic(ErrInvalidParam)
 	}
 
 	state := simState.NewSimulatorState(unsafe.Pointer(db))
 	pState := simState.NewProgramStateManager(state)
-	account := C.GoBytes(unsafe.Pointer(address), codec.AddressLen)
+	account := C.GoBytes(unsafe.Pointer(&address.address[0]), codec.AddressLen)
 
 	balance, err := pState.GetBalance(SimContext, codec.Address(account))
 	if err != nil {
@@ -178,14 +178,14 @@ func GetBalance(db *C.Mutable, address *C.Address) C.uint64_t {
 // Panics if there is an error.
 //
 //export SetBalance
-func SetBalance(db *C.Mutable, address *C.Address, balance C.uint64_t) {
-	if db == nil || address == nil {
+func SetBalance(db *C.Mutable, address C.Address, balance C.uint64_t) {
+	if db == nil {
 		panic(ErrInvalidParam)
 	}
 
 	state := simState.NewSimulatorState(unsafe.Pointer(db))
 	pState := simState.NewProgramStateManager(state)
-	account := C.GoBytes(unsafe.Pointer(address), codec.AddressLen)
+	account := C.GoBytes(unsafe.Pointer(&address.address[0]), codec.AddressLen)
 
 	err := pState.SetBalance(SimContext, codec.Address(account), uint64(balance))
 	if err != nil {

--- a/x/programs/simulator/ffi/ffi.go
+++ b/x/programs/simulator/ffi/ffi.go
@@ -164,7 +164,7 @@ func GetBalance(db *C.Mutable, address C.Address) C.uint64_t {
 
 	state := simState.NewSimulatorState(unsafe.Pointer(db))
 	pState := simState.NewProgramStateManager(state)
-	account := C.GoBytes(unsafe.Pointer(&address.address[0]), codec.AddressLen)
+	account := C.GoBytes(unsafe.Pointer(&address.address), codec.AddressLen)
 
 	balance, err := pState.GetBalance(SimContext, codec.Address(account))
 	if err != nil {
@@ -185,7 +185,7 @@ func SetBalance(db *C.Mutable, address C.Address, balance C.uint64_t) {
 
 	state := simState.NewSimulatorState(unsafe.Pointer(db))
 	pState := simState.NewProgramStateManager(state)
-	account := C.GoBytes(unsafe.Pointer(&address.address[0]), codec.AddressLen)
+	account := C.GoBytes(unsafe.Pointer(&address.address), codec.AddressLen)
 
 	err := pState.SetBalance(SimContext, codec.Address(account), uint64(balance))
 	if err != nil {

--- a/x/programs/simulator/ffi/ffi.go
+++ b/x/programs/simulator/ffi/ffi.go
@@ -164,7 +164,7 @@ func GetBalance(db *C.Mutable, address C.Address) C.uint64_t {
 
 	state := simState.NewSimulatorState(unsafe.Pointer(db))
 	pState := simState.NewProgramStateManager(state)
-	account := C.GoBytes(unsafe.Pointer(&address.address), codec.AddressLen)
+	account := C.GoBytes(unsafe.Pointer(&address.address), codec.AddressLen) //nolint:all
 
 	balance, err := pState.GetBalance(SimContext, codec.Address(account))
 	if err != nil {
@@ -185,7 +185,7 @@ func SetBalance(db *C.Mutable, address C.Address, balance C.uint64_t) {
 
 	state := simState.NewSimulatorState(unsafe.Pointer(db))
 	pState := simState.NewProgramStateManager(state)
-	account := C.GoBytes(unsafe.Pointer(&address.address), codec.AddressLen)
+	account := C.GoBytes(unsafe.Pointer(&address.address), codec.AddressLen) //nolint:all
 
 	err := pState.SetBalance(SimContext, codec.Address(account), uint64(balance))
 	if err != nil {

--- a/x/programs/simulator/src/simulator.rs
+++ b/x/programs/simulator/src/simulator.rs
@@ -11,7 +11,10 @@ use thiserror::Error;
 use wasmlanche_sdk::{Address, ExternalCallError, Id};
 
 use crate::{
-    bindings::{Bytes, CallProgramResponse, CreateProgramResponse, SimulatorCallContext},
+    bindings::{
+        Address as BindingAddress, Bytes, CallProgramResponse, CreateProgramResponse,
+        SimulatorCallContext,
+    },
     state::{Mutable, SimpleState},
 };
 
@@ -38,10 +41,10 @@ extern "C" {
     fn call_program(db: usize, ctx: *const SimulatorCallContext) -> CallProgramResponse;
 
     #[link_name = "GetBalance"]
-    fn get_balance(db: usize, account: Address) -> u64;
+    fn get_balance(db: usize, account: BindingAddress) -> u64;
 
     #[link_name = "SetBalance"]
-    fn set_balance(db: usize, account: Address, balance: u64);
+    fn set_balance(db: usize, account: BindingAddress, balance: u64);
 }
 
 pub struct Simulator<'a> {
@@ -107,13 +110,13 @@ impl<'a> Simulator<'a> {
     /// Returns the balance of the given account.
     pub fn get_balance(&self, account: Address) -> u64 {
         let state_addr = &self.state as *const _ as usize;
-        unsafe { get_balance(state_addr, account) }
+        unsafe { get_balance(state_addr, account.into()) }
     }
 
     /// Sets the balance of the given account.
     pub fn set_balance(&mut self, account: Address, balance: u64) {
         let state_addr = &self.state as *const _ as usize;
-        unsafe { set_balance(state_addr, account, balance) }
+        unsafe { set_balance(state_addr, account.into(), balance) }
     }
 }
 


### PR DESCRIPTION
Weird tidbit of go that I was forgetting to do when reading the bytes of `Address`. 

Strange that it was working both on linux & mac locally.


> In C, a function argument written as a fixed size array actually requires a pointer to the first element of the array. C compilers are aware of this calling convention and adjust the call accordingly, but Go cannot. In Go, you must pass the pointer to the first element explicitly: C.f(&C.x[0]).

https://pkg.go.dev/cmd/cgo#hdr-Go_references_to_C