### PR TITLE
Fix memory lock issue for testing

### DIFF
--- a/x/programs/wasmlanche/Cargo.toml
+++ b/x/programs/wasmlanche/Cargo.toml
@@ -6,14 +6,19 @@ edition = "2021"
 [dependencies]
 borsh = { version = "1.5.1", features = ["derive"] }
 bytemuck = { version = "1.17.0", features = ["derive"] }
+cfg-if = "1.0.0"
 displaydoc = { version = "0.2.5", default-features = false }
 hashbrown = "0.14.5"
 sdk-macros = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 wasmtime = "14"
 
 [features]
-build = []
-debug = []
+build = ["std"]
+debug = ["std"]
+std = []
+test = ["std"]

--- a/x/programs/wasmlanche/src/context.rs
+++ b/x/programs/wasmlanche/src/context.rs
@@ -27,7 +27,7 @@ pub struct Context {
 #[cfg(feature = "debug")]
 mod debug {
     use super::Context;
-    use std::fmt::{Debug, Formatter, Result};
+    use core::fmt::{Debug, Formatter, Result};
 
     macro_rules! debug_struct_fields {
         ($f:expr, $struct_name:ty, $($name:expr),* $(,)*) => {

--- a/x/programs/wasmlanche/src/lib.rs
+++ b/x/programs/wasmlanche/src/lib.rs
@@ -2,7 +2,8 @@
 // See the file LICENSE for licensing terms.
 
 #![deny(clippy::pedantic)]
-#![cfg_attr(not(any(feature = "build", feature = "debug", test)), no_std)]
+// "build" and "debug" features enable std, so does `test`
+#![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
 
 //! Welcome to the wasmlanche! This SDK provides a set of tools to help you write
 //! your smart-contracts in Rust to be deployed and run on a `HyperVM`.

--- a/x/programs/wasmlanche/src/logging.rs
+++ b/x/programs/wasmlanche/src/logging.rs
@@ -6,11 +6,8 @@
 #[macro_export]
 macro_rules! dbg {
     () => {
-        #[cfg(debug_assertions)]
-        {
-            let as_string = format!("[{}:{}:{}]", file!(), line!(), column!());
-            $crate::log(as_string.as_str());
-        }
+        let as_string = format!("[{}:{}:{}]", file!(), line!(), column!());
+        $crate::log(as_string.as_str());
     };
     ($val:expr $(,)?) => {{
         match $val {
@@ -39,17 +36,15 @@ macro_rules! dbg {
 #[doc(hidden)]
 /// Catch panics by sending their information to the host.
 pub fn register_panic() {
-    #[cfg(debug_assertions)]
-    {
-        use std::{panic, sync::Once};
+    use std::{panic, sync::Once};
 
-        static START: Once = Once::new();
-        START.call_once(|| {
-            panic::set_hook(Box::new(|info| {
-                log(&format!("program {info}"));
-            }));
-        });
-    }
+    static SET_PANIC_HOOK: Once = Once::new();
+
+    SET_PANIC_HOOK.call_once(|| {
+        panic::set_hook(Box::new(|info| {
+            log(&format!("program {info}"));
+        }));
+    });
 }
 
 #[doc(hidden)]

--- a/x/programs/wasmlanche/src/memory/allocations.rs
+++ b/x/programs/wasmlanche/src/memory/allocations.rs
@@ -1,0 +1,250 @@
+// Copyright (C) 2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+//! Safety:
+//! Only safe to use in a single-threaded environment
+
+use cfg_if::cfg_if;
+use hashbrown::HashMap;
+
+// Map of pointer to the length of its content on the heap
+type LenMap = HashMap<*const u8, usize>;
+
+/// Get size of allocation at `key`
+pub fn get(key: *const u8) -> Option<usize> {
+    ALLOCATIONS.with_borrow(|map| map.get(&key).copied())
+}
+
+/// Insert size of allocation at `key`
+pub fn insert(key: *const u8, value: usize) {
+    ALLOCATIONS.with_borrow_mut(|map| map.insert(key, value));
+}
+
+/// Remove size of allocation at `key` in preparation of deallocation or move
+pub fn remove(key: *const u8) -> Option<usize> {
+    ALLOCATIONS.with_borrow_mut(|map| map.remove(&key))
+}
+
+cfg_if! {
+    if #[cfg(feature = "test")] {
+        use std::cell::RefCell;
+        std::thread_local! {
+            static ALLOCATIONS: RefCell<LenMap> = RefCell::new(HashMap::new());
+        }
+    } else {
+        // Here, we don't have access to std
+        // this code is only thread safe in that it will panic upon concurrent access
+        extern crate alloc;
+
+        use alloc::boxed::Box;
+        use core::{
+            sync::atomic::{AtomicPtr, AtomicBool, Ordering::{Acquire, Relaxed, Release}},
+            ops::{Deref, DerefMut},
+        };
+
+        static ALLOCATIONS: SingletonLenMap = SingletonLenMap::new();
+
+        struct Guard<'a> {
+            map: *mut LenMap,
+            lock: &'a AtomicBool,
+        }
+
+        impl Drop for Guard<'_> {
+            fn drop(&mut self) {
+                self.lock.store(false, Release);
+            }
+        }
+
+        impl Deref for Guard<'_> {
+            type Target = LenMap;
+
+            fn deref(&self) -> &Self::Target {
+                // Safety:
+                // Can't create a guard without initializing first
+                unsafe { self.map.as_ref().expect("uninitialized") }
+            }
+        }
+
+        impl DerefMut for Guard<'_> {
+            fn deref_mut(&mut self) -> &mut Self::Target {
+                // Safety:
+                // Can't create a guard without initializing first
+                unsafe { self.map.as_mut().expect("uninitialized") }
+            }
+        }
+
+        /// A singleton wrapping a pointer to the [LenMap]
+        struct SingletonLenMap {
+            map: AtomicPtr<LenMap>,
+            lock: AtomicBool,
+        }
+
+        impl SingletonLenMap {
+            const fn new() -> Self {
+                let map = AtomicPtr::new(core::ptr::null_mut());
+                let lock = AtomicBool::new(false);
+                Self { map, lock }
+            }
+
+            /// Initialize is for lazy-laoding the map.
+            /// Safety:
+            /// Data-races are prevented with a lock
+            #[must_use]
+            fn init_and_lock(&self) -> Guard<'_> {
+                assert!(!self.lock.swap(true, Acquire), "already accessed");
+
+                let mut map = self.map.load(Relaxed);
+
+                if map.is_null() {
+                    map = Box::into_raw(Box::new(HashMap::new()));
+                    self.map.store(map, Relaxed);
+                }
+
+                Guard { map, lock: &self.lock }
+            }
+
+            /// Matches the `LocalKey` API
+            fn with_borrow<F: FnOnce(&LenMap) -> R, R>(&self, f: F) -> R {
+                let map = self.init_and_lock();
+                f(&map)
+            }
+
+            /// Matches the `LocalKey` API
+            fn with_borrow_mut<F: FnOnce(&mut LenMap) -> R, R>(&self, f: F) -> R {
+                let mut map = self.init_and_lock();
+                f(&mut map)
+            }
+        }
+
+        #[cfg(test)]
+        mod tests {
+            use super::*;
+            use core::sync::atomic::Ordering::SeqCst;
+
+            #[test]
+            #[should_panic(expected = "uninitialized")]
+            fn deref_null_panics() {
+                let map = core::ptr::null_mut();
+                let lock = &AtomicBool::new(false);
+                let guard = Guard { map, lock };
+                let _ = &*guard;
+            }
+
+            #[test]
+            #[should_panic(expected = "uninitialized")]
+            fn deref_mut_null_panics() {
+                let map = core::ptr::null_mut();
+                let lock = &AtomicBool::new(false);
+                let mut guard = Guard { map, lock };
+                let _ = &mut *guard;
+            }
+
+            #[test]
+            #[should_panic(expected = "already accessed")]
+            fn cannot_initialize_singleton_twice() {
+                let singleton = SingletonLenMap::new();
+                let _first = singleton.init_and_lock();
+                let _second = singleton.init_and_lock();
+            }
+
+            #[test]
+            fn assure_lock_is_dropped() {
+                let singleton = SingletonLenMap::new();
+                let first = singleton.init_and_lock();
+                drop(first);
+                let _second = singleton.init_and_lock();
+            }
+
+            // assure initialization
+            #[test]
+            fn is_initialized() {
+                let singleton = SingletonLenMap::new();
+
+                let inner = singleton.map.load(SeqCst);
+                assert!(inner.is_null());
+
+                let guard = singleton.init_and_lock();
+                drop(guard);
+
+                let inner = singleton.map.load(SeqCst);
+                assert!(!inner.is_null());
+            }
+
+            // make sure code is still sound in a multi-threaded environment
+            #[cfg(not(target_arch = "wasm32"))]
+            #[test]
+            #[should_panic(expected = "already accessed")]
+            fn panic_on_concurrent_access() {
+                static SINGLETON: SingletonLenMap = SingletonLenMap::new();
+
+                let test = || {
+                    // run enough times to make sure there's a collision
+                    for _ in 0..10000 {
+                        SINGLETON.with_borrow(|map| {
+                            assert!(map.is_empty());
+                        });
+                    }
+                };
+
+                std::thread::scope(|scope| {
+                    let t1 = scope.spawn(test);
+                    let t2 = scope.spawn(test);
+                    let (t1, t2) = (t1.join(), t2.join());
+
+                    if let Err(e) = t1.and(t2) {
+                        std::panic::resume_unwind(e);
+                    }
+                });
+            }
+
+            #[test]
+            #[should_panic(expected = "already accessed")]
+            fn cannot_borrow_twice() {
+                let singleton = SingletonLenMap::new();
+                singleton.with_borrow(|map| {
+                    assert!(map.is_empty());
+                    singleton.with_borrow(|map| {
+                        assert!(map.is_empty());
+                    });
+                });
+            }
+
+            #[test]
+            #[should_panic(expected = "already accessed")]
+            fn cannot_borrow_mut_twice() {
+                let singleton = SingletonLenMap::new();
+                singleton.with_borrow_mut(|map| {
+                    assert!(map.is_empty());
+                    singleton.with_borrow_mut(|map| {
+                        assert!(map.is_empty());
+                    });
+                });
+            }
+
+            #[test]
+            #[should_panic(expected = "already accessed")]
+            fn cannot_borrow_then_borrow_mut() {
+                let singleton = SingletonLenMap::new();
+                singleton.with_borrow(|map| {
+                    assert!(map.is_empty());
+                    singleton.with_borrow_mut(|map| {
+                        assert!(map.is_empty());
+                    });
+                });
+            }
+
+
+            #[test]
+            #[should_panic(expected = "already accessed")]
+            fn cannot_borrow_mut_then_borrow() {
+                let singleton = SingletonLenMap::new();
+                singleton.with_borrow_mut(|map| {
+                    assert!(map.is_empty());
+                    singleton.with_borrow(|map| {
+                        assert!(map.is_empty());
+                    });
+                });
+            }
+        }
+    }
+}

--- a/x/programs/wasmlanche/tests/wasmtime-integration.rs
+++ b/x/programs/wasmlanche/tests/wasmtime-integration.rs
@@ -1,6 +1,8 @@
 // Copyright (C) 2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
+#![cfg(not(target_arch = "wasm32"))]
+
 use std::{
     collections::HashMap,
     path::{Path, PathBuf},


### PR DESCRIPTION
In this PR, I use conditional compilation to either use `thread_local` or a static `RefCell` with unsafe. The "unsafe" code is safe to use in a single-threaded environment (wasm), but not in a multi-threaded environment. Unit tests are usually run on local architecture in a multi-threaded environment. 

"But @richardpringle, doesn't that mean that you aren't testing the code that will be run in wasm? Isn't that the main code that we care about?" See TODO below.

### TODO
I tested this locally with `cross` to make sure it would run on `wasm32`, but I need to add integration tests so that it runs in CI with every PR. 

@samliok, my suggestion is we merge this code *without* the extra integration tests. I'm going to clean up those tests a little to differenciate between memory tests and testing the macro code. 

