### PR TITLE
Fix addlicense Call in fix.lint.sh for MorpheusVM

### DIFF
--- a/examples/morpheusvm/scripts/lint.sh
+++ b/examples/morpheusvm/scripts/lint.sh
@@ -13,5 +13,4 @@ fi
 
 # Specify the version of golangci-lint. Should be upgraded after linting issues are resolved.
 export GOLANGCI_LINT_VERSION="v1.51.2"
-export ADD_LICENSE=false
 ../../scripts/lint.sh

--- a/scripts/common/utils.sh
+++ b/scripts/common/utils.sh
@@ -12,7 +12,14 @@ function check_command() {
 }
 
 function install_if_not_exists() {
-  go install -v "$2"
+  if ! command -v "$1" &> /dev/null
+  then
+    echo "$1 not found, installing..."
+    go install -v "$2"
+  fi
+
+  # alert the user if they do not have $GOPATH properly configured
+  check_command "$1"
 }
 
 # Function to check if the script is run from the repository root

--- a/scripts/common/utils.sh
+++ b/scripts/common/utils.sh
@@ -12,14 +12,7 @@ function check_command() {
 }
 
 function install_if_not_exists() {
-  if ! command -v "$1" &> /dev/null
-  then
-    echo "$1 not found, installing..."
-    go install -v "$2"
-  fi
-
-  # alert the user if they do not have $GOPATH properly configured
-  check_command "$1"
+  go install -v "$2"
 }
 
 # Function to check if the script is run from the repository root
@@ -57,7 +50,6 @@ function add_license_headers() {
 
   echo "${action} license headers"
 
-  for ext in "*.go" "*.rs" "*.sh"; do
-    find . -type f -name "$ext" -print0 | xargs -0 -n1 addlicense "${args[@]}"
-  done
+  # Find and process files with the specified extensions
+  find . -type f \( -name "*.go" -o -name "*.rs" -o -name "*.sh" \) -print0 | xargs -0 addlicense "${args[@]}"
 }

--- a/scripts/fix.lint.sh
+++ b/scripts/fix.lint.sh
@@ -16,7 +16,7 @@ SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=/scripts/common/utils.sh
 source "${SCRIPT_DIR}/common/utils.sh"
 
-add_license_headers
+add_license_headers ""
 
 echo "gofumpt files"
 install_if_not_exists gofumpt mvdan.cc/gofumpt@latest

--- a/scripts/fix.lint.sh
+++ b/scripts/fix.lint.sh
@@ -16,7 +16,7 @@ SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=/scripts/common/utils.sh
 source "${SCRIPT_DIR}/common/utils.sh"
 
-add_license_headers ""
+add_license_headers
 
 echo "gofumpt files"
 install_if_not_exists gofumpt mvdan.cc/gofumpt@latest

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -25,10 +25,7 @@ else
   TARGET="${1}"
 fi
 
-ADD_LICENSE=${ADD_LICENSE:-true}
-if [ "$ADD_LICENSE" = true ]; then
-  add_license_headers -check
-fi
+add_license_headers -check
 
 # by default, "./scripts/lint.sh" runs all lint tests
 TESTS=${TESTS:-"golangci_lint gci"}


### PR DESCRIPTION
This fix resolves a bug that prevents `addlicense` from running when the folder contains no `*.rs` files.

Please see example log below:

```
vscode ➜ /workspaces/hypersdk (main) $ cd examples/morpheusvm/ && ./scripts/fix.lint.sh 
adding license headers
Usage: addlicense [flags] pattern [pattern ...]
...
```