### PR TITLE
Remove clippy warning for Sealed trait

### DIFF
--- a/x/programs/rust/wasmlanche-sdk/src/state.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/state.rs
@@ -251,9 +251,8 @@ fn get_bytes(key: &[u8]) -> Option<CacheValue> {
     }
 }
 
-trait Sealed {}
+pub trait Sealed {}
 
-#[allow(private_bounds)]
 pub trait IntoPairs: Sealed {
     fn into_pairs(self) -> impl IntoIterator<Item = Result<(CacheKey, CacheValue), Error>>;
 }


### PR DESCRIPTION
I was reading an open-source crate and realized that you can make your `Sealed` traits pub without actually exporting them from your crate. This feels like a bit of a hack, but it's nice to get rid of the warning.

