### PR TITLE
Remove WrapRegisterFunc and move controller/VM options into separate files

### DIFF
--- a/api/jsonrpc/option.go
+++ b/api/jsonrpc/option.go
@@ -8,7 +8,7 @@ import "github.com/ava-labs/hypersdk/vm"
 const Namespace = "core"
 
 func With() vm.Option {
-	return vm.NewOption(Namespace, func(v *vm.VM, b []byte) error {
+	return vm.NewOption(Namespace, func(v *vm.VM, _ []byte) error {
 		vm.WithVMAPIs(JSONRPCServerFactory{})(v)
 		return nil
 	})

--- a/api/jsonrpc/option.go
+++ b/api/jsonrpc/option.go
@@ -9,7 +9,7 @@ const Namespace = "core"
 
 func With() vm.Option {
 	return vm.NewOption(Namespace, func(v *vm.VM, b []byte) error {
-		vm.WithVMAPIs(JSONRPCServerFactory{})
+		vm.WithVMAPIs(JSONRPCServerFactory{})(v)
 		return nil
 	})
 }

--- a/api/jsonrpc/option.go
+++ b/api/jsonrpc/option.go
@@ -1,0 +1,15 @@
+// Copyright (C) 2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package jsonrpc
+
+import "github.com/ava-labs/hypersdk/vm"
+
+const Namespace = "core"
+
+func With() vm.Option {
+	return vm.NewOption(Namespace, func(v *vm.VM, b []byte) error {
+		vm.WithVMAPIs(JSONRPCServerFactory{})
+		return nil
+	})
+}

--- a/examples/morpheusvm/controller/controller.go
+++ b/examples/morpheusvm/controller/controller.go
@@ -29,14 +29,12 @@ var (
 
 // New returns a VM with the indexer, websocket, and rpc apis enabled.
 func New(options ...vm.Option) (*vm.VM, error) {
-	opts := []vm.Option{
+	opts := append([]vm.Option{
 		indexer.With(consts.Name, indexer.Endpoint),
 		ws.With(),
-		vm.WrapRegisterFunc("vmAPIs", vm.WithVMAPIs(jsonrpc.JSONRPCServerFactory{})),
-		vm.WrapRegisterFunc("controllerAPIs", vm.WithControllerAPIs(&jsonRPCServerFactory{})),
-	}
-
-	opts = append(opts, options...)
+		jsonrpc.With(),
+		With(), // Add Controller API
+	}, options...)
 
 	return NewWithOptions(opts...)
 }

--- a/examples/morpheusvm/controller/option.go
+++ b/examples/morpheusvm/controller/option.go
@@ -9,7 +9,7 @@ const Namespace = "controller"
 
 func With() vm.Option {
 	return vm.NewOption(Namespace, func(v *vm.VM, _ []byte) error {
-		vm.WithControllerAPIs(jsonRPCServerFactory{})
+		vm.WithControllerAPIs(jsonRPCServerFactory{})(v)
 		return nil
 	})
 }

--- a/examples/morpheusvm/controller/option.go
+++ b/examples/morpheusvm/controller/option.go
@@ -1,0 +1,15 @@
+// Copyright (C) 2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package controller
+
+import "github.com/ava-labs/hypersdk/vm"
+
+const Namespace = "controller"
+
+func With() vm.Option {
+	return vm.NewOption(Namespace, func(v *vm.VM, _ []byte) error {
+		vm.WithControllerAPIs(jsonRPCServerFactory{})
+		return nil
+	})
+}

--- a/vm/option.go
+++ b/vm/option.go
@@ -27,16 +27,6 @@ func NewOption(namespace string, optionFunc OptionFunc) Option {
 	}
 }
 
-func WrapRegisterFunc(namespace string, registerFunc RegisterFunc) Option {
-	return NewOption(
-		namespace,
-		func(v *VM, _ []byte) error {
-			registerFunc(v)
-			return nil
-		},
-	)
-}
-
 func WithBuilder() RegisterFunc {
 	return func(vm *VM) {
 		vm.builder = builder.NewManual(vm)


### PR DESCRIPTION
As described + replacing the use of `WrapRegisterFunc` in the morpheusvm controller with using the options defined by each component ie. core HyperSDK API + Controller APIs.

Future work is to:

- switch from supplying `[]byte` to each option to VM unmarshalling directly into a struct provided by the option
- [remove name/path params from tx indexer and standardize them](https://github.com/ava-labs/hypersdk/pull/1456)
- Update options to depend on minimal VM interface instead of pointer to VM
- Switch from using `vm.DataDir` to a namespaced subdirectory for each option
- Move default options from morpheusvm controller to convenience function