### PR TITLE
Reduce e2e test runtime by reducing tx check interval and reducing StateSyncMinBlocks for e2e setup

### DIFF
--- a/api/indexer/client.go
+++ b/api/indexer/client.go
@@ -6,6 +6,7 @@ package indexer
 import (
 	"context"
 	"strings"
+	"time"
 
 	"github.com/ava-labs/avalanchego/ids"
 
@@ -46,10 +47,10 @@ func (c *Client) GetTx(ctx context.Context, txID ids.ID) (GetTxResponse, bool, e
 	return resp, true, nil
 }
 
-func (c *Client) WaitForTransaction(ctx context.Context, txID ids.ID) (bool, uint64, error) {
+func (c *Client) WaitForTransaction(ctx context.Context, txCheckInterval time.Duration, txID ids.ID) (bool, uint64, error) {
 	var success bool
 	var fee uint64
-	if err := jsonrpc.Wait(ctx, func(ctx context.Context) (bool, error) {
+	if err := jsonrpc.Wait(ctx, txCheckInterval, func(ctx context.Context) (bool, error) {
 		response, found, err := c.GetTx(ctx, txID)
 		if err != nil {
 			return false, err

--- a/api/jsonrpc/client.go
+++ b/api/jsonrpc/client.go
@@ -18,10 +18,7 @@ import (
 	"github.com/ava-labs/hypersdk/utils"
 )
 
-const (
-	unitPricesCacheRefresh = 10 * time.Second
-	waitSleep              = 500 * time.Millisecond
-)
+const unitPricesCacheRefresh = 10 * time.Second
 
 type JSONRPCClient struct {
 	requester *requester.EndpointRequester
@@ -184,7 +181,7 @@ func (cli *JSONRPCClient) GenerateTransactionManual(
 	}, tx, nil
 }
 
-func Wait(ctx context.Context, check func(ctx context.Context) (bool, error)) error {
+func Wait(ctx context.Context, interval time.Duration, check func(ctx context.Context) (bool, error)) error {
 	for ctx.Err() == nil {
 		exit, err := check(ctx)
 		if err != nil {
@@ -193,7 +190,7 @@ func Wait(ctx context.Context, check func(ctx context.Context) (bool, error)) er
 		if exit {
 			return nil
 		}
-		time.Sleep(waitSleep)
+		time.Sleep(interval)
 	}
 	return ctx.Err()
 }

--- a/examples/morpheusvm/controller/client.go
+++ b/examples/morpheusvm/controller/client.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"strings"
+	"time"
 
 	"github.com/ava-labs/hypersdk/api/jsonrpc"
 	"github.com/ava-labs/hypersdk/chain"
@@ -17,6 +18,8 @@ import (
 	"github.com/ava-labs/hypersdk/requester"
 	"github.com/ava-labs/hypersdk/utils"
 )
+
+const balanceCheckInterval = 500 * time.Millisecond
 
 type JSONRPCClient struct {
 	requester *requester.EndpointRequester
@@ -68,7 +71,7 @@ func (cli *JSONRPCClient) WaitForBalance(
 	addr string,
 	min uint64,
 ) error {
-	return jsonrpc.Wait(ctx, func(ctx context.Context) (bool, error) {
+	return jsonrpc.Wait(ctx, balanceCheckInterval, func(ctx context.Context) (bool, error) {
 		balance, err := cli.Balance(ctx, addr)
 		if err != nil {
 			return false, err

--- a/examples/morpheusvm/tests/workload/workload.go
+++ b/examples/morpheusvm/tests/workload/workload.go
@@ -6,6 +6,7 @@ package workload
 import (
 	"context"
 	"math"
+	"time"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/stretchr/testify/require"
@@ -26,7 +27,10 @@ import (
 	"github.com/ava-labs/hypersdk/tests/workload"
 )
 
-const initialBalance uint64 = 10_000_000_000_000
+const (
+	initialBalance  uint64 = 10_000_000_000_000
+	txCheckInterval        = 10 * time.Millisecond
+)
 
 var (
 	_              workload.TxWorkloadFactory  = (*workloadFactory)(nil)
@@ -135,7 +139,7 @@ func (g *simpleTxWorkload) GenerateTxWithAssertion(ctx context.Context) (*chain.
 
 	return tx, func(ctx context.Context, require *require.Assertions, uri string) {
 		indexerCli := indexer.NewClient(uri)
-		success, _, err := indexerCli.WaitForTransaction(ctx, tx.ID())
+		success, _, err := indexerCli.WaitForTransaction(ctx, txCheckInterval, tx.ID())
 		require.NoError(err)
 		require.True(success)
 		lcli := controller.NewJSONRPCClient(uri)
@@ -232,7 +236,7 @@ func (g *mixedAuthWorkload) GenerateTxWithAssertion(ctx context.Context) (*chain
 
 	return tx, func(ctx context.Context, require *require.Assertions, uri string) {
 		indexerCli := indexer.NewClient(uri)
-		success, _, err := indexerCli.WaitForTransaction(ctx, tx.ID())
+		success, _, err := indexerCli.WaitForTransaction(ctx, txCheckInterval, tx.ID())
 		require.NoError(err)
 		require.True(success)
 		lcli := controller.NewJSONRPCClient(uri)

--- a/examples/morpheusvm/tests/workload/workload.go
+++ b/examples/morpheusvm/tests/workload/workload.go
@@ -29,7 +29,7 @@ import (
 
 const (
 	initialBalance  uint64 = 10_000_000_000_000
-	txCheckInterval        = 10 * time.Millisecond
+	txCheckInterval        = 100 * time.Millisecond
 )
 
 var (

--- a/tests/e2e/e2e.go
+++ b/tests/e2e/e2e.go
@@ -105,8 +105,8 @@ var _ = ginkgo.Describe("[HyperSDK Syncing]", func() {
 		ginkgo.By("Restart the node", func() {
 			require.NoError(e2e.GetEnv(tc).GetNetwork().RestartNode(tc.DefaultContext(), ginkgo.GinkgoWriter, bootstrapNode))
 		})
-		ginkgo.By("Generate 1024 blocks", func() {
-			workload.GenerateNBlocks(tc.ContextWithTimeout(20*time.Minute), require, uris, txWorkloadFactory, 1024)
+		ginkgo.By("Generate > StateSyncMinBlocks=512", func() {
+			workload.GenerateNBlocks(tc.ContextWithTimeout(20*time.Minute), require, uris, txWorkloadFactory, 512)
 		})
 		var (
 			syncNode    *tmpnet.Node

--- a/tests/fixture/subnet.go
+++ b/tests/fixture/subnet.go
@@ -24,7 +24,8 @@ func NewHyperVMSubnet(name string, vmID ids.ID, genesisBytes []byte, nodes ...*t
   					"transactionExecutionCores": 2,
   					"verifyAuth":true,
   					"streamingBacklogSize": 10000000,
-  					"stateSyncServerDelay": 100000000
+  					"stateSyncServerDelay": 100000000,
+					"stateSyncMinBlocks": 512
 				}`,
 			},
 		},

--- a/tests/workload/transactions.go
+++ b/tests/workload/transactions.go
@@ -14,6 +14,8 @@ import (
 	"github.com/ava-labs/hypersdk/utils"
 )
 
+const reachedAcceptedTipSleepInterval = 10 * time.Millisecond
+
 // TxWorkloadFactory prescribes an exact interface for generating transactions to test on a given environment
 // and a sized sequence of transactions to test on a given environment and reach a particular state
 type TxWorkloadFactory interface {
@@ -94,7 +96,7 @@ func GenerateNBlocks(ctx context.Context, require *require.Assertions, uris []st
 
 	for _, uri := range uris {
 		client := jsonrpc.NewJSONRPCClient(uri)
-		err := jsonrpc.Wait(ctx, func(ctx context.Context) (bool, error) {
+		err := jsonrpc.Wait(ctx, reachedAcceptedTipSleepInterval, func(ctx context.Context) (bool, error) {
 			_, acceptedHeight, _, err := client.Accepted(ctx)
 			if err != nil {
 				return false, err


### PR DESCRIPTION
This PR updates the existing functions with the syntax of `Wait[OptionalSuffix](ctx, ...)` to take an additional `time.Duration` argument that specifies the amount of time to wait between running a check condition.

This reduces wasted time during the e2e tests when we're checking for transaction confirmation (previously 500ms) even though once a transaction is produced, it takes ~10ms to build, distribute, and accept a block across the small local network used in tmpnet testing.

Additionally, this test sets `StateSyncMinBlocks` to 512 (avoiding getting too close to the validity window or state history length params) and reduces the number of blocks necessary to force a fall back to state sync from 1024 to 512 to reduce the state sync tests runtime.