### PR TITLE
Swap misnomer stateful and stateless blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ store revisions for at least as long as it takes to complete a sync, which may
 require significantly more storage).
 
 ```golang
-type StatefulBlock struct {
+type StatelessBlock struct {
 	Prnt   ids.ID `json:"parent"`
 	Tmstmp int64  `json:"timestamp"`
 	Hght   uint64 `json:"height"`
@@ -574,7 +574,7 @@ type Controller interface {
 
 	// Anything that the VM wishes to store outside of state or blocks must be
 	// recorded here
-	Accepted(ctx context.Context, blk *chain.StatelessBlock) error
+	Accepted(ctx context.Context, blk *chain.StatefulBlock) error
 
 	// Shutdown should be used by the [Controller] to terminate any async
 	// processes it may be running in the background. It is invoked when

--- a/api/dependencies.go
+++ b/api/dependencies.go
@@ -29,7 +29,7 @@ type VM interface {
 		verifySig bool,
 		txs []*chain.Transaction,
 	) (errs []error)
-	LastAcceptedBlock() *chain.StatelessBlock
+	LastAcceptedBlock() *chain.StatefulBlock
 	UnitPrices(context.Context) (fees.Dimensions, error)
 	CurrentValidators(
 		context.Context,

--- a/api/indexer/tx_indexer.go
+++ b/api/indexer/tx_indexer.go
@@ -28,8 +28,8 @@ var (
 	failureByte = byte(0x0)
 	successByte = byte(0x1)
 
-	_ event.SubscriptionFactory[*chain.StatelessBlock] = (*subscriptionFactory)(nil)
-	_ event.Subscription[*chain.StatelessBlock]        = (*txDBIndexer)(nil)
+	_ event.SubscriptionFactory[*chain.StatefulBlock] = (*subscriptionFactory)(nil)
+	_ event.Subscription[*chain.StatefulBlock]        = (*txDBIndexer)(nil)
 )
 
 func With() vm.Option {
@@ -67,7 +67,7 @@ type subscriptionFactory struct {
 	indexer *txDBIndexer
 }
 
-func (s *subscriptionFactory) New() (event.Subscription[*chain.StatelessBlock], error) {
+func (s *subscriptionFactory) New() (event.Subscription[*chain.StatefulBlock], error) {
 	return s.indexer, nil
 }
 
@@ -75,7 +75,7 @@ type txDBIndexer struct {
 	db database.Database
 }
 
-func (t *txDBIndexer) Accept(blk *chain.StatelessBlock) error {
+func (t *txDBIndexer) Accept(blk *chain.StatefulBlock) error {
 	batch := t.db.NewBatch()
 	defer batch.Reset()
 

--- a/api/ws/client.go
+++ b/api/ws/client.go
@@ -148,7 +148,7 @@ func (c *WebSocketClient) RegisterBlocks() error {
 func (c *WebSocketClient) ListenBlock(
 	ctx context.Context,
 	parser chain.Parser,
-) (*chain.StatefulBlock, []*chain.Result, fees.Dimensions, error) {
+) (*chain.StatelessBlock, []*chain.Result, fees.Dimensions, error) {
 	select {
 	case msg := <-c.pendingBlocks:
 		return UnpackBlockMessage(msg, parser)

--- a/api/ws/packer.go
+++ b/api/ws/packer.go
@@ -19,7 +19,7 @@ const (
 	TxMode    byte = 1
 )
 
-func PackBlockMessage(b *chain.StatelessBlock) ([]byte, error) {
+func PackBlockMessage(b *chain.StatefulBlock) ([]byte, error) {
 	results := b.Results()
 	size := codec.BytesLen(b.Bytes()) + consts.IntLen + codec.CummSize(results) + fees.DimensionsLen
 	p := codec.NewWriter(size, consts.MaxInt)
@@ -36,7 +36,7 @@ func PackBlockMessage(b *chain.StatelessBlock) ([]byte, error) {
 func UnpackBlockMessage(
 	msg []byte,
 	parser chain.Parser,
-) (*chain.StatefulBlock, []*chain.Result, fees.Dimensions, error) {
+) (*chain.StatelessBlock, []*chain.Result, fees.Dimensions, error) {
 	p := codec.NewReader(msg, consts.MaxInt)
 	var blkMsg []byte
 	p.UnpackBytes(-1, true, &blkMsg)

--- a/api/ws/server.go
+++ b/api/ws/server.go
@@ -79,8 +79,8 @@ func OptionFunc(v *vm.VM, configBytes []byte) error {
 		},
 	}
 
-	blockSubscription := event.SubscriptionFuncFactory[*chain.StatelessBlock]{
-		AcceptF: func(event *chain.StatelessBlock) error {
+	blockSubscription := event.SubscriptionFuncFactory[*chain.StatefulBlock]{
+		AcceptF: func(event *chain.StatefulBlock) error {
 			return server.AcceptBlock(event)
 		},
 	}
@@ -200,7 +200,7 @@ func (w *WebSocketServer) setMinTx(t int64) error {
 	return nil
 }
 
-func (w *WebSocketServer) AcceptBlock(b *chain.StatelessBlock) error {
+func (w *WebSocketServer) AcceptBlock(b *chain.StatefulBlock) error {
 	if w.blockListeners.Len() > 0 {
 		bytes, err := PackBlockMessage(b)
 		if err != nil {

--- a/builder/dependencies.go
+++ b/builder/dependencies.go
@@ -15,7 +15,7 @@ import (
 type VM interface {
 	StopChan() chan struct{}
 	EngineChan() chan<- common.Message
-	PreferredBlock(context.Context) (*chain.StatelessBlock, error)
+	PreferredBlock(context.Context) (*chain.StatefulBlock, error)
 	Logger() logging.Logger
 	Mempool() chain.Mempool
 	Rules(int64) chain.Rules

--- a/chain/block.go
+++ b/chain/block.go
@@ -150,7 +150,7 @@ func NewGenesisBlock(root ids.ID) *StatelessBlock {
 }
 
 // Stateless is defined separately from "Block"
-// in case external packages need to use the stateful block
+// in case external packages need to use the stateless block
 // without mocking VM or parent block
 type StatefulBlock struct {
 	*StatelessBlock `json:"block"`

--- a/chain/block.go
+++ b/chain/block.go
@@ -28,11 +28,11 @@ import (
 )
 
 var (
-	_ snowman.Block      = (*StatelessBlock)(nil)
+	_ snowman.Block      = (*StatefulBlock)(nil)
 	_ block.StateSummary = (*SyncableBlock)(nil)
 )
 
-type StatefulBlock struct {
+type StatelessBlock struct {
 	Prnt   ids.ID `json:"parent"`
 	Tmstmp int64  `json:"timestamp"`
 	Hght   uint64 `json:"height"`
@@ -56,11 +56,11 @@ type StatefulBlock struct {
 	authCounts map[uint8]int
 }
 
-func (b *StatefulBlock) Size() int {
+func (b *StatelessBlock) Size() int {
 	return b.size
 }
 
-func (b *StatefulBlock) ID() (ids.ID, error) {
+func (b *StatelessBlock) ID() (ids.ID, error) {
 	blk, err := b.Marshal()
 	if err != nil {
 		return ids.ID{}, err
@@ -68,7 +68,7 @@ func (b *StatefulBlock) ID() (ids.ID, error) {
 	return utils.ToID(blk), nil
 }
 
-func (b *StatefulBlock) Marshal() ([]byte, error) {
+func (b *StatelessBlock) Marshal() ([]byte, error) {
 	size := ids.IDLen + consts.Uint64Len + consts.Uint64Len +
 		consts.Uint64Len + window.WindowSliceSize +
 		consts.IntLen + codec.CummSize(b.Txs) +
@@ -98,10 +98,10 @@ func (b *StatefulBlock) Marshal() ([]byte, error) {
 	return bytes, nil
 }
 
-func UnmarshalBlock(raw []byte, parser Parser) (*StatefulBlock, error) {
+func UnmarshalBlock(raw []byte, parser Parser) (*StatelessBlock, error) {
 	var (
 		p = codec.NewReader(raw, consts.NetworkSizeLimit)
-		b StatefulBlock
+		b StatelessBlock
 	)
 	b.size = len(raw)
 
@@ -132,8 +132,8 @@ func UnmarshalBlock(raw []byte, parser Parser) (*StatefulBlock, error) {
 	return &b, p.Err()
 }
 
-func NewGenesisBlock(root ids.ID) *StatefulBlock {
-	return &StatefulBlock{
+func NewGenesisBlock(root ids.ID) *StatelessBlock {
+	return &StatelessBlock{
 		// We set the genesis block timestamp to be after the ProposerVM fork activation.
 		//
 		// This prevents an issue (when using millisecond timestamps) during ProposerVM activation
@@ -152,8 +152,8 @@ func NewGenesisBlock(root ids.ID) *StatefulBlock {
 // Stateless is defined separately from "Block"
 // in case external packages need to use the stateful block
 // without mocking VM or parent block
-type StatelessBlock struct {
-	*StatefulBlock `json:"block"`
+type StatefulBlock struct {
+	*StatelessBlock `json:"block"`
 
 	id       ids.ID
 	accepted bool
@@ -170,9 +170,9 @@ type StatelessBlock struct {
 	sigJob workers.Job
 }
 
-func NewBlock(vm VM, parent snowman.Block, tmstp int64) *StatelessBlock {
-	return &StatelessBlock{
-		StatefulBlock: &StatefulBlock{
+func NewBlock(vm VM, parent snowman.Block, tmstp int64) *StatefulBlock {
+	return &StatefulBlock{
+		StatelessBlock: &StatelessBlock{
 			Prnt:   parent.ID(),
 			Tmstmp: tmstp,
 			Hght:   parent.Height() + 1,
@@ -187,7 +187,7 @@ func ParseBlock(
 	source []byte,
 	accepted bool,
 	vm VM,
-) (*StatelessBlock, error) {
+) (*StatefulBlock, error) {
 	ctx, span := vm.Tracer().Start(ctx, "chain.ParseBlock")
 	defer span.End()
 
@@ -196,16 +196,16 @@ func ParseBlock(
 		return nil, err
 	}
 	// Not guaranteed that a parsed block is verified
-	return ParseStatefulBlock(ctx, blk, source, accepted, vm)
+	return ParseStatelessBlock(ctx, blk, source, accepted, vm)
 }
 
 // populateTxs is only called on blocks we did not build
-func (b *StatelessBlock) populateTxs(ctx context.Context) error {
-	ctx, span := b.vm.Tracer().Start(ctx, "StatelessBlock.populateTxs")
+func (b *StatefulBlock) populateTxs(ctx context.Context) error {
+	ctx, span := b.vm.Tracer().Start(ctx, "StatefulBlock.populateTxs")
 	defer span.End()
 
 	// Setup signature verification job
-	_, sigVerifySpan := b.vm.Tracer().Start(ctx, "StatelessBlock.verifySignatures") //nolint:spancheck
+	_, sigVerifySpan := b.vm.Tracer().Start(ctx, "StatefulBlock.verifySignatures") //nolint:spancheck
 	job, err := b.vm.AuthVerifiers().NewJob(len(b.Txs))
 	if err != nil {
 		return err //nolint:spancheck
@@ -242,14 +242,14 @@ func (b *StatelessBlock) populateTxs(ctx context.Context) error {
 	return nil
 }
 
-func ParseStatefulBlock(
+func ParseStatelessBlock(
 	ctx context.Context,
-	blk *StatefulBlock,
+	blk *StatelessBlock,
 	source []byte,
 	accepted bool,
 	vm VM,
-) (*StatelessBlock, error) {
-	ctx, span := vm.Tracer().Start(ctx, "chain.ParseStatefulBlock")
+) (*StatefulBlock, error) {
+	ctx, span := vm.Tracer().Start(ctx, "chain.ParseStatelessBlock")
 	defer span.End()
 
 	// Perform basic correctness checks before doing any expensive work
@@ -264,13 +264,13 @@ func ParseStatefulBlock(
 		}
 		source = nsource
 	}
-	b := &StatelessBlock{
-		StatefulBlock: blk,
-		t:             time.UnixMilli(blk.Tmstmp),
-		bytes:         source,
-		accepted:      accepted,
-		vm:            vm,
-		id:            utils.ToID(source),
+	b := &StatefulBlock{
+		StatelessBlock: blk,
+		t:              time.UnixMilli(blk.Tmstmp),
+		bytes:          source,
+		accepted:       accepted,
+		vm:             vm,
+		id:             utils.ToID(source),
 	}
 
 	// If we are parsing an older block, it will not be re-executed and should
@@ -285,23 +285,23 @@ func ParseStatefulBlock(
 }
 
 // [initializeBuilt] is invoked after a block is built
-func (b *StatelessBlock) initializeBuilt(
+func (b *StatefulBlock) initializeBuilt(
 	ctx context.Context,
 	view merkledb.View,
 	results []*Result,
 	feeManager *fees.Manager,
 ) error {
-	_, span := b.vm.Tracer().Start(ctx, "StatelessBlock.initializeBuilt")
+	_, span := b.vm.Tracer().Start(ctx, "StatefulBlock.initializeBuilt")
 	defer span.End()
 
-	blk, err := b.StatefulBlock.Marshal()
+	blk, err := b.StatelessBlock.Marshal()
 	if err != nil {
 		return err
 	}
 	b.bytes = blk
 	b.id = utils.ToID(b.bytes)
 	b.view = view
-	b.t = time.UnixMilli(b.StatefulBlock.Tmstmp)
+	b.t = time.UnixMilli(b.StatelessBlock.Tmstmp)
 	b.results = results
 	b.feeManager = feeManager
 	b.txsSet = set.NewSet[ids.ID](len(b.Txs))
@@ -312,10 +312,10 @@ func (b *StatelessBlock) initializeBuilt(
 }
 
 // implements "snowman.Block.choices.Decidable"
-func (b *StatelessBlock) ID() ids.ID { return b.id }
+func (b *StatefulBlock) ID() ids.ID { return b.id }
 
 // implements "snowman.Block"
-func (b *StatelessBlock) Verify(ctx context.Context) error {
+func (b *StatefulBlock) Verify(ctx context.Context) error {
 	start := time.Now()
 	defer func() {
 		b.vm.RecordBlockVerify(time.Since(start))
@@ -323,7 +323,7 @@ func (b *StatelessBlock) Verify(ctx context.Context) error {
 
 	stateReady := b.vm.StateReady()
 	ctx, span := b.vm.Tracer().Start(
-		ctx, "StatelessBlock.Verify",
+		ctx, "StatefulBlock.Verify",
 		trace.WithAttributes(
 			attribute.Int("txs", len(b.Txs)),
 			attribute.Int64("height", int64(b.Hght)),
@@ -400,7 +400,7 @@ func (b *StatelessBlock) Verify(ctx context.Context) error {
 //  2. If the parent view is missing when verifying (dynamic state sync)
 //  3. If the view of a block we are accepting is missing (finishing dynamic
 //     state sync)
-func (b *StatelessBlock) innerVerify(ctx context.Context, vctx VerifyContext) error {
+func (b *StatefulBlock) innerVerify(ctx context.Context, vctx VerifyContext) error {
 	var (
 		log = b.vm.Logger()
 		r   = b.vm.Rules(b.Tmstmp)
@@ -519,7 +519,7 @@ func (b *StatelessBlock) innerVerify(ctx context.Context, vctx VerifyContext) er
 	//
 	// Because fee bytes are not recorded in state, it is sufficient to check the state root
 	// to verify all fee calculations were correct.
-	_, rspan := b.vm.Tracer().Start(ctx, "StatelessBlock.Verify.WaitRoot")
+	_, rspan := b.vm.Tracer().Start(ctx, "StatefulBlock.Verify.WaitRoot")
 	start := time.Now()
 	computedRoot, err := parentView.GetMerkleRoot(ctx)
 	rspan.End()
@@ -537,7 +537,7 @@ func (b *StatelessBlock) innerVerify(ctx context.Context, vctx VerifyContext) er
 	}
 
 	// Ensure signatures are verified
-	_, sspan := b.vm.Tracer().Start(ctx, "StatelessBlock.Verify.WaitSignatures")
+	_, sspan := b.vm.Tracer().Start(ctx, "StatefulBlock.Verify.WaitSignatures")
 	start = time.Now()
 	err = b.sigJob.Wait()
 	sspan.End()
@@ -574,20 +574,20 @@ func (b *StatelessBlock) innerVerify(ctx context.Context, vctx VerifyContext) er
 }
 
 // implements "snowman.Block.choices.Decidable"
-func (b *StatelessBlock) Accept(ctx context.Context) error {
+func (b *StatefulBlock) Accept(ctx context.Context) error {
 	start := time.Now()
 	defer func() {
 		b.vm.RecordBlockAccept(time.Since(start))
 	}()
 
-	ctx, span := b.vm.Tracer().Start(ctx, "StatelessBlock.Accept")
+	ctx, span := b.vm.Tracer().Start(ctx, "StatefulBlock.Accept")
 	defer span.End()
 
 	// Consider verifying the a block if it is not processed and we are no longer
 	// syncing.
 	if !b.Processed() {
 		// The state of this block was not calculated during the call to
-		// [StatelessBlock.Verify]. This is because the VM was state syncing
+		// [StatefulBlock.Verify]. This is because the VM was state syncing
 		// and did not have the state necessary to verify the block.
 		updated, err := b.vm.UpdateSyncTarget(b)
 		if err != nil {
@@ -631,7 +631,7 @@ func (b *StatelessBlock) Accept(ctx context.Context) error {
 	return nil
 }
 
-func (b *StatelessBlock) MarkAccepted(ctx context.Context) {
+func (b *StatefulBlock) MarkAccepted(ctx context.Context) {
 	// Accept block and free unnecessary memory
 	b.accepted = true
 	b.txsSet = nil // only used for replay protection when processing
@@ -644,8 +644,8 @@ func (b *StatelessBlock) MarkAccepted(ctx context.Context) {
 }
 
 // implements "snowman.Block.choices.Decidable"
-func (b *StatelessBlock) Reject(ctx context.Context) error {
-	ctx, span := b.vm.Tracer().Start(ctx, "StatelessBlock.Reject")
+func (b *StatefulBlock) Reject(ctx context.Context) error {
+	ctx, span := b.vm.Tracer().Start(ctx, "StatefulBlock.Reject")
 	defer span.End()
 
 	b.vm.Rejected(ctx, b)
@@ -653,19 +653,19 @@ func (b *StatelessBlock) Reject(ctx context.Context) error {
 }
 
 // implements "snowman.Block"
-func (b *StatelessBlock) Parent() ids.ID { return b.StatefulBlock.Prnt }
+func (b *StatefulBlock) Parent() ids.ID { return b.StatelessBlock.Prnt }
 
 // implements "snowman.Block"
-func (b *StatelessBlock) Bytes() []byte { return b.bytes }
+func (b *StatefulBlock) Bytes() []byte { return b.bytes }
 
 // implements "snowman.Block"
-func (b *StatelessBlock) Height() uint64 { return b.StatefulBlock.Hght }
+func (b *StatefulBlock) Height() uint64 { return b.StatelessBlock.Hght }
 
 // implements "snowman.Block"
-func (b *StatelessBlock) Timestamp() time.Time { return b.t }
+func (b *StatefulBlock) Timestamp() time.Time { return b.t }
 
 // Used to determine if should notify listeners and/or pass to controller
-func (b *StatelessBlock) Processed() bool {
+func (b *StatefulBlock) Processed() bool {
 	return b.view != nil
 }
 
@@ -682,8 +682,8 @@ func (b *StatelessBlock) Processed() bool {
 //
 // Invariant: [View] with [verify] == true should not be called concurrently, otherwise,
 // it will result in undefined behavior.
-func (b *StatelessBlock) View(ctx context.Context, verify bool) (state.View, error) {
-	ctx, span := b.vm.Tracer().Start(ctx, "StatelessBlock.View",
+func (b *StatefulBlock) View(ctx context.Context, verify bool) (state.View, error) {
+	ctx, span := b.vm.Tracer().Start(ctx, "StatefulBlock.View",
 		trace.WithAttributes(
 			attribute.Bool("processed", b.Processed()),
 			attribute.Bool("verify", verify),
@@ -798,14 +798,14 @@ func (b *StatelessBlock) View(ctx context.Context, verify bool) (state.View, err
 //
 // If [stop] is set to true, IsRepeat will return as soon as the first repeat
 // is found (useful for block verification).
-func (b *StatelessBlock) IsRepeat(
+func (b *StatefulBlock) IsRepeat(
 	ctx context.Context,
 	oldestAllowed int64,
 	txs []*Transaction,
 	marker set.Bits,
 	stop bool,
 ) (set.Bits, error) {
-	ctx, span := b.vm.Tracer().Start(ctx, "StatelessBlock.IsRepeat")
+	ctx, span := b.vm.Tracer().Start(ctx, "StatefulBlock.IsRepeat")
 	defer span.End()
 
 	// Early exit if we are already back at least [ValidityWindow]
@@ -834,38 +834,38 @@ func (b *StatelessBlock) IsRepeat(
 			}
 		}
 	}
-	prnt, err := b.vm.GetStatelessBlock(ctx, b.Prnt)
+	prnt, err := b.vm.GetStatefulBlock(ctx, b.Prnt)
 	if err != nil {
 		return marker, err
 	}
 	return prnt.IsRepeat(ctx, oldestAllowed, txs, marker, stop)
 }
 
-func (b *StatelessBlock) GetTxs() []*Transaction {
+func (b *StatefulBlock) GetTxs() []*Transaction {
 	return b.Txs
 }
 
-func (b *StatelessBlock) GetTimestamp() int64 {
+func (b *StatefulBlock) GetTimestamp() int64 {
 	return b.Tmstmp
 }
 
-func (b *StatelessBlock) Results() []*Result {
+func (b *StatefulBlock) Results() []*Result {
 	return b.results
 }
 
-func (b *StatelessBlock) FeeManager() *fees.Manager {
+func (b *StatefulBlock) FeeManager() *fees.Manager {
 	return b.feeManager
 }
 
 type SyncableBlock struct {
-	*StatelessBlock
+	*StatefulBlock
 }
 
 func (sb *SyncableBlock) Accept(ctx context.Context) (block.StateSyncMode, error) {
 	return sb.vm.AcceptedSyncableBlock(ctx, sb)
 }
 
-func NewSyncableBlock(sb *StatelessBlock) *SyncableBlock {
+func NewSyncableBlock(sb *StatefulBlock) *SyncableBlock {
 	return &SyncableBlock{sb}
 }
 
@@ -874,6 +874,6 @@ func (sb *SyncableBlock) String() string {
 }
 
 // Testing
-func (b *StatelessBlock) MarkUnprocessed() {
+func (b *StatefulBlock) MarkUnprocessed() {
 	b.view = nil
 }

--- a/chain/builder.go
+++ b/chain/builder.go
@@ -63,8 +63,8 @@ func HandlePreExecute(log logging.Logger, err error) bool {
 func BuildBlock(
 	ctx context.Context,
 	vm VM,
-	parent *StatelessBlock,
-) (*StatelessBlock, error) {
+	parent *StatefulBlock,
+) (*StatefulBlock, error) {
 	ctx, span := vm.Tracer().Start(ctx, "chain.BuildBlock")
 	defer span.End()
 	log := vm.Logger()

--- a/chain/dependencies.go
+++ b/chain/dependencies.go
@@ -65,8 +65,8 @@ type VM interface {
 	GetVerifyAuth() bool
 
 	IsBootstrapped() bool
-	LastAcceptedBlock() *StatelessBlock
-	GetStatelessBlock(context.Context, ids.ID) (*StatelessBlock, error)
+	LastAcceptedBlock() *StatefulBlock
+	GetStatefulBlock(context.Context, ids.ID) (*StatefulBlock, error)
 
 	GetVerifyContext(ctx context.Context, blockHeight uint64, parent ids.ID) (VerifyContext, error)
 
@@ -80,15 +80,15 @@ type VM interface {
 	GetTransactionExecutionCores() int
 	GetStateFetchConcurrency() int
 
-	Verified(context.Context, *StatelessBlock)
-	Rejected(context.Context, *StatelessBlock)
-	Accepted(context.Context, *StatelessBlock)
+	Verified(context.Context, *StatefulBlock)
+	Rejected(context.Context, *StatefulBlock)
+	Accepted(context.Context, *StatefulBlock)
 	AcceptedSyncableBlock(context.Context, *SyncableBlock) (block.StateSyncMode, error)
 
 	// UpdateSyncTarget returns a bool that is true if the root
 	// was updated and the sync is continuing with the new specified root
 	// and false if the sync completed with the previous root.
-	UpdateSyncTarget(*StatelessBlock) (bool, error)
+	UpdateSyncTarget(*StatefulBlock) (bool, error)
 	StateReady() bool
 }
 

--- a/chain/processor.go
+++ b/chain/processor.go
@@ -23,7 +23,7 @@ type fetchData struct {
 	chunks uint16
 }
 
-func (b *StatelessBlock) Execute(
+func (b *StatefulBlock) Execute(
 	ctx context.Context,
 	tracer trace.Tracer, //nolint:interfacer
 	im state.Immutable,

--- a/extension/externalsubscriber/client.go
+++ b/extension/externalsubscriber/client.go
@@ -17,7 +17,7 @@ import (
 	pb "github.com/ava-labs/hypersdk/proto/pb/externalsubscriber"
 )
 
-var _ event.Subscription[*chain.StatelessBlock] = (*ExternalSubscriberClient)(nil)
+var _ event.Subscription[*chain.StatefulBlock] = (*ExternalSubscriberClient)(nil)
 
 type ExternalSubscriberClient struct {
 	conn   *grpc.ClientConn
@@ -55,7 +55,7 @@ func NewExternalSubscriberClient(
 	}, nil
 }
 
-func (e *ExternalSubscriberClient) Accept(blk *chain.StatelessBlock) error {
+func (e *ExternalSubscriberClient) Accept(blk *chain.StatefulBlock) error {
 	blockBytes, err := blk.Marshal()
 	if err != nil {
 		return err

--- a/extension/externalsubscriber/option.go
+++ b/extension/externalsubscriber/option.go
@@ -49,8 +49,8 @@ func OptionFunc(v *vm.VM, configBytes []byte) error {
 		return err
 	}
 
-	blockSubscription := event.SubscriptionFuncFactory[*chain.StatelessBlock]{
-		AcceptF: func(blk *chain.StatelessBlock) error {
+	blockSubscription := event.SubscriptionFuncFactory[*chain.StatefulBlock]{
+		AcceptF: func(blk *chain.StatefulBlock) error {
 			return server.Accept(blk)
 		},
 	}

--- a/extension/externalsubscriber/server.go
+++ b/extension/externalsubscriber/server.go
@@ -27,12 +27,12 @@ var (
 // TODO: switch to eventually using chain.Stateless block
 // Wrapper to pass blocks + results to subscribers
 type ExternalSubscriberSubscriptionData struct {
-	Blk     *chain.StatefulBlock
+	Blk     *chain.StatelessBlock
 	Results []*chain.Result
 }
 
 func NewExternalSubscriberSubscriptionData(
-	blk *chain.StatefulBlock,
+	blk *chain.StatelessBlock,
 	results []*chain.Result,
 ) *ExternalSubscriberSubscriptionData {
 	return &ExternalSubscriberSubscriptionData{

--- a/gossiper/dependencies.go
+++ b/gossiper/dependencies.go
@@ -25,7 +25,7 @@ type VM interface {
 	Proposers(ctx context.Context, diff int, depth int) (set.Set[ids.NodeID], error)
 	IsValidator(context.Context, ids.NodeID) (bool, error)
 	Logger() logging.Logger
-	PreferredBlock(context.Context) (*chain.StatelessBlock, error)
+	PreferredBlock(context.Context) (*chain.StatefulBlock, error)
 	Registry() (chain.ActionRegistry, chain.AuthRegistry)
 	NodeID() ids.NodeID
 	Rules(int64) chain.Rules

--- a/tests/integration/integration.go
+++ b/tests/integration/integration.go
@@ -398,7 +398,7 @@ var _ = ginkgo.Describe("[Tx Processing]", ginkgo.Serial, func() {
 			require.NoError(err)
 			require.Equal(lastAccepted, blk.ID())
 
-			results := blk.(*chain.StatelessBlock).Results()
+			results := blk.(*chain.StatefulBlock).Results()
 			require.Len(results, 1)
 			require.True(results[0].Success)
 			require.Empty(results[0].Outputs[0])
@@ -440,7 +440,7 @@ var _ = ginkgo.Describe("[Tx Processing]", ginkgo.Serial, func() {
 
 			// Ensure we can handle case where accepted block is not processed
 			latestBlock := blocks[len(blocks)-1]
-			latestBlock.(*chain.StatelessBlock).MarkUnprocessed()
+			latestBlock.(*chain.StatefulBlock).MarkUnprocessed()
 
 			// Accept new block (should use accepted state)
 			accept := expectBlk(instances[1])
@@ -672,6 +672,6 @@ func expectBlk(i instance) func(add bool) []*chain.Result {
 		lastAccepted, err := i.vm.LastAccepted(ctx)
 		require.NoError(err)
 		require.Equal(lastAccepted, blk.ID())
-		return blk.(*chain.StatelessBlock).Results()
+		return blk.(*chain.StatefulBlock).Results()
 	}
 }

--- a/vm/option.go
+++ b/vm/option.go
@@ -50,7 +50,7 @@ func WithManual() Option {
 	)
 }
 
-func WithBlockSubscriptions(subscriptions ...event.SubscriptionFactory[*chain.StatelessBlock]) RegisterFunc {
+func WithBlockSubscriptions(subscriptions ...event.SubscriptionFactory[*chain.StatefulBlock]) RegisterFunc {
 	return func(vm *VM) {
 		vm.blockSubscriptionFactories = append(vm.blockSubscriptionFactories, subscriptions...)
 	}

--- a/vm/proposer_monitor.go
+++ b/vm/proposer_monitor.go
@@ -105,7 +105,7 @@ func (p *ProposerMonitor) Proposers(
 	if err := p.refresh(ctx); err != nil {
 		return nil, err
 	}
-	preferredBlk, err := p.vm.GetStatelessBlock(ctx, p.vm.preferred)
+	preferredBlk, err := p.vm.GetStatefulBlock(ctx, p.vm.preferred)
 	if err != nil {
 		return nil, err
 	}

--- a/vm/resolutions.go
+++ b/vm/resolutions.go
@@ -70,7 +70,7 @@ func (vm *VM) Rules(t int64) chain.Rules {
 	return vm.ruleFactory.GetRules(t)
 }
 
-func (vm *VM) LastAcceptedBlock() *chain.StatelessBlock {
+func (vm *VM) LastAcceptedBlock() *chain.StatefulBlock {
 	return vm.lastAccepted
 }
 
@@ -97,7 +97,7 @@ func (vm *VM) IsRepeat(ctx context.Context, txs []*chain.Transaction, marker set
 	return vm.seen.Contains(txs, marker, stop)
 }
 
-func (vm *VM) Verified(ctx context.Context, b *chain.StatelessBlock) {
+func (vm *VM) Verified(ctx context.Context, b *chain.StatefulBlock) {
 	ctx, span := vm.tracer.Start(ctx, "VM.Verified")
 	defer span.End()
 
@@ -136,7 +136,7 @@ func (vm *VM) Verified(ctx context.Context, b *chain.StatelessBlock) {
 	}
 }
 
-func (vm *VM) Rejected(ctx context.Context, b *chain.StatelessBlock) {
+func (vm *VM) Rejected(ctx context.Context, b *chain.StatefulBlock) {
 	ctx, span := vm.tracer.Start(ctx, "VM.Rejected")
 	defer span.End()
 
@@ -150,7 +150,7 @@ func (vm *VM) Rejected(ctx context.Context, b *chain.StatelessBlock) {
 	vm.snowCtx.Log.Info("rejected block", zap.Stringer("id", b.ID()))
 }
 
-func (vm *VM) processAcceptedBlock(b *chain.StatelessBlock) {
+func (vm *VM) processAcceptedBlock(b *chain.StatefulBlock) {
 	start := time.Now()
 	defer func() {
 		vm.metrics.blockProcess.Observe(float64(time.Since(start)))
@@ -214,7 +214,7 @@ func (vm *VM) processAcceptedBlocks() {
 	}
 }
 
-func (vm *VM) Accepted(ctx context.Context, b *chain.StatelessBlock) {
+func (vm *VM) Accepted(ctx context.Context, b *chain.StatefulBlock) {
 	ctx, span := vm.tracer.Start(ctx, "VM.Accepted")
 	defer span.End()
 
@@ -304,8 +304,8 @@ func (vm *VM) NodeID() ids.NodeID {
 	return vm.snowCtx.NodeID
 }
 
-func (vm *VM) PreferredBlock(ctx context.Context) (*chain.StatelessBlock, error) {
-	return vm.GetStatelessBlock(ctx, vm.preferred)
+func (vm *VM) PreferredBlock(ctx context.Context) (*chain.StatefulBlock, error) {
+	return vm.GetStatefulBlock(ctx, vm.preferred)
 }
 
 func (vm *VM) StopChan() chan struct{} {
@@ -340,7 +340,7 @@ func (vm *VM) StateReady() bool {
 	return vm.stateSyncClient.StateReady()
 }
 
-func (vm *VM) UpdateSyncTarget(b *chain.StatelessBlock) (bool, error) {
+func (vm *VM) UpdateSyncTarget(b *chain.StatefulBlock) (bool, error) {
 	return vm.stateSyncClient.UpdateSyncTarget(b)
 }
 

--- a/vm/storage.go
+++ b/vm/storage.go
@@ -65,7 +65,7 @@ func (vm *VM) HasGenesis() (bool, error) {
 	return vm.HasDiskBlock(0)
 }
 
-func (vm *VM) GetGenesis(ctx context.Context) (*chain.StatelessBlock, error) {
+func (vm *VM) GetGenesis(ctx context.Context) (*chain.StatefulBlock, error) {
 	return vm.GetDiskBlock(ctx, 0)
 }
 
@@ -118,7 +118,7 @@ func (vm *VM) shouldCompact(expiryHeight uint64) bool {
 //
 // We store blocks by height because it doesn't cause nearly as much
 // compaction as storing blocks randomly on-disk (when using [block.ID]).
-func (vm *VM) UpdateLastAccepted(blk *chain.StatelessBlock) error {
+func (vm *VM) UpdateLastAccepted(blk *chain.StatefulBlock) error {
 	batch := vm.vmDB.NewBatch()
 	bigEndianHeight := binary.BigEndian.AppendUint64(nil, blk.Height())
 	if err := batch.Put(lastAccepted, bigEndianHeight); err != nil {
@@ -174,7 +174,7 @@ func (vm *VM) UpdateLastAccepted(blk *chain.StatelessBlock) error {
 	return nil
 }
 
-func (vm *VM) GetDiskBlock(ctx context.Context, height uint64) (*chain.StatelessBlock, error) {
+func (vm *VM) GetDiskBlock(ctx context.Context, height uint64) (*chain.StatefulBlock, error) {
 	b, err := vm.vmDB.Get(PrefixBlockKey(height))
 	if err != nil {
 		return nil, err

--- a/vm/syncervm_client.go
+++ b/vm/syncervm_client.go
@@ -26,7 +26,7 @@ type stateSyncerClient struct {
 
 	// tracks the sync target so we can update last accepted
 	// block when sync completes.
-	target        *chain.StatelessBlock
+	target        *chain.StatefulBlock
 	targetUpdated bool
 
 	// State Sync results
@@ -110,7 +110,7 @@ func (s *stateSyncerClient) AcceptedSyncableBlock(
 	//
 	// MerkleDB will handle clearing any keys on-disk that are no
 	// longer necessary.
-	s.target = sb.StatelessBlock
+	s.target = sb.StatefulBlock
 	s.vm.snowCtx.Log.Info(
 		"starting state sync",
 		zap.Uint64("height", s.target.Hght),
@@ -257,7 +257,7 @@ func (s *stateSyncerClient) StateReady() bool {
 
 // UpdateSyncTarget returns a boolean indicating if the root was
 // updated and an error if one occurred while updating the root.
-func (s *stateSyncerClient) UpdateSyncTarget(b *chain.StatelessBlock) (bool, error) {
+func (s *stateSyncerClient) UpdateSyncTarget(b *chain.StatefulBlock) (bool, error) {
 	err := s.syncManager.UpdateSyncTarget(b.StateRoot)
 	if errors.Is(err, avasync.ErrAlreadyClosed) {
 		<-s.done          // Wait for goroutine to exit for consistent return values with IsSyncing

--- a/vm/syncervm_server.go
+++ b/vm/syncervm_server.go
@@ -28,7 +28,7 @@ func (vm *VM) GetStateSummary(ctx context.Context, height uint64) (block.StateSu
 	if err != nil {
 		return nil, err
 	}
-	block, err := vm.GetStatelessBlock(ctx, id)
+	block, err := vm.GetStatefulBlock(ctx, id)
 	if err != nil {
 		return nil, err
 	}

--- a/vm/verify_context.go
+++ b/vm/verify_context.go
@@ -28,7 +28,7 @@ func (vm *VM) GetVerifyContext(ctx context.Context, blockHeight uint64, parent i
 	// If the parent block is not yet accepted, we should return the block's processing parent (it may
 	// or may not be verified yet).
 	if blockHeight-1 > vm.lastAccepted.Hght {
-		blk, err := vm.GetStatelessBlock(ctx, parent)
+		blk, err := vm.GetStatefulBlock(ctx, parent)
 		if err != nil {
 			return nil, err
 		}
@@ -52,7 +52,7 @@ func (vm *VM) GetVerifyContext(ctx context.Context, blockHeight uint64, parent i
 }
 
 type PendingVerifyContext struct {
-	blk *chain.StatelessBlock
+	blk *chain.StatefulBlock
 }
 
 func (p *PendingVerifyContext) View(ctx context.Context, verify bool) (state.View, error) {

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -76,8 +76,8 @@ type VM struct {
 	options                    []Option
 	builder                    builder.Builder
 	gossiper                   gossiper.Gossiper
-	blockSubscriptionFactories []event.SubscriptionFactory[*chain.StatelessBlock]
-	blockSubscriptions         []event.Subscription[*chain.StatelessBlock]
+	blockSubscriptionFactories []event.SubscriptionFactory[*chain.StatefulBlock]
+	blockSubscriptions         []event.Subscription[*chain.StatefulBlock]
 	// TODO remove by returning an verification error from the submit tx api
 	txRemovedSubscriptionFactories []event.SubscriptionFactory[TxRemovedEvent]
 	txRemovedSubscriptions         []event.Subscription[TxRemovedEvent]
@@ -102,20 +102,20 @@ type VM struct {
 	seenValidityWindow     chan struct{}
 
 	// We cannot use a map here because we may parse blocks up in the ancestry
-	parsedBlocks *avacache.LRU[ids.ID, *chain.StatelessBlock]
+	parsedBlocks *avacache.LRU[ids.ID, *chain.StatefulBlock]
 
 	// Each element is a block that passed verification but
 	// hasn't yet been accepted/rejected
 	verifiedL      sync.RWMutex
-	verifiedBlocks map[ids.ID]*chain.StatelessBlock
+	verifiedBlocks map[ids.ID]*chain.StatefulBlock
 
 	// We store the last [AcceptedBlockWindowCache] blocks in memory
 	// to avoid reading blocks from disk.
-	acceptedBlocksByID     *cache.FIFO[ids.ID, *chain.StatelessBlock]
+	acceptedBlocksByID     *cache.FIFO[ids.ID, *chain.StatefulBlock]
 	acceptedBlocksByHeight *cache.FIFO[uint64, ids.ID]
 
 	// Accepted block queue
-	acceptedQueue chan *chain.StatelessBlock
+	acceptedQueue chan *chain.StatefulBlock
 	acceptorDone  chan struct{}
 
 	// authVerifiers are used to verify signatures in parallel
@@ -123,9 +123,9 @@ type VM struct {
 	authVerifiers workers.Workers
 
 	bootstrapped avautils.Atomic[bool]
-	genesisBlk   *chain.StatelessBlock
+	genesisBlk   *chain.StatefulBlock
 	preferred    ids.ID
-	lastAccepted *chain.StatelessBlock
+	lastAccepted *chain.StatefulBlock
 	toEngine     chan<- common.Message
 
 	// State Sync client and AppRequest handlers
@@ -300,9 +300,9 @@ func (vm *VM) Initialize(
 	// Init channels before initializing other structs
 	vm.toEngine = toEngine
 
-	vm.parsedBlocks = &avacache.LRU[ids.ID, *chain.StatelessBlock]{Size: vm.config.ParsedBlockCacheSize}
-	vm.verifiedBlocks = make(map[ids.ID]*chain.StatelessBlock)
-	vm.acceptedBlocksByID, err = cache.NewFIFO[ids.ID, *chain.StatelessBlock](vm.config.AcceptedBlockWindowCache)
+	vm.parsedBlocks = &avacache.LRU[ids.ID, *chain.StatefulBlock]{Size: vm.config.ParsedBlockCacheSize}
+	vm.verifiedBlocks = make(map[ids.ID]*chain.StatefulBlock)
+	vm.acceptedBlocksByID, err = cache.NewFIFO[ids.ID, *chain.StatefulBlock](vm.config.AcceptedBlockWindowCache)
 	if err != nil {
 		return err
 	}
@@ -318,7 +318,7 @@ func (vm *VM) Initialize(
 	if acceptedBlockWindow < MinAcceptedBlockWindow {
 		return fmt.Errorf("AcceptedBlockWindow (%d) must be >= to MinAcceptedBlockWindow (%d)", acceptedBlockWindow, MinAcceptedBlockWindow)
 	}
-	vm.acceptedQueue = make(chan *chain.StatelessBlock, vm.config.AcceptorSize)
+	vm.acceptedQueue = make(chan *chain.StatefulBlock, vm.config.AcceptorSize)
 	vm.acceptorDone = make(chan struct{})
 
 	vm.mempool = mempool.New[*chain.Transaction](vm.tracer, vm.config.MempoolSize, vm.config.MempoolSponsorSize)
@@ -368,7 +368,7 @@ func (vm *VM) Initialize(
 		snowCtx.Log.Info("genesis state created", zap.Stringer("root", root))
 
 		// Create genesis block
-		genesisBlk, err := chain.ParseStatefulBlock(
+		genesisBlk, err := chain.ParseStatelessBlock(
 			ctx,
 			chain.NewGenesisBlock(root),
 			nil,
@@ -715,11 +715,11 @@ func (vm *VM) GetBlock(ctx context.Context, id ids.ID) (snowman.Block, error) {
 	defer span.End()
 
 	// We purposely don't return parsed but unverified blocks from here
-	return vm.GetStatelessBlock(ctx, id)
+	return vm.GetStatefulBlock(ctx, id)
 }
 
-func (vm *VM) GetStatelessBlock(ctx context.Context, blkID ids.ID) (*chain.StatelessBlock, error) {
-	_, span := vm.tracer.Start(ctx, "VM.GetStatelessBlock")
+func (vm *VM) GetStatefulBlock(ctx context.Context, blkID ids.ID) (*chain.StatefulBlock, error) {
+	_, span := vm.tracer.Start(ctx, "VM.GetStatefulBlock")
 	defer span.End()
 
 	// Check if verified block
@@ -774,7 +774,7 @@ func (vm *VM) ParseBlock(ctx context.Context, source []byte) (snowman.Block, err
 
 	// If we have seen this block before, return it with the most
 	// up-to-date info
-	if oldBlk, err := vm.GetStatelessBlock(ctx, id); err == nil {
+	if oldBlk, err := vm.GetStatefulBlock(ctx, id); err == nil {
 		vm.snowCtx.Log.Debug("returning previously parsed block", zap.Stringer("id", oldBlk.ID()))
 		return oldBlk, nil
 	}
@@ -837,7 +837,7 @@ func (vm *VM) BuildBlock(ctx context.Context) (snowman.Block, error) {
 	}
 
 	// Build block and store as parsed
-	preferredBlk, err := vm.GetStatelessBlock(ctx, vm.preferred)
+	preferredBlk, err := vm.GetStatefulBlock(ctx, vm.preferred)
 	if err != nil {
 		vm.snowCtx.Log.Warn("unable to get preferred block", zap.Error(err))
 		return nil, err
@@ -870,7 +870,7 @@ func (vm *VM) Submit(
 	}
 
 	// Create temporary execution context
-	blk, err := vm.GetStatelessBlock(ctx, vm.preferred)
+	blk, err := vm.GetStatefulBlock(ctx, vm.preferred)
 	if err != nil {
 		return []error{err}
 	}
@@ -1161,7 +1161,7 @@ func (vm *VM) backfillSeenTransactions() {
 		}
 
 		// Set next blk in lookback
-		tblk, err := vm.GetStatelessBlock(context.Background(), blk.Prnt)
+		tblk, err := vm.GetStatefulBlock(context.Background(), blk.Prnt)
 		if err != nil {
 			vm.snowCtx.Log.Info("could not load block, exiting backfill",
 				zap.Uint64("height", blk.Height()-1),
@@ -1228,7 +1228,7 @@ func (vm *VM) restoreAcceptedQueue(ctx context.Context) error {
 			return fmt.Errorf("could not find accepted block at height %d: %w", height, err)
 		}
 
-		blk, err := vm.GetStatelessBlock(ctx, blkID)
+		blk, err := vm.GetStatefulBlock(ctx, blkID)
 		if err != nil {
 			return fmt.Errorf("could not find accepted block (%s) at height %d: %w", blkID, height, err)
 		}

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -29,8 +29,8 @@ func TestBlockCache(t *testing.T) {
 	defer ctrl.Finish()
 
 	// create a block with "Unknown" status
-	blk := &chain.StatelessBlock{
-		StatefulBlock: &chain.StatefulBlock{
+	blk := &chain.StatefulBlock{
+		StatelessBlock: &chain.StatelessBlock{
 			Prnt: ids.GenerateTestID(),
 			Hght: 10000,
 		},
@@ -38,7 +38,7 @@ func TestBlockCache(t *testing.T) {
 	blkID := blk.ID()
 
 	tracer, _ := trace.New(&trace.Config{Enabled: false})
-	bByID, _ := cache.NewFIFO[ids.ID, *chain.StatelessBlock](3)
+	bByID, _ := cache.NewFIFO[ids.ID, *chain.StatefulBlock](3)
 	bByHeight, _ := cache.NewFIFO[uint64, ids.ID](3)
 	rules := chain.NewMockRules(ctrl)
 	vm := VM{
@@ -50,10 +50,10 @@ func TestBlockCache(t *testing.T) {
 		acceptedBlocksByID:     bByID,
 		acceptedBlocksByHeight: bByHeight,
 
-		verifiedBlocks: make(map[ids.ID]*chain.StatelessBlock),
+		verifiedBlocks: make(map[ids.ID]*chain.StatefulBlock),
 		seen:           emap.NewEMap[*chain.Transaction](),
 		mempool:        mempool.New[*chain.Transaction](tracer, 100, 32),
-		acceptedQueue:  make(chan *chain.StatelessBlock, 1024), // don't block on queue
+		acceptedQueue:  make(chan *chain.StatefulBlock, 1024), // don't block on queue
 		ruleFactory:    &genesis.ImmutableRuleFactory{Rules: rules},
 	}
 
@@ -71,7 +71,7 @@ func TestBlockCache(t *testing.T) {
 
 	// we have not set up any persistent db
 	// so this must succeed from using cache
-	blk2, err := vm.GetStatelessBlock(ctx, blkID)
+	blk2, err := vm.GetStatefulBlock(ctx, blkID)
 	require.NoError(err)
 	require.Equal(blk, blk2)
 }


### PR DESCRIPTION
As per the title this PR fixes the naming convention of stateful/stateless blocks. Previously, these names were in reverse of what they were actually doing ie. stateful block was stateless and stateless block was stateful.

Additionally, this PR moves what was previously called StatefulBlock functions next to the other StatefulBlock functions within `chain/block.go`.