### PR TITLE
Move Extern Calls into Context

### DIFF
--- a/x/programs/test/programs/balance/src/lib.rs
+++ b/x/programs/test/programs/balance/src/lib.rs
@@ -1,16 +1,16 @@
 // Copyright (C) 2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-use wasmlanche::{get_balance, public, send, Address, Context, Gas, Program};
+use wasmlanche::{public, Address, Context, Gas, Program};
 
 #[public]
 pub fn balance(ctx: &mut Context) -> u64 {
-    get_balance(ctx.actor())
+    ctx.get_balance(ctx.actor())
 }
 
 #[public]
-pub fn send_balance(_: &mut Context, recipient: Address) -> bool {
-    send(recipient, 1).is_ok()
+pub fn send_balance(ctx: &mut Context, recipient: Address) -> bool {
+    ctx.send(recipient, 1).is_ok()
 }
 
 #[public]

--- a/x/programs/test/programs/fuel/src/lib.rs
+++ b/x/programs/test/programs/fuel/src/lib.rs
@@ -5,7 +5,7 @@ use wasmlanche::{public, Context, ExternalCallError, Program};
 
 #[public]
 pub fn get_fuel(ctx: &mut Context) -> u64 {
-    ctx.program().remaining_fuel()
+    ctx.remaining_fuel()
 }
 
 #[public]

--- a/x/programs/wasmlanche/src/lib.rs
+++ b/x/programs/wasmlanche/src/lib.rs
@@ -79,8 +79,8 @@ mod logging {
 
 pub use self::{
     context::{Context, ExternalCallContext},
-    program::{send, ExternalCallError, Program},
-    state::{get_balance, macro_types, Error},
+    program::{ExternalCallError, Program},
+    state::{macro_types, Error},
     types::{Address, Gas, Id, ProgramId, ID_LEN},
 };
 #[doc(hidden)]

--- a/x/programs/wasmlanche/src/state.rs
+++ b/x/programs/wasmlanche/src/state.rs
@@ -6,7 +6,6 @@ extern crate alloc;
 use crate::{
     context::{CacheKey, CacheValue},
     memory::HostPtr,
-    types::Address,
 };
 use alloc::{boxed::Box, vec::Vec};
 use borsh::{from_slice, BorshDeserialize, BorshSerialize};
@@ -27,22 +26,6 @@ pub enum Error {
     Serialization,
     /// failed to deserialize bytes
     Deserialization,
-}
-
-/// Gets the balance for the specified address
-/// # Panics
-/// Panics if there was an issue deserializing the balance
-#[must_use]
-pub fn get_balance(account: Address) -> u64 {
-    #[link(wasm_import_module = "balance")]
-    extern "C" {
-        #[link_name = "get"]
-        fn get(ptr: *const u8, len: usize) -> HostPtr;
-    }
-    let ptr = borsh::to_vec(&account).expect("failed to serialize args");
-    let bytes = unsafe { get(ptr.as_ptr(), ptr.len()) };
-
-    borsh::from_slice(&bytes).expect("failed to deserialize the balance")
 }
 
 pub struct Cache {


### PR DESCRIPTION
makes host function calls more explicit by ensuring they are called from a `context`.

going to move `call_function` into context as well but in a separate pr(alongside other changes to `program`)