### PR TITLE
Cleanup MorpheusVM CI workflow dependencies

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
 * @aaronbuchwald @joshua-kim
+.github/ @richardpringle
 /x/programs/ @dboehm-avalabs @iFrostizz @richardpringle @samliok

--- a/.github/workflows/hypersdk-ci.yml
+++ b/.github/workflows/hypersdk-ci.yml
@@ -145,7 +145,7 @@ jobs:
         run: scripts/tests.integration.sh
 
   morpheusvm-e2e-tests:
-    needs: [hypersdk-tests]
+    needs: [morpheusvm-lint, morpheusvm-unit-tests]
     runs-on: ubuntu-20.04-32
     timeout-minutes: 25
     steps:
@@ -170,7 +170,7 @@ jobs:
           name: morpheusvm-e2e-tmpnet-data
 
   morpheusvm-release:
-    needs: [morpheusvm-lint, morpheusvm-unit-tests, morpheusvm-e2e-tests]
+    needs: [morpheusvm-e2e-tests]
     # We build with 20.04 to maintain max compatibility: https://github.com/golang/go/issues/57328
     runs-on: ubuntu-20.04-32
     permissions:


### PR DESCRIPTION
E2E tests are heavy and need to be rerun if either the unit tests or linter tests fail. We should wait for these other workflows to pass *before* triggering the e2e tests. 

