### PR TITLE
Remove std dependency from wasmlanche-sdk

### DIFF
--- a/x/programs/rust/wasmlanche-sdk/Cargo.toml
+++ b/x/programs/rust/wasmlanche-sdk/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 borsh = { version = "1.5.1", features = ["derive"] }
 bytemuck = { version = "1.17.0", features = ["derive"] }
+displaydoc = { version = "0.2.5", default-features = false }
 hashbrown = "0.14.5"
 sdk-macros = { workspace = true }
 thiserror = { workspace = true }

--- a/x/programs/rust/wasmlanche-sdk/Cargo.toml
+++ b/x/programs/rust/wasmlanche-sdk/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 borsh = { version = "1.5.1", features = ["derive"] }
 bytemuck = { version = "1.17.0", features = ["derive"] }
+hashbrown = "0.14.5"
 sdk-macros = { workspace = true }
 thiserror = { workspace = true }
 

--- a/x/programs/rust/wasmlanche-sdk/src/context.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/context.rs
@@ -1,11 +1,14 @@
 // Copyright (C) 2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
+extern crate alloc;
+
 use crate::{
     state::{Cache, Error, IntoPairs, Schema},
     types::{Address, ProgramId},
     Gas, HostPtr, Id, Program,
 };
+use alloc::{boxed::Box, vec::Vec};
 use borsh::BorshDeserialize;
 
 pub type CacheKey = Box<[u8]>;

--- a/x/programs/rust/wasmlanche-sdk/src/context.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/context.rs
@@ -23,8 +23,8 @@ pub struct Context {
 
 #[cfg(feature = "debug")]
 mod debug {
-
     use super::Context;
+    use std::fmt::{Debug, Formatter, Result};
 
     macro_rules! debug_struct_fields {
         ($f:expr, $struct_name:ty, $($name:expr),* $(,)*) => {
@@ -34,8 +34,8 @@ mod debug {
         };
     }
 
-    impl std::fmt::Debug for Context {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    impl Debug for Context {
+        fn fmt(&self, f: &mut Formatter<'_>) -> Result {
             let Self {
                 program,
                 actor,
@@ -51,7 +51,7 @@ mod debug {
 }
 
 impl BorshDeserialize for Context {
-    fn deserialize_reader<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
+    fn deserialize_reader<R: borsh::io::Read>(reader: &mut R) -> borsh::io::Result<Self> {
         let program = Program::deserialize_reader(reader)?;
         let actor = Address::deserialize_reader(reader)?;
         let height = u64::deserialize_reader(reader)?;

--- a/x/programs/rust/wasmlanche-sdk/src/lib.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/lib.rs
@@ -2,7 +2,7 @@
 // See the file LICENSE for licensing terms.
 
 #![deny(clippy::pedantic)]
-// #![cfg_attr(not(any(feature = "build", feature = "debug")), no_std)]
+#![cfg_attr(not(any(feature = "build", feature = "debug", test)), no_std)]
 
 //! Welcome to the wasmlanche-sdk! This SDK provides a set of tools to help you write
 //! your smart-contracts in Rust to be deployed and run on a `HyperVM`.

--- a/x/programs/rust/wasmlanche-sdk/src/lib.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/lib.rs
@@ -2,6 +2,7 @@
 // See the file LICENSE for licensing terms.
 
 #![deny(clippy::pedantic)]
+// #![cfg_attr(not(or(feature = "build", feature = "debug")), no_std)]
 
 //! Welcome to the wasmlanche-sdk! This SDK provides a set of tools to help you write
 //! your smart-contracts in Rust to be deployed and run on a `HyperVM`.
@@ -62,11 +63,18 @@
 pub mod build;
 
 mod context;
-mod logging;
 mod memory;
 mod program;
 mod state;
 mod types;
+
+#[cfg(feature = "debug")]
+mod logging;
+#[cfg(not(feature = "debug"))]
+mod logging {
+    pub fn log(_msg: &str) {}
+    pub fn register_panic() {}
+}
 
 pub use self::{
     context::{Context, ExternalCallContext},

--- a/x/programs/rust/wasmlanche-sdk/src/lib.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/lib.rs
@@ -2,7 +2,7 @@
 // See the file LICENSE for licensing terms.
 
 #![deny(clippy::pedantic)]
-// #![cfg_attr(not(or(feature = "build", feature = "debug")), no_std)]
+// #![cfg_attr(not(any(feature = "build", feature = "debug")), no_std)]
 
 //! Welcome to the wasmlanche-sdk! This SDK provides a set of tools to help you write
 //! your smart-contracts in Rust to be deployed and run on a `HyperVM`.

--- a/x/programs/rust/wasmlanche-sdk/src/logging.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/logging.rs
@@ -41,8 +41,7 @@ macro_rules! dbg {
 pub fn register_panic() {
     #[cfg(debug_assertions)]
     {
-        use std::panic;
-        use std::sync::Once;
+        use std::{panic, sync::Once};
 
         static START: Once = Once::new();
         START.call_once(|| {
@@ -54,20 +53,17 @@ pub fn register_panic() {
 }
 
 #[doc(hidden)]
-/// Log an arbitrary [&str] on the terminal.
-pub fn log(text: &str) {
-    log_bytes(text.as_bytes());
-}
-
 /// Logging facility for debugging purposes.
 /// # Panics
 /// Panics if there was an issue regarding memory allocation on the host
-pub(super) fn log_bytes(bytes: &[u8]) {
+pub fn log(text: &str) {
     #[link(wasm_import_module = "log")]
     extern "C" {
         #[link_name = "write"]
         fn ffi(ptr: *const u8, len: usize);
     }
+
+    let bytes = text.as_bytes();
 
     unsafe { ffi(bytes.as_ptr(), bytes.len()) };
 }

--- a/x/programs/rust/wasmlanche-sdk/src/memory.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/memory.rs
@@ -7,10 +7,10 @@
 //! the program. These methods are unsafe as should be used
 //! with caution.
 
+use hashbrown::HashMap;
 use std::{
     alloc::{self, Layout},
     cell::RefCell,
-    collections::HashMap,
     mem::ManuallyDrop,
     ops::Deref,
     slice,

--- a/x/programs/rust/wasmlanche-sdk/src/program.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/program.rs
@@ -3,21 +3,21 @@
 
 use crate::{memory::HostPtr, types::Address, Gas};
 use borsh::{BorshDeserialize, BorshSerialize};
-use thiserror::Error;
+use displaydoc::Display;
 
 /// An error that is returned from call to public functions.
-#[derive(Error, Debug, BorshSerialize, BorshDeserialize, PartialEq, Eq)]
+#[derive(Debug, Display, BorshSerialize, BorshDeserialize, PartialEq, Eq)]
 #[repr(u8)]
 #[non_exhaustive]
 #[borsh(use_discriminant = true)]
 pub enum ExternalCallError {
-    #[error("an error happened during the execution")]
+    /// an error happened during execution
     ExecutionFailure = 0,
-    #[error("the call panicked")]
+    /// the call panicked
     CallPanicked = 1,
-    #[error("not enough fuel to cover the execution")]
+    /// not enough fuel to cover the execution
     OutOfFuel = 2,
-    #[error("insufficient funds")]
+    /// insufficient funds
     InsufficientFunds = 3,
 }
 

--- a/x/programs/rust/wasmlanche-sdk/src/state.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/state.rs
@@ -12,21 +12,20 @@ use alloc::{boxed::Box, vec::Vec};
 use borsh::{from_slice, BorshDeserialize, BorshSerialize};
 use bytemuck::NoUninit;
 use core::mem::{self, size_of};
+use displaydoc::Display;
 use hashbrown::HashMap;
 use sdk_macros::impl_to_pairs;
 
 // maximum number of chunks that can be stored at the key as big endian u16
 pub const STATE_MAX_CHUNKS: [u8; 2] = 4u16.to_be_bytes();
 
-#[derive(Clone, thiserror::Error, Debug)]
+#[derive(Clone, Debug, Display)]
 pub enum Error {
-    #[error("invalid byte length: {0}")]
+    /// invalid byte length {0}
     InvalidByteLength(usize),
-
-    #[error("failed to serialize bytes")]
+    /// failed to serialize bytes
     Serialization,
-
-    #[error("failed to deserialize bytes")]
+    /// failed to deserialize bytes
     Deserialization,
 }
 

--- a/x/programs/rust/wasmlanche-sdk/src/state.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/state.rs
@@ -1,11 +1,14 @@
 // Copyright (C) 2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
+extern crate alloc;
+
 use crate::{
     context::{CacheKey, CacheValue},
     memory::HostPtr,
     types::Address,
 };
+use alloc::{boxed::Box, vec::Vec};
 use borsh::{from_slice, BorshDeserialize, BorshSerialize};
 use bytemuck::NoUninit;
 use core::mem::{self, size_of};

--- a/x/programs/rust/wasmlanche-sdk/src/state.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/state.rs
@@ -8,9 +8,9 @@ use crate::{
 };
 use borsh::{from_slice, BorshDeserialize, BorshSerialize};
 use bytemuck::NoUninit;
+use core::mem::{self, size_of};
 use hashbrown::HashMap;
 use sdk_macros::impl_to_pairs;
-use std::mem::{self, size_of};
 
 // maximum number of chunks that can be stored at the key as big endian u16
 pub const STATE_MAX_CHUNKS: [u8; 2] = 4u16.to_be_bytes();

--- a/x/programs/rust/wasmlanche-sdk/src/state.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/state.rs
@@ -8,11 +8,9 @@ use crate::{
 };
 use borsh::{from_slice, BorshDeserialize, BorshSerialize};
 use bytemuck::NoUninit;
+use hashbrown::HashMap;
 use sdk_macros::impl_to_pairs;
-use std::{
-    collections::HashMap,
-    mem::{self, size_of},
-};
+use std::mem::{self, size_of};
 
 // maximum number of chunks that can be stored at the key as big endian u16
 pub const STATE_MAX_CHUNKS: [u8; 2] = 4u16.to_be_bytes();

--- a/x/programs/rust/wasmlanche-sdk/src/state.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/state.rs
@@ -9,7 +9,10 @@ use crate::{
 use borsh::{from_slice, BorshDeserialize, BorshSerialize};
 use bytemuck::NoUninit;
 use sdk_macros::impl_to_pairs;
-use std::{collections::HashMap, mem::size_of};
+use std::{
+    collections::HashMap,
+    mem::{self, size_of},
+};
 
 // maximum number of chunks that can be stored at the key as big endian u16
 pub const STATE_MAX_CHUNKS: [u8; 2] = 4u16.to_be_bytes();
@@ -194,7 +197,7 @@ impl Cache {
         match cache_entry {
             None => Ok(None),
             Some(val) if val.is_empty() => Ok(None),
-            Some(val) => from_slice(&std::mem::take(val))
+            Some(val) => from_slice(&mem::take(val))
                 .map_err(|_| Error::Deserialization)
                 .map(Some),
         }

--- a/x/programs/rust/wasmlanche-sdk/src/types.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/types.rs
@@ -3,7 +3,7 @@
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use bytemuck::{Pod, Zeroable};
-use std::mem::size_of;
+use std::{array, mem::size_of};
 
 /// Byte length of an action ID.
 pub const ID_LEN: usize = 32;
@@ -49,7 +49,7 @@ impl Default for Address {
 
 impl IntoIterator for Address {
     type Item = u8;
-    type IntoIter = std::array::IntoIter<Self::Item, { Address::LEN }>;
+    type IntoIter = array::IntoIter<Self::Item, { Address::LEN }>;
 
     fn into_iter(self) -> Self::IntoIter {
         IntoIterator::into_iter(self.0)

--- a/x/programs/rust/wasmlanche-sdk/src/types.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/types.rs
@@ -1,6 +1,9 @@
 // Copyright (C) 2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
+extern crate alloc;
+
+use alloc::boxed::Box;
 use borsh::{BorshDeserialize, BorshSerialize};
 use bytemuck::{Pod, Zeroable};
 use core::{array, mem::size_of};

--- a/x/programs/rust/wasmlanche-sdk/src/types.rs
+++ b/x/programs/rust/wasmlanche-sdk/src/types.rs
@@ -3,7 +3,7 @@
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use bytemuck::{Pod, Zeroable};
-use std::{array, mem::size_of};
+use core::{array, mem::size_of};
 
 /// Byte length of an action ID.
 pub const ID_LEN: usize = 32;

--- a/x/programs/simulator/src/error.rs
+++ b/x/programs/simulator/src/error.rs
@@ -1,0 +1,44 @@
+// Copyright (C) 2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+use std::{
+    error::Error,
+    fmt::{Debug, Display},
+    str::Utf8Error,
+};
+
+#[derive(thiserror::Error, Debug)]
+pub enum SimulatorError {
+    #[error("Error across the FFI boundary: {0}")]
+    Ffi(#[from] Utf8Error),
+    #[error(transparent)]
+    Serialization(#[from] wasmlanche_sdk::borsh::io::Error),
+    #[error(transparent)]
+    ExternalCall(#[from] ExternalCallError),
+    #[error("Error during program creation")]
+    CreateProgram(String),
+    #[error("Error during program execution")]
+    CallProgram(String),
+}
+
+pub struct ExternalCallError(wasmlanche_sdk::ExternalCallError);
+
+impl From<wasmlanche_sdk::ExternalCallError> for ExternalCallError {
+    fn from(e: wasmlanche_sdk::ExternalCallError) -> Self {
+        Self(e)
+    }
+}
+
+impl Display for ExternalCallError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(&self.0, f)
+    }
+}
+
+impl Debug for ExternalCallError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Debug::fmt(&self.0, f)
+    }
+}
+
+impl Error for ExternalCallError {}

--- a/x/programs/simulator/src/lib.rs
+++ b/x/programs/simulator/src/lib.rs
@@ -2,6 +2,7 @@
 // See the file LICENSE for licensing terms.
 
 mod bindings;
+mod error;
 mod simulator;
 mod state;
 

--- a/x/programs/simulator/src/simulator.rs
+++ b/x/programs/simulator/src/simulator.rs
@@ -1,35 +1,16 @@
 // Copyright (C) 2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-use libc::c_char;
-use std::{
-    ffi::{CStr, CString},
-    fmt::Debug,
-    str::Utf8Error,
-};
-use thiserror::Error;
-use wasmlanche_sdk::{Address, ExternalCallError, ProgramId};
-
 use crate::{
     bindings::{
         Address as BindingAddress, CallProgramResponse, CreateProgramResponse, SimulatorCallContext,
     },
+    error::SimulatorError,
     state::{Mutable, SimpleState},
 };
-
-#[derive(Error, Debug)]
-pub enum SimulatorError {
-    #[error("Error across the FFI boundary: {0}")]
-    Ffi(#[from] Utf8Error),
-    #[error(transparent)]
-    Serialization(#[from] wasmlanche_sdk::borsh::io::Error),
-    #[error(transparent)]
-    ExternalCall(#[from] ExternalCallError),
-    #[error("Error during program creation")]
-    CreateProgram(String),
-    #[error("Error during program execution")]
-    CallProgram(String),
-}
+use libc::c_char;
+use std::ffi::{CStr, CString};
+use wasmlanche_sdk::{Address, ProgramId};
 
 #[link(name = "simulator")]
 extern "C" {


### PR DESCRIPTION
- **Consolidate std use**
- **Replace the standard-library hash-map**
- **Remove std dependency from wasmlanche_sdk::memory**
- **Remove std dependency in wasmlanche_sdk::state**
- **Remove std dependency from wasmlanche_sdk::types**
- **Don't use thread_local for allocations**
- **Remove std dependency from wasmlanche-sdk**
