### PR TITLE
Expose Program as Child of Runtime

### DIFF
--- a/x/programs/runtime/import_balance_test.go
+++ b/x/programs/runtime/import_balance_test.go
@@ -18,7 +18,9 @@ func TestImportBalanceSendBalanceToAnotherProgram(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	program, err := newTestProgram(ctx, "balance")
+
+	rt := newTestRuntime(ctx)
+	program, err := rt.newTestProgram("balance")
 	require.NoError(err)
 
 	r := program.Runtime
@@ -54,7 +56,8 @@ func TestImportBalanceGetBalance(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	actor := codec.CreateAddress(0, ids.GenerateTestID())
-	program, err := newTestProgram(ctx, "balance")
+	rt := newTestRuntime(ctx)
+	program, err := rt.newTestProgram("balance")
 	require.NoError(err)
 	program.Runtime.StateManager.(TestStateManager).Balances[actor] = 3
 	result, err := program.WithActor(actor).Call("balance")
@@ -68,7 +71,8 @@ func TestImportBalanceSend(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	actor := codec.CreateAddress(0, ids.GenerateTestID())
-	program, err := newTestProgram(ctx, "balance")
+	rt := newTestRuntime(ctx)
+	program, err := rt.newTestProgram("balance")
 	require.NoError(err)
 
 	program.Runtime.StateManager.(TestStateManager).Balances[program.Address] = 3

--- a/x/programs/runtime/import_program_test.go
+++ b/x/programs/runtime/import_program_test.go
@@ -19,12 +19,13 @@ func TestImportProgramDeployProgram(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	program, err := newTestProgram(ctx, "deploy_program")
+	rt := newTestRuntime(ctx)
+	program, err := rt.newTestProgram("deploy_program")
 	require.NoError(err)
 
 	runtime := program.Runtime
 	otherProgramID := ids.GenerateTestID()
-	err = runtime.AddProgram(otherProgramID[:], "call_program")
+	err = runtime.AddProgram(otherProgramID[:], codec.CreateAddress(0, otherProgramID) , "call_program")
 	require.NoError(err)
 
 	result, err := program.Call(
@@ -45,7 +46,8 @@ func TestImportProgramCallProgram(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	program, err := newTestProgram(ctx, "call_program")
+	rt := newTestRuntime(ctx)
+	program, err := rt.newTestProgram("call_program")
 	require.NoError(err)
 
 	expected, err := Serialize(0)
@@ -68,7 +70,8 @@ func TestImportProgramCallProgramActor(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	program, err := newTestProgram(ctx, "call_program")
+	rt := newTestRuntime(ctx)
+	program, err := rt.newTestProgram("call_program")
 	require.NoError(err)
 	actor := codec.CreateAddress(1, ids.GenerateTestID())
 
@@ -85,7 +88,8 @@ func TestImportProgramCallProgramActorChange(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	program, err := newTestProgram(ctx, "call_program")
+	rt := newTestRuntime(ctx)
+	program, err := rt.newTestProgram("call_program")
 	require.NoError(err)
 	actor := codec.CreateAddress(1, ids.GenerateTestID())
 
@@ -104,7 +108,8 @@ func TestImportProgramCallProgramWithParam(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	program, err := newTestProgram(ctx, "call_program")
+	rt := newTestRuntime(ctx)
+	program, err := rt.newTestProgram("call_program")
 	require.NoError(err)
 
 	expected, err := Serialize(uint64(1))
@@ -129,7 +134,8 @@ func TestImportProgramCallProgramWithParams(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	program, err := newTestProgram(ctx, "call_program")
+	rt := newTestRuntime(ctx)
+	program, err := rt.newTestProgram("call_program")
 	require.NoError(err)
 
 	expected, err := Serialize(int64(3))
@@ -155,7 +161,8 @@ func TestImportGetRemainingFuel(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	program, err := newTestProgram(ctx, "fuel")
+	rt := newTestRuntime(ctx)
+	program, err := rt.newTestProgram("fuel")
 	require.NoError(err)
 
 	result, err := program.Call("get_fuel")
@@ -169,7 +176,8 @@ func TestImportOutOfFuel(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	program, err := newTestProgram(ctx, "fuel")
+	rt := newTestRuntime(ctx)
+	program, err := rt.newTestProgram("fuel")
 	require.NoError(err)
 
 	result, err := program.Call("out_of_fuel", program.Address)

--- a/x/programs/runtime/import_program_test.go
+++ b/x/programs/runtime/import_program_test.go
@@ -25,7 +25,7 @@ func TestImportProgramDeployProgram(t *testing.T) {
 
 	runtime := program.Runtime
 	otherProgramID := ids.GenerateTestID()
-	err = runtime.AddProgram(otherProgramID[:], "call_program")
+	err = runtime.AddProgram(otherProgramID[:], codec.CreateAddress(0, otherProgramID), "call_program")
 	require.NoError(err)
 
 	result, err := program.Call(

--- a/x/programs/runtime/import_program_test.go
+++ b/x/programs/runtime/import_program_test.go
@@ -25,7 +25,7 @@ func TestImportProgramDeployProgram(t *testing.T) {
 
 	runtime := program.Runtime
 	otherProgramID := ids.GenerateTestID()
-	err = runtime.AddProgram(otherProgramID[:], codec.CreateAddress(0, otherProgramID) , "call_program")
+	err = runtime.AddProgram(otherProgramID[:], "call_program")
 	require.NoError(err)
 
 	result, err := program.Call(

--- a/x/programs/runtime/import_state_test.go
+++ b/x/programs/runtime/import_state_test.go
@@ -80,7 +80,7 @@ func TestImportStateGetMissingKey(t *testing.T) {
 	defer cancel()
 
 	rt := newTestRuntime(ctx)
-	program, err := rt.newTestProgram( "state_access")
+	program, err := rt.newTestProgram("state_access")
 	require.NoError(err)
 
 	result, err := program.Call("get")

--- a/x/programs/runtime/import_state_test.go
+++ b/x/programs/runtime/import_state_test.go
@@ -17,7 +17,8 @@ func TestImportStatePutGet(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	program, err := newTestProgram(ctx, "state_access")
+	rt := newTestRuntime(ctx)
+	program, err := rt.newTestProgram("state_access")
 	require.NoError(err)
 
 	result, err := program.Call("put", int64(10))
@@ -37,7 +38,8 @@ func TestImportStateRemove(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	program, err := newTestProgram(ctx, "state_access")
+	rt := newTestRuntime(ctx)
+	program, err := rt.newTestProgram("state_access")
 	require.NoError(err)
 
 	valueBytes, err := borsh.Serialize(int64(10))
@@ -62,7 +64,8 @@ func TestImportStateDeleteMissingKey(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	program, err := newTestProgram(ctx, "state_access")
+	rt := newTestRuntime(ctx)
+	program, err := rt.newTestProgram("state_access")
 	require.NoError(err)
 
 	result, err := program.Call("delete")
@@ -76,7 +79,8 @@ func TestImportStateGetMissingKey(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	program, err := newTestProgram(ctx, "state_access")
+	rt := newTestRuntime(ctx)
+	program, err := rt.newTestProgram( "state_access")
 	require.NoError(err)
 
 	result, err := program.Call("get")

--- a/x/programs/runtime/runtime_test.go
+++ b/x/programs/runtime/runtime_test.go
@@ -19,7 +19,8 @@ func BenchmarkRuntimeCallProgramBasic(b *testing.B) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	program, err := newTestProgram(ctx, "simple")
+	rt := newTestRuntime(ctx)
+	program, err := rt.newTestProgram("simple")
 	require.NoError(err)
 
 	for i := 0; i < b.N; i++ {
@@ -35,7 +36,8 @@ func TestRuntimeCallProgramBasicAttachValue(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	program, err := newTestProgram(ctx, "simple")
+	rt := newTestRuntime(ctx)
+	program, err := rt.newTestProgram("simple")
 	require.NoError(err)
 
 	actor := codec.CreateAddress(0, ids.GenerateTestID())
@@ -65,7 +67,8 @@ func TestRuntimeCallProgramBasic(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	program, err := newTestProgram(ctx, "simple")
+	rt := newTestRuntime(ctx)
+	program, err := rt.newTestProgram("simple")
 	require.NoError(err)
 
 	result, err := program.Call("get_value")
@@ -84,7 +87,8 @@ func TestRuntimeCallProgramComplexReturn(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	program, err := newTestProgram(ctx, "return_complex_type")
+	rt := newTestRuntime(ctx)
+	program, err := rt.newTestProgram("return_complex_type")
 	require.NoError(err)
 
 	result, err := program.Call("get_value")

--- a/x/programs/runtime/util_test.go
+++ b/x/programs/runtime/util_test.go
@@ -189,16 +189,14 @@ func (t *testRuntime) WithValue(value uint64) *testRuntime {
 	return t
 }
 
-// AddProgram compiles [programName] and sets the bytes and account in the state manager
-func (t *testRuntime) AddProgram(programID ProgramID, account codec.Address, programName string) error {
-	err := t.StateManager.(TestStateManager).CompileAndSetProgram(programID, programName)
-	if err != nil {
-		return err
-	}
+// AddProgram compiles [programName] and sets the bytes in the state manager
+func (t *testRuntime) AddProgram(programID ProgramID, programName string) error {
+	return t.StateManager.(TestStateManager).CompileAndSetProgram(programID, programName)
+}
 
+// AddProgramInstance sets creates a new account with the program [programID]
+func (t *testRuntime) AddProgramInstance(programID ProgramID, account codec.Address) {
 	t.StateManager.(TestStateManager).AccountMap[account] = string(programID)
-
-	return nil
 }
 
 func (t *testRuntime) CallProgram(program codec.Address, function string, params ...interface{}) ([]byte, error) {
@@ -236,10 +234,11 @@ func (t *testRuntime) newTestProgram(program string) (*testProgram, error) {
 		Runtime: t,
 	}
 
-	err := t.AddProgram(ProgramID(stringedID),account, program)
+	err := t.AddProgram(ProgramID(stringedID), program)
 	if err != nil {
 		return nil, err
 	}
+	t.AddProgramInstance(ProgramID(stringedID), account)
 
 	return testProgram, nil
 }

--- a/x/programs/runtime/util_test.go
+++ b/x/programs/runtime/util_test.go
@@ -194,7 +194,7 @@ func (t *testRuntime) AddProgram(programID ProgramID, programName string) error 
 	return t.StateManager.(TestStateManager).CompileAndSetProgram(programID, programName)
 }
 
-// AddProgramInstance sets creates a new account with the program [programID]
+// AddProgramInstance creates a new account with the program [programID]
 func (t *testRuntime) AddProgramInstance(programID ProgramID, account codec.Address) {
 	t.StateManager.(TestStateManager).AccountMap[account] = string(programID)
 }

--- a/x/programs/runtime/util_test.go
+++ b/x/programs/runtime/util_test.go
@@ -190,13 +190,14 @@ func (t *testRuntime) WithValue(value uint64) *testRuntime {
 }
 
 // AddProgram compiles [programName] and sets the bytes in the state manager
-func (t *testRuntime) AddProgram(programID ProgramID, programName string) error {
-	return t.StateManager.(TestStateManager).CompileAndSetProgram(programID, programName)
-}
+func (t *testRuntime) AddProgram(programID ProgramID, account codec.Address, programName string) error {
+	err := t.StateManager.(TestStateManager).CompileAndSetProgram(programID, programName)
+	if err != nil {
+		return err
+	}
 
-// AddProgramInstance creates a new account with the program [programID]
-func (t *testRuntime) AddProgramInstance(programID ProgramID, account codec.Address) {
 	t.StateManager.(TestStateManager).AccountMap[account] = string(programID)
+	return nil
 }
 
 func (t *testRuntime) CallProgram(program codec.Address, function string, params ...interface{}) ([]byte, error) {
@@ -234,11 +235,10 @@ func (t *testRuntime) newTestProgram(program string) (*testProgram, error) {
 		Runtime: t,
 	}
 
-	err := t.AddProgram(ProgramID(stringedID), program)
+	err := t.AddProgram(ProgramID(stringedID), account, program)
 	if err != nil {
 		return nil, err
 	}
-	t.AddProgramInstance(ProgramID(stringedID), account)
 
 	return testProgram, nil
 }


### PR DESCRIPTION
programs should be children of runtime as a runtime can hold multiple programs