### PR TITLE
Ignore `target` dir when checking for license

### DIFF
--- a/scripts/common/utils.sh
+++ b/scripts/common/utils.sh
@@ -58,5 +58,7 @@ function add_license_headers() {
   echo "${action} license headers"
 
   # Find and process files with the specified extensions
-  find . -type f \( -name "*.go" -o -name "*.rs" -o -name "*.sh" \) -print0 | xargs -0 addlicense "${args[@]}"
+  file_args="$(find . -type f \( -name "*.go" -o -name "*.rs" -o -name "*.sh" \) | grep -v "^./target/" | xargs)"
+
+  addlicense "${file_args}"
 }


### PR DESCRIPTION
This is necessary for running the script locally
