### PR TITLE
Fix immutable state implementation

### DIFF
--- a/vm/resolutions.go
+++ b/vm/resolutions.go
@@ -23,7 +23,9 @@ import (
 	"github.com/ava-labs/hypersdk/internal/builder"
 	"github.com/ava-labs/hypersdk/internal/executor"
 	"github.com/ava-labs/hypersdk/internal/gossiper"
+	"github.com/ava-labs/hypersdk/internal/state/tstate"
 	"github.com/ava-labs/hypersdk/internal/workers"
+	"github.com/ava-labs/hypersdk/state"
 
 	internalfees "github.com/ava-labs/hypersdk/internal/fees"
 )
@@ -86,6 +88,15 @@ func (vm *VM) State() (merkledb.MerkleDB, error) {
 		return nil, ErrStateMissing
 	}
 	return vm.stateDB, nil
+}
+
+func (vm *VM) ImmutableState(ctx context.Context) (state.Immutable, error) {
+	ts := tstate.New(0)
+	state, err := vm.State()
+	if err != nil {
+		return nil, err
+	}
+	return ts.ExportMerkleDBView(ctx, vm.tracer, state)
 }
 
 func (vm *VM) Mempool() chain.Mempool {

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -144,13 +144,6 @@ type VM struct {
 	stop  chan struct{}
 }
 
-// TODO: update VM ImmutableState to return an isolated trie view instead of
-// reading directly from the on-disk view, which may change mid operation.
-// ref. https://github.com/ava-labs/avalanchego/pull/3358/files
-func (vm *VM) ImmutableState(_ context.Context) (state.Immutable, error) {
-	return vm.State()
-}
-
 func New(
 	v *version.Semantic,
 	genesisFactory genesis.GenesisAndRuleFactory,


### PR DESCRIPTION
This PR updates the `ImmutableState` function so that:
- it returns a view of the last accepted state that becomes invalid when the state changes instead of silently allowing corruption
- Moves the implementation to `resolutions.go`