### PR TITLE
Morpheus scripts - allow absolute paths via arg

### DIFF
--- a/examples/morpheusvm/scripts/build.release.sh
+++ b/examples/morpheusvm/scripts/build.release.sh
@@ -6,9 +6,14 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-if ! [[ "$0" =~ scripts/build.release.sh ]]; then
-  echo "must be run from morpheusvm root"
-  exit 255
+if [ -n "$1" ]; then
+    # Attempt to change to the directory provided as the argument
+    if cd "$1"; then
+        echo "cd $1"
+    else
+        echo "failed to cd to directory; $1"
+        exit 255
+    fi
 fi
 
 # shellcheck source=/scripts/constants.sh

--- a/examples/morpheusvm/scripts/fix.lint.sh
+++ b/examples/morpheusvm/scripts/fix.lint.sh
@@ -6,9 +6,14 @@ set -o errexit
 set -o pipefail
 set -e
 
-if ! [[ "$0" =~ scripts/fix.lint.sh ]]; then
-  echo "must be run from morpheusvm root"
-  exit 255
+if [ -n "$1" ]; then
+    # Attempt to change to the directory provided as the argument
+    if cd "$1"; then
+        echo "cd $1"
+    else
+        echo "failed to cd to directory; $1"
+        exit 255
+    fi
 fi
 
 ../../scripts/fix.lint.sh

--- a/examples/morpheusvm/scripts/lint.sh
+++ b/examples/morpheusvm/scripts/lint.sh
@@ -6,9 +6,14 @@ set -o errexit
 set -o pipefail
 set -e
 
-if ! [[ "$0" =~ scripts/lint.sh ]]; then
-  echo "must be run from morpheusvm root"
-  exit 255
+if [ -n "$1" ]; then
+    # Attempt to change to the directory provided as the argument
+    if cd "$1"; then
+        echo "cd $1"
+    else
+        echo "failed to cd to directory; $1"
+        exit 255
+    fi
 fi
 
 # Specify the version of golangci-lint. Should be upgraded after linting issues are resolved.

--- a/examples/morpheusvm/scripts/run.sh
+++ b/examples/morpheusvm/scripts/run.sh
@@ -7,9 +7,19 @@ set -e
 # to run E2E tests (terminates cluster afterwards)
 # MODE=test ./scripts/run.sh
 MODE=${MODE:-run}
-if ! [[ "$0" =~ scripts/run.sh ]]; then
-  echo "must be run from morpheusvm root"
-  exit 255
+# if ! [[ "$0" =~ scripts/run.sh ]]; then
+#   echo "must be run from morpheusvm root"
+#   exit 255
+# fi
+
+if [ -n "$1" ]; then
+    # Attempt to change to the directory provided as the argument
+    if cd "$1"; then
+        echo "cd $1"
+    else
+        echo "failed to cd to directory; $1"
+        exit 255
+    fi
 fi
 
 # shellcheck source=/scripts/constants.sh

--- a/examples/morpheusvm/scripts/tests.integration.sh
+++ b/examples/morpheusvm/scripts/tests.integration.sh
@@ -4,9 +4,14 @@
 
 set -e
 
-if ! [[ "$0" =~ scripts/tests.integration.sh ]]; then
-  echo "must be run from morpheusvm root"
-  exit 255
+if [ -n "$1" ]; then
+    # Attempt to change to the directory provided as the argument
+    if cd "$1"; then
+        echo "cd $1"
+    else
+        echo "failed to cd to directory; $1"
+        exit 255
+    fi
 fi
 
 # shellcheck source=/scripts/common/utils.sh

--- a/examples/morpheusvm/scripts/tests.unit.sh
+++ b/examples/morpheusvm/scripts/tests.unit.sh
@@ -4,9 +4,14 @@
 
 set -e
 
-if ! [[ "$0" =~ scripts/tests.unit.sh ]]; then
-  echo "must be run from morpheusvm root"
-  exit 255
+if [ -n "$1" ]; then
+    # Attempt to change to the directory provided as the argument
+    if cd "$1"; then
+        echo "cd $1"
+    else
+        echo "failed to cd to directory; $1"
+        exit 255
+    fi
 fi
 
 # shellcheck source=/scripts/common/utils.sh


### PR DESCRIPTION
This PR removes the necessity for certain scripts in MorpheusVM to be called from the MorpheusVM directory by allowing for a path argument to be passed in when executing these scripts. For scripts that previously had this requirement, they first check a path argument is passed in and if so, attempt to `cd` into the directory (exiting if unable to do so). 

## Example
To utilize `scripts/tests.integration.sh` from anywhere, one would run the following

`./tests.integration.sh $GOPATH/src/github.com/ava-labs/hypersdk/examples/morpheusvm`