### PR TITLE
Rely on build-script for setting the crate-type

### DIFF
--- a/x/programs/examples/automated-market-maker/Cargo.toml
+++ b/x/programs/examples/automated-market-maker/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [lib]
-crate-type = ["cdylib"]
 
 [dependencies]
 token = { path = "../token", features = ["bindings"] }

--- a/x/programs/examples/counter-external/Cargo.toml
+++ b/x/programs/examples/counter-external/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [lib]
-crate-type = ["cdylib"]
 
 [dependencies]
 wasmlanche = { workspace = true, features = ["debug"] }

--- a/x/programs/examples/counter/Cargo.toml
+++ b/x/programs/examples/counter/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [lib]
-crate-type = ["cdylib", "lib"]
+crate-type = ["lib"]
 
 [features]
 bindings = ["wasmlanche/bindings"]

--- a/x/programs/examples/token/Cargo.toml
+++ b/x/programs/examples/token/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [lib]
-crate-type = ["cdylib", "lib"]
+crate-type = ["lib"]
 
 [dependencies]
 wasmlanche = { workspace = true, features = ["debug"] }


### PR DESCRIPTION
The normal case for building is to build on the current target (for integration and unit testing), and rely on the build-scripts to build the wasm binaries. The build script already chooses the proper crate-type. If you want to build as a `cdylib`, you can use `cargo rustc`.

This allows developers to run `cargo test -p counter` for example without getting a bunch of linking errors. Prior to this, you could run `cargo test -p counter --lib`, but you no longer need to add that extra specification.