### PR TITLE
Remove Controller Reference from `cmd/morpheusvm`

### DIFF
--- a/examples/morpheusvm/cmd/morpheusvm/main.go
+++ b/examples/morpheusvm/cmd/morpheusvm/main.go
@@ -47,9 +47,9 @@ func runFunc(*cobra.Command, []string) error {
 		return fmt.Errorf("%w: failed to set fd limit correctly", err)
 	}
 
-	controller, err := vm.New()
+	vm, err := vm.New()
 	if err != nil {
 		return err
 	}
-	return rpcchainvm.Serve(context.TODO(), controller)
+	return rpcchainvm.Serve(context.TODO(), vm)
 }


### PR DESCRIPTION
Since the concept of the controller has been mostly removed from MorpheusVM, this PR renames `controller` to `vm` in `cmd/morpheusvm`. This change in variable name better reflects `rpcchainvm.Serve()` which has the following header:

`func rpcchainvm.Serve(ctx context.Context, vm block.ChainVM, opts ...grpcutils.ServerOption) error`