### PR TITLE
MorpheusCLI - Add Deploy Command

### DIFF
--- a/examples/morpheusvm/cmd/morpheus-cli/cmd/root.go
+++ b/examples/morpheusvm/cmd/morpheus-cli/cmd/root.go
@@ -35,6 +35,9 @@ var (
 	prometheusFile        string
 	prometheusData        string
 	startPrometheus       bool
+	avalancheGoPath       string
+	avalancheGoPluginDir  string
+	numOfNodes            int
 
 	rootCmd = &cobra.Command{
 		Use:        "morpheus-cli",
@@ -182,6 +185,26 @@ func init() {
 	)
 	prometheusCmd.AddCommand(
 		generatePrometheusCmd,
+	)
+
+	// deploy
+	deployCmd.PersistentFlags().StringVar(
+		&avalancheGoPath,
+		"avalancheGo-path",
+		"/tmp/hypersdk/avalanchego-d729e5c7ef9f008c3e89cd7131148ad3acda2e34/avalanchego",
+		"location of avalancheGo binary",
+	)
+	deployCmd.PersistentFlags().StringVar(
+		&avalancheGoPluginDir,
+		"avalancheGo-plugin-dir",
+		"/tmp/hypersdk/avalanchego-d729e5c7ef9f008c3e89cd7131148ad3acda2e34/plugins",
+		"location of avalancheGo plugin binaries",
+	)
+	deployCmd.PersistentFlags().IntVar(
+		&numOfNodes,
+		"num-of-nodes",
+		1,
+		"number of nodes to deploy with",
 	)
 }
 

--- a/examples/morpheusvm/cmd/morpheus-cli/cmd/root.go
+++ b/examples/morpheusvm/cmd/morpheus-cli/cmd/root.go
@@ -55,6 +55,7 @@ func init() {
 		actionCmd,
 		spamCmd,
 		prometheusCmd,
+		deployCmd,
 	)
 	rootCmd.PersistentFlags().StringVar(
 		&dbPath,

--- a/examples/morpheusvm/tests/e2e/e2e_test_helpers.go
+++ b/examples/morpheusvm/tests/e2e/e2e_test_helpers.go
@@ -1,0 +1,54 @@
+// Copyright (C) 2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package e2e
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"github.com/ava-labs/avalanchego/tests/fixture/tmpnet"
+
+	"github.com/ava-labs/hypersdk/examples/morpheusvm/consts"
+	"github.com/ava-labs/hypersdk/tests/fixture"
+)
+
+// Creates and start a new Morpheus network
+// Closing server is responsibility of caller
+func NewMorpheusNetwork(numOfNodes int,
+	devNetPort string,
+	genesisBytes []byte,
+	owner string,
+	avalancheGoPath string,
+	avalancheGoPluginDir string,
+) (*tmpnet.Network, error) {
+	nodes := tmpnet.NewNodesOrPanic(numOfNodes)
+	// Set static port for DevNet
+	nodes[0].Flags["http-port"] = devNetPort
+	subnet := fixture.NewHyperVMSubnet(
+		consts.Name,
+		consts.ID,
+		genesisBytes,
+		nodes...,
+	)
+
+	timeOut := 2 * time.Minute
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeOut)
+	defer cancel()
+
+	network := fixture.NewTmpnetNetwork(owner, nodes, subnet)
+	if err := tmpnet.BootstrapNewNetwork(
+		ctx,
+		os.Stdout,
+		network,
+		"",
+		avalancheGoPath,
+		avalancheGoPluginDir,
+	); err != nil {
+		return nil, err
+	}
+
+	return network, nil
+}


### PR DESCRIPTION
This command extends the MorpheusCLI by adding a `deploy` command. This command, when called, spins up an instance of MorpheusVM using `tmpnet`. This command differs from the existing `run.sh`/`stop.sh` workflow by allowing the user to stop the instance via `Ctrl-C`.