### PR TITLE
Use newly stabalized "C-unwind" ABI string

### DIFF
--- a/x/programs/sdk-macros/src/lib.rs
+++ b/x/programs/sdk-macros/src/lib.rs
@@ -172,7 +172,7 @@ pub fn public(_: TokenStream, item: TokenStream) -> TokenStream {
             }
 
             #[no_mangle]
-            unsafe extern "C" fn #name(args: wasmlanche::HostPtr) {
+            unsafe extern "C-unwind" fn #name(args: wasmlanche::HostPtr) {
                 wasmlanche::register_panic();
 
                 let result = {

--- a/x/programs/wasmlanche/src/memory.rs
+++ b/x/programs/wasmlanche/src/memory.rs
@@ -69,7 +69,7 @@ impl HostPtr {
 /// # Panics
 /// Panics if the pointer exceeds the maximum size of an isize or that the allocated memory is null.
 #[no_mangle]
-extern "C" fn alloc(len: usize) -> HostPtr {
+extern "C-unwind" fn alloc(len: usize) -> HostPtr {
     assert!(len > 0, "cannot allocate 0 sized data");
     // can only fail if `len > isize::MAX` for u8
     let layout = Layout::array::<u8>(len).expect("capacity overflow");
@@ -172,7 +172,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     #[should_panic = "cannot allocate 0 sized data"]
     fn zero_allocation_panics() {
         alloc(0);

--- a/x/programs/wasmlanche/tests/wasmtime-integration.rs
+++ b/x/programs/wasmlanche/tests/wasmtime-integration.rs
@@ -31,7 +31,8 @@ fn public_functions() {
 }
 
 #[test]
-#[should_panic]
+// the failure message is from the `expect` in this file
+#[should_panic = "failed to allocate memory"]
 fn allocate_zero() {
     let mut test_crate = build_test_crate();
     let result = test_crate.allocate(Vec::new());


### PR DESCRIPTION
This should be used for any `extern` functions that panic

Closes #1507
