### PR TITLE
Include toml linting in CI

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -23,8 +23,28 @@ jobs:
         uses: ./.github/actions/install-rust
         with:
           cache: false
+      - uses: Swatinem/rust-cache@v2
+        with:
+          # we just want to cache the tools for this one
+          cache-targets: false
+          # need to cache "all-crates" to get the tools
+          cache-all-crates: true
+          # caching isn't actually for dependencies but the tools
+          # so it doesn't matter if the job passes or fails
+          cache-on-failure: true
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: taplo-cli
       - name: Run static analysis tests
         run: cargo fmt --all --check
+      - name: Check TOML files
+        run: taplo fmt --check
+      - name: print diff
+        if: failure()
+        run: |
+          cargo fmt --all
+          taplo fmt
+          git diff --color=always
 
   docs:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,15 @@
 [workspace]
 members = [
-    "x/programs/sdk-macros",
-    "x/programs/wasmlanche",
-    "x/programs/examples/token",
-    "x/programs/examples/counter",
-    "x/programs/examples/counter-external",
-    "x/programs/examples/automated-market-maker",
-    "x/programs/wasmlanche/tests/test-crate",
-    "x/programs/test/programs/*",
-    "x/programs/simulator",
-    "x/programs/examples/tutorial",
+  "x/programs/sdk-macros",
+  "x/programs/wasmlanche",
+  "x/programs/examples/token",
+  "x/programs/examples/counter",
+  "x/programs/examples/counter-external",
+  "x/programs/examples/automated-market-maker",
+  "x/programs/wasmlanche/tests/test-crate",
+  "x/programs/test/programs/*",
+  "x/programs/simulator",
+  "x/programs/examples/tutorial",
 ]
 resolver = "2"
 
@@ -24,5 +24,5 @@ strip = true
 [workspace.dependencies]
 sdk-macros = { path = "x/programs/sdk-macros" }
 wasmlanche = { path = "x/programs/wasmlanche" }
-simulator = { path = "x/programs/simulator"}
+simulator = { path = "x/programs/simulator" }
 thiserror = "1.0.61"

--- a/x/programs/examples/token/Cargo.toml
+++ b/x/programs/examples/token/Cargo.toml
@@ -17,4 +17,3 @@ wasmlanche = { workspace = true, features = ["build"] }
 
 [features]
 bindings = []
-


### PR DESCRIPTION
I don't like inconsistent file formatting

This is what it looks like when the `fmt` jobs fail:
https://github.com/ava-labs/hypersdk/actions/runs/10618875864/job/29435160984?pr=1477

