### PR TITLE
Remove RefCell wrapping the state cache

### DIFF
--- a/x/programs/rust/wasmlanche-sdk/src/context.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/context.rs
@@ -2,30 +2,51 @@
 // See the file LICENSE for licensing terms.
 
 use crate::{
-    state::{Error, IntoPairs, Schema, State},
+    state::{Cache, Error, IntoPairs, Schema},
     types::Address,
     Gas, HostPtr, Id, Program,
 };
 use borsh::BorshDeserialize;
-use std::{cell::RefCell, collections::HashMap};
 
 pub type CacheKey = Box<[u8]>;
 pub type CacheValue = Vec<u8>;
 
 /// Representation of the context that is passed to programs at runtime.
-#[cfg_attr(feature = "debug", derive(Debug))]
 pub struct Context {
     program: Program,
     actor: Address,
     height: u64,
     timestamp: u64,
     action_id: Id,
-    state_cache: RefCell<HashMap<CacheKey, Option<CacheValue>>>,
+    state_cache: Cache,
 }
 
-impl Drop for Context {
-    fn drop(&mut self) {
-        State::new(&self.state_cache).flush();
+#[cfg(feature = "debug")]
+mod debug {
+
+    use super::Context;
+
+    macro_rules! debug_struct_fields {
+        ($f:expr, $struct_name:ty, $($name:expr),* $(,)*) => {
+            $f.debug_struct(stringify!(struct_name))
+                $(.field(stringify!($name), $name))*
+                .finish()
+        };
+    }
+
+    impl std::fmt::Debug for Context {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            let Self {
+                program,
+                actor,
+                height,
+                timestamp,
+                action_id,
+                state_cache: _,
+            } = self;
+
+            debug_struct_fields!(f, Context, program, actor, height, timestamp, action_id)
+        }
     }
 }
 
@@ -43,32 +64,37 @@ impl BorshDeserialize for Context {
             height,
             timestamp,
             action_id,
-            state_cache: RefCell::new(HashMap::new()),
+            state_cache: Cache::new(),
         })
     }
 }
 
 impl Context {
+    #[must_use]
     pub fn program(&self) -> &Program {
         &self.program
     }
 
     /// Returns the address of the actor that is executing the program.
+    #[must_use]
     pub fn actor(&self) -> Address {
         self.actor
     }
 
     /// Returns the block-height
+    #[must_use]
     pub fn height(&self) -> u64 {
         self.height
     }
 
     /// Returns the block-timestamp
+    #[must_use]
     pub fn timestamp(&self) -> u64 {
         self.timestamp
     }
 
     /// Returns the action-id
+    #[must_use]
     pub fn action_id(&self) -> Id {
         self.action_id
     }
@@ -85,17 +111,7 @@ impl Context {
     where
         Key: Schema,
     {
-        key.get(self)
-    }
-
-    /// Should not use this function directly.
-    /// # Errors
-    /// Errors when there's an issue deserializing.
-    pub fn get_with_raw_key<V>(&mut self, key: &[u8]) -> Result<Option<V>, Error>
-    where
-        V: BorshDeserialize,
-    {
-        State::new(&self.state_cache).get_with_raw_key(key)
+        key.get(&mut self.state_cache)
     }
 
     /// Store a key and value to the host storage. If the key already exists,
@@ -103,19 +119,19 @@ impl Context {
     /// # Errors
     /// Returns an [`Error`] if the key or value cannot be
     /// serialized or if the host fails to handle the operation.
-    pub fn store_by_key<K>(&self, key: K, value: K::Value) -> Result<(), Error>
+    pub fn store_by_key<K>(&mut self, key: K, value: K::Value) -> Result<(), Error>
     where
         K: Schema,
     {
-        State::new(&self.state_cache).store_by_key(key, value)
+        self.state_cache.store_by_key(key, value)
     }
 
     /// Store a list of tuple of key and value to the host storage.
     /// # Errors
     /// Returns an [`Error`] if the key or value cannot be
     /// serialized or if the host fails to handle the operation.
-    pub fn store<Pairs: IntoPairs>(&self, pairs: Pairs) -> Result<(), Error> {
-        State::new(&self.state_cache).store(pairs)
+    pub fn store<Pairs: IntoPairs>(&mut self, pairs: Pairs) -> Result<(), Error> {
+        self.state_cache.store(pairs)
     }
 
     /// Delete a value from the hosts's storage.
@@ -123,8 +139,8 @@ impl Context {
     /// Returns an [Error] if the value is inexistent
     /// or if the key cannot be serialized
     /// or if the host fails to delete the key and the associated value
-    pub fn delete<K: Schema>(&self, key: K) -> Result<Option<K::Value>, Error> {
-        State::new(&self.state_cache).delete(key)
+    pub fn delete<K: Schema>(&mut self, key: K) -> Result<Option<K::Value>, Error> {
+        self.state_cache.delete(key)
     }
 
     /// Deploy an instance of the specified program and returns the account of the new instance

--- a/x/programs/simulator/src/bindings.rs
+++ b/x/programs/simulator/src/bindings.rs
@@ -1,0 +1,61 @@
+// Copyright (C) 2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+#![allow(dead_code)]
+
+use std::ffi::CString;
+use wasmlanche_sdk::Address as SdkAddress;
+
+// include the generated bindings
+// reference: https://rust-lang.github.io/rust-bindgen/tutorial-3.html
+include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+
+impl std::ops::Deref for Bytes {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        // # Safety:
+        // These bytes were allocated by CGo
+        // They are guaranteed to be valid for the length of the slice
+        unsafe { std::slice::from_raw_parts(self.data, self.length as usize) }
+    }
+}
+
+impl From<SdkAddress> for Address {
+    fn from(value: SdkAddress) -> Self {
+        Address {
+            // # Safety:
+            // Address is a simple wrapper around an array of bytes
+            // this will fail at compile time if the size is changed
+            address: unsafe {
+                std::mem::transmute::<SdkAddress, [libc::c_uchar; SdkAddress::LEN]>(value)
+            },
+        }
+    }
+}
+
+impl SimulatorCallContext {
+    pub(crate) fn new(
+        simulator: &super::Simulator,
+        program: SdkAddress,
+        method: &CString,
+        params: &[u8],
+        gas: u64,
+    ) -> SimulatorCallContext {
+        SimulatorCallContext {
+            program_address: program.into(),
+            actor_address: simulator.get_actor().into(),
+            height: simulator.get_height(),
+            timestamp: simulator.get_timestamp(),
+            method: method.as_ptr(),
+            params: Bytes {
+                data: params.as_ptr(),
+                length: params.len() as u64,
+            },
+            max_gas: gas,
+        }
+    }
+}

--- a/x/programs/simulator/src/lib.rs
+++ b/x/programs/simulator/src/lib.rs
@@ -1,42 +1,7 @@
 // Copyright (C) 2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-mod bindings {
-    #![allow(non_upper_case_globals)]
-    #![allow(non_camel_case_types)]
-    #![allow(non_snake_case)]
-    #![allow(dead_code)]
-
-    use wasmlanche_sdk::Address as SdkAddress;
-    // include the generated bindings
-    // reference: https://rust-lang.github.io/rust-bindgen/tutorial-3.html
-    include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
-
-    impl std::ops::Deref for Bytes {
-        type Target = [u8];
-
-        fn deref(&self) -> &Self::Target {
-            // # Safety:
-            // These bytes were allocated by CGo
-            // They are guaranteed to be valid for the length of the slice
-            unsafe { std::slice::from_raw_parts(self.data, self.length as usize) }
-        }
-    }
-
-    impl From<SdkAddress> for Address {
-        fn from(value: SdkAddress) -> Self {
-            Address {
-                // # Safety:
-                // Address is a simple wrapper around an array of bytes
-                // this will fail at compile time if the size is changed
-                address: unsafe {
-                    std::mem::transmute::<SdkAddress, [libc::c_uchar; SdkAddress::LEN]>(value)
-                },
-            }
-        }
-    }
-}
-
+mod bindings;
 mod simulator;
 mod state;
 

--- a/x/programs/simulator/src/simulator.rs
+++ b/x/programs/simulator/src/simulator.rs
@@ -12,8 +12,7 @@ use wasmlanche_sdk::{Address, ExternalCallError, Id};
 
 use crate::{
     bindings::{
-        Address as BindingAddress, Bytes, CallProgramResponse, CreateProgramResponse,
-        SimulatorCallContext,
+        Address as BindingAddress, CallProgramResponse, CreateProgramResponse, SimulatorCallContext,
     },
     state::{Mutable, SimpleState},
 };
@@ -94,35 +93,12 @@ impl<'a> Simulator<'a> {
     where
         T: wasmlanche_sdk::borsh::BorshSerialize,
     {
-        // serialize the params
         let params = wasmlanche_sdk::borsh::to_vec(&params).expect("error serializing result");
         let method = CString::new(method).expect("Unable to create a cstring");
-        // build the call context
-        let context = self.new_call_context(program, &method, &params, gas);
+        let context = SimulatorCallContext::new(self, program, &method, &params, gas);
         let state_addr = &self.state as *const _ as usize;
 
         unsafe { call_program(state_addr, &context) }
-    }
-
-    fn new_call_context(
-        &self,
-        program: Address,
-        method: &CString,
-        params: &[u8],
-        gas: u64,
-    ) -> SimulatorCallContext {
-        SimulatorCallContext {
-            program_address: program.into(),
-            actor_address: self.actor.into(),
-            height: self.height,
-            timestamp: self.timestamp,
-            method: method.as_ptr(),
-            params: Bytes {
-                data: params.as_ptr(),
-                length: params.len() as u64,
-            },
-            max_gas: gas,
-        }
     }
 
     /// Returns the actor address for the simulator.


### PR DESCRIPTION
When writing the state-schema code, I wanted to make the changes as minimal as possible (though the PR was huge). Now that we use `Context` the way that we do (`&mut Context`), we no longer need to wrap the cache in a `RefCell`. Now we can actually construct the `State` struct that wraps the `HashMap` with extra logic and make that a part of the `Context` properties

