### PR TITLE
Remove params from tx indexer option

### DIFF
--- a/api/indexer/client.go
+++ b/api/indexer/client.go
@@ -13,12 +13,12 @@ import (
 	"github.com/ava-labs/hypersdk/requester"
 )
 
-func NewClient(uri string, name string, endpoint string) *Client {
+func NewClient(uri string) *Client {
 	uri = strings.TrimSuffix(uri, "/")
-	uri += endpoint
+	uri += Endpoint
 
 	return &Client{
-		requester: requester.New(uri, name),
+		requester: requester.New(uri, Name),
 	}
 }
 

--- a/api/indexer/tx_indexer.go
+++ b/api/indexer/tx_indexer.go
@@ -32,7 +32,7 @@ var (
 	_ event.Subscription[*chain.StatelessBlock]        = (*txDBIndexer)(nil)
 )
 
-func With(name string, path string) vm.Option {
+func With() vm.Option {
 	return vm.NewOption(Namespace, OptionFunc)
 }
 

--- a/examples/morpheusvm/controller/controller.go
+++ b/examples/morpheusvm/controller/controller.go
@@ -30,7 +30,7 @@ var (
 // New returns a VM with the indexer, websocket, and rpc apis enabled.
 func New(options ...vm.Option) (*vm.VM, error) {
 	opts := []vm.Option{
-		indexer.With(consts.Name, indexer.Endpoint),
+		indexer.With(),
 		ws.With(),
 		vm.WrapRegisterFunc("vmAPIs", vm.WithVMAPIs(jsonrpc.JSONRPCServerFactory{})),
 		vm.WrapRegisterFunc("controllerAPIs", vm.WithControllerAPIs(&jsonRPCServerFactory{})),

--- a/examples/morpheusvm/tests/workload/workload.go
+++ b/examples/morpheusvm/tests/workload/workload.go
@@ -138,7 +138,7 @@ func (g *simpleTxWorkload) GenerateTxWithAssertion(ctx context.Context) (*chain.
 	}
 
 	return tx, func(ctx context.Context, require *require.Assertions, uri string) {
-		indexerCli := indexer.NewClient(uri, consts.Name, indexer.Endpoint)
+		indexerCli := indexer.NewClient(uri)
 		success, _, err := indexerCli.WaitForTransaction(ctx, tx.ID())
 		require.NoError(err)
 		require.True(success)
@@ -235,7 +235,7 @@ func (g *mixedAuthWorkload) GenerateTxWithAssertion(ctx context.Context) (*chain
 	g.balance = expectedBalance
 
 	return tx, func(ctx context.Context, require *require.Assertions, uri string) {
-		indexerCli := indexer.NewClient(uri, consts.Name, indexer.Endpoint)
+		indexerCli := indexer.NewClient(uri)
 		success, _, err := indexerCli.WaitForTransaction(ctx, tx.ID())
 		require.NoError(err)
 		require.True(success)


### PR DESCRIPTION
This PR removes the params from the tx indexer option.

Previously, the option had a name and endpoint extension parameter, which were just the VM name and the endpoint, which was always imported from the package itself. It's cleaner to just include the name and endpoint as constants in the package and use them directly, so that callers don't need to provide them.