### PR TITLE
Adding Setup Actions to `chaintest`

### DIFF
--- a/chaintest/action_test_helpers.go
+++ b/chaintest/action_test_helpers.go
@@ -57,7 +57,7 @@ type ActionTest struct {
 	// not tested against ExpectedOutputs and ExpectedErr, but they must not return an error.
 	// The last action in this array is tested against ExpectedOutputs and
 	// ExpectedErr
-	Actions       []chain.Action
+	Actions []chain.Action
 
 	Rules     chain.Rules
 	State     state.Mutable

--- a/chaintest/action_test_helpers.go
+++ b/chaintest/action_test_helpers.go
@@ -52,7 +52,8 @@ func (i *InMemoryStore) Remove(_ context.Context, key []byte) error {
 type ActionTest struct {
 	Name string
 
-	Action chain.Action
+	SetupActions []chain.Action
+	Action       chain.Action
 
 	Rules     chain.Rules
 	State     state.Mutable
@@ -70,6 +71,11 @@ type ActionTest struct {
 func (test *ActionTest) Run(ctx context.Context, t *testing.T) {
 	t.Run(test.Name, func(t *testing.T) {
 		require := require.New(t)
+
+		for _, act := range test.SetupActions {
+			_, err := act.Execute(ctx, test.Rules, test.State, test.Timestamp, test.Actor, test.ActionID)
+			require.NoError(err)
+		}
 
 		output, err := test.Action.Execute(ctx, test.Rules, test.State, test.Timestamp, test.Actor, test.ActionID)
 

--- a/examples/morpheusvm/actions/transfer_test.go
+++ b/examples/morpheusvm/actions/transfer_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/ava-labs/hypersdk/chain"
 	"github.com/ava-labs/hypersdk/chaintest"
 	"github.com/ava-labs/hypersdk/codec"
 	"github.com/ava-labs/hypersdk/codectest"
@@ -29,18 +30,22 @@ func TestTransferAction(t *testing.T) {
 		{
 			Name:  "ZeroTransfer",
 			Actor: codec.EmptyAddress,
-			Action: &Transfer{
-				To:    codec.EmptyAddress,
-				Value: 0,
+			Actions: []chain.Action{
+				&Transfer{
+					To:    codec.EmptyAddress,
+					Value: 0,
+				},
 			},
 			ExpectedErr: ErrOutputValueZero,
 		},
 		{
 			Name:  "InvalidStateKey",
 			Actor: codec.EmptyAddress,
-			Action: &Transfer{
-				To:    codec.EmptyAddress,
-				Value: 1,
+			Actions: []chain.Action{
+				&Transfer{
+					To:    codec.EmptyAddress,
+					Value: 1,
+				},
 			},
 			State:       ts.NewView(make(state.Keys), map[string][]byte{}),
 			ExpectedErr: tstate.ErrInvalidKeyOrPermission,
@@ -48,9 +53,11 @@ func TestTransferAction(t *testing.T) {
 		{
 			Name:  "NotEnoughBalance",
 			Actor: codec.EmptyAddress,
-			Action: &Transfer{
-				To:    codec.EmptyAddress,
-				Value: 1,
+			Actions: []chain.Action{
+				&Transfer{
+					To:    codec.EmptyAddress,
+					Value: 1,
+				},
 			},
 			State: func() state.Mutable {
 				keys := make(state.Keys)
@@ -63,9 +70,11 @@ func TestTransferAction(t *testing.T) {
 		{
 			Name:  "SelfTransfer",
 			Actor: codec.EmptyAddress,
-			Action: &Transfer{
-				To:    codec.EmptyAddress,
-				Value: 1,
+			Actions: []chain.Action{
+				&Transfer{
+					To:    codec.EmptyAddress,
+					Value: 1,
+				},
 			},
 			State: func() state.Mutable {
 				keys := make(state.Keys)
@@ -84,9 +93,11 @@ func TestTransferAction(t *testing.T) {
 		{
 			Name:  "OverflowBalance",
 			Actor: codec.EmptyAddress,
-			Action: &Transfer{
-				To:    codec.EmptyAddress,
-				Value: math.MaxUint64,
+			Actions: []chain.Action{
+				&Transfer{
+					To:    codec.EmptyAddress,
+					Value: math.MaxUint64,
+				},
 			},
 			State: func() state.Mutable {
 				keys := make(state.Keys)
@@ -100,9 +111,11 @@ func TestTransferAction(t *testing.T) {
 		{
 			Name:  "SimpleTransfer",
 			Actor: codec.EmptyAddress,
-			Action: &Transfer{
-				To:    addr,
-				Value: 1,
+			Actions: []chain.Action{
+				&Transfer{
+					To:    addr,
+					Value: 1,
+				},
 			},
 			State: func() state.Mutable {
 				keys := make(state.Keys)


### PR DESCRIPTION
This PR extends `ActionTest` by adding setup actions; these actions are executed prior to the action being tested.

For complex VMs, aiming for high coverage via integration tests of actions might require for these actions to be tested in a particular state; while this can be done by modifying the state passed into `ActionTest`, this inherently leads to duplicate code. Adding setup actions allows for developers to easily set up the state required for testing a particular action