### PR TITLE
Rename option specific config to services

### DIFF
--- a/tests/integration/integration.go
+++ b/tests/integration/integration.go
@@ -158,19 +158,19 @@ func setInstances() {
 		_ = listener.Close()
 	})
 
-	externalSubscriberConfig := vm.NewConfig()
-	namespacedConfig := map[string]interface{}{
-		externalsubscriber.Namespace: externalsubscriber.Config{
-			Enabled:       true,
-			ServerAddress: listener.Addr().String(),
-		},
+	vmWithExternalSubscriberConfig := vm.NewConfig()
+	actualExternalSubscriberConfig := externalsubscriber.Config{
+		Enabled:       true,
+		ServerAddress: listener.Addr().String(),
 	}
-
-	namespacedConfigBytes, err := json.Marshal(namespacedConfig)
+	actualExternalSubscriberConfigBytes, err := json.Marshal(actualExternalSubscriberConfig)
 	require.NoError(err)
-	externalSubscriberConfig.Config = namespacedConfigBytes
+	namespacedConfig := map[string]json.RawMessage{
+		externalsubscriber.Namespace: actualExternalSubscriberConfigBytes,
+	}
+	vmWithExternalSubscriberConfig.ServiceConfig = namespacedConfig
 
-	externalSubscriberConfigBytes, err := json.Marshal(externalSubscriberConfig)
+	externalSubscriberConfigBytes, err := json.Marshal(vmWithExternalSubscriberConfig)
 	require.NoError(err)
 	configs := make([][]byte, numVMs)
 	configs[0] = externalSubscriberConfigBytes

--- a/vm/config.go
+++ b/vm/config.go
@@ -1,0 +1,73 @@
+// Copyright (C) 2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package vm
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/ava-labs/avalanchego/utils/profiler"
+	"github.com/ava-labs/avalanchego/utils/units"
+
+	"github.com/ava-labs/hypersdk/internal/trace"
+)
+
+type Config struct {
+	TraceConfig                      trace.Config               `json:"traceConfig"`
+	MempoolSize                      int                        `json:"mempoolSize"`
+	AuthVerificationCores            int                        `json:"authVerificationCores"`
+	VerifyAuth                       bool                       `json:"verifyAuth"`
+	RootGenerationCores              int                        `json:"rootGenerationCores"`
+	TransactionExecutionCores        int                        `json:"transactionExecutionCores"`
+	StateFetchConcurrency            int                        `json:"stateFetchConcurrency"`
+	MempoolSponsorSize               int                        `json:"mempoolSponsorSize"`
+	StateHistoryLength               int                        `json:"stateHistoryLength"`               // how many roots back of data to keep to serve state queries
+	IntermediateNodeCacheSize        int                        `json:"intermediateNodeCacheSize"`        // how many bytes to keep in intermediate cache
+	StateIntermediateWriteBufferSize int                        `json:"stateIntermediateWriteBufferSize"` // how many bytes to keep unwritten in intermediate cache
+	StateIntermediateWriteBatchSize  int                        `json:"stateIntermediateWriteBatchSize"`  // how many bytes to write from intermediate cache at once
+	ValueNodeCacheSize               int                        `json:"valueNodeCacheSize"`               // how many bytes to keep in value cache
+	AcceptorSize                     int                        `json:"acceptorSize"`                     // how far back we can fall in processing accepted blocks
+	StateSyncParallelism             int                        `json:"stateSyncParallelism"`
+	StateSyncMinBlocks               uint64                     `json:"stateSyncMinBlocks"`
+	StateSyncServerDelay             time.Duration              `json:"stateSyncServerDelay"`
+	ParsedBlockCacheSize             int                        `json:"parsedBlockCacheSize"`
+	AcceptedBlockWindow              int                        `json:"acceptedBlockWindow"`
+	AcceptedBlockWindowCache         int                        `json:"acceptedBlockWindowCache"`
+	ContinuousProfilerConfig         profiler.Config            `json:"continuousProfilerConfig"`
+	TargetBuildDuration              time.Duration              `json:"targetBuildDuration"`
+	ProcessingBuildSkip              int                        `json:"processingBuildSkip"`
+	TargetGossipDuration             time.Duration              `json:"targetGossipDuration"`
+	BlockCompactionFrequency         int                        `json:"blockCompactionFrequency"`
+	ServiceConfig                    map[string]json.RawMessage `json:"services"` // Config of service namespace -> raw service config
+}
+
+func NewConfig() Config {
+	return Config{
+		TraceConfig:                      trace.Config{Enabled: false},
+		MempoolSize:                      2_048,
+		AuthVerificationCores:            1,
+		VerifyAuth:                       true,
+		RootGenerationCores:              1,
+		TransactionExecutionCores:        1,
+		StateFetchConcurrency:            1,
+		MempoolSponsorSize:               32,
+		StateHistoryLength:               256,
+		IntermediateNodeCacheSize:        4 * units.GiB,
+		StateIntermediateWriteBufferSize: 32 * units.MiB,
+		StateIntermediateWriteBatchSize:  4 * units.MiB,
+		ValueNodeCacheSize:               2 * units.GiB,
+		AcceptorSize:                     64,
+		StateSyncParallelism:             4,
+		StateSyncMinBlocks:               768, // set to max int for archive nodes to ensure no skips
+		StateSyncServerDelay:             0,   // used for testing
+		ParsedBlockCacheSize:             128,
+		AcceptedBlockWindow:              50_000, // ~3.5hr with 250ms block time (100GB at 2MB)
+		AcceptedBlockWindowCache:         128,    // 256MB at 2MB blocks
+		ContinuousProfilerConfig:         profiler.Config{Enabled: false},
+		TargetBuildDuration:              100 * time.Millisecond,
+		ProcessingBuildSkip:              16,
+		TargetGossipDuration:             20 * time.Millisecond,
+		BlockCompactionFrequency:         32, // 64 MB of deletion if 2 MB blocks
+	}
+}

--- a/vm/dependencies.go
+++ b/vm/dependencies.go
@@ -4,76 +4,10 @@
 package vm
 
 import (
-	"encoding/json"
-	"time"
-
 	"github.com/ava-labs/avalanchego/ids"
-	"github.com/ava-labs/avalanchego/utils/profiler"
-	"github.com/ava-labs/avalanchego/utils/units"
 
 	"github.com/ava-labs/hypersdk/chain"
-	"github.com/ava-labs/hypersdk/internal/trace"
 )
-
-type Config struct {
-	TraceConfig                      trace.Config    `json:"traceConfig"`
-	MempoolSize                      int             `json:"mempoolSize"`
-	AuthVerificationCores            int             `json:"authVerificationCores"`
-	VerifyAuth                       bool            `json:"verifyAuth"`
-	RootGenerationCores              int             `json:"rootGenerationCores"`
-	TransactionExecutionCores        int             `json:"transactionExecutionCores"`
-	StateFetchConcurrency            int             `json:"stateFetchConcurrency"`
-	MempoolSponsorSize               int             `json:"mempoolSponsorSize"`
-	StateHistoryLength               int             `json:"stateHistoryLength"`               // how many roots back of data to keep to serve state queries
-	IntermediateNodeCacheSize        int             `json:"intermediateNodeCacheSize"`        // how many bytes to keep in intermediate cache
-	StateIntermediateWriteBufferSize int             `json:"stateIntermediateWriteBufferSize"` // how many bytes to keep unwritten in intermediate cache
-	StateIntermediateWriteBatchSize  int             `json:"stateIntermediateWriteBatchSize"`  // how many bytes to write from intermediate cache at once
-	ValueNodeCacheSize               int             `json:"valueNodeCacheSize"`               // how many bytes to keep in value cache
-	AcceptorSize                     int             `json:"acceptorSize"`                     // how far back we can fall in processing accepted blocks
-	StateSyncParallelism             int             `json:"stateSyncParallelism"`
-	StateSyncMinBlocks               uint64          `json:"stateSyncMinBlocks"`
-	StateSyncServerDelay             time.Duration   `json:"stateSyncServerDelay"`
-	ParsedBlockCacheSize             int             `json:"parsedBlockCacheSize"`
-	AcceptedBlockWindow              int             `json:"acceptedBlockWindow"`
-	AcceptedBlockWindowCache         int             `json:"acceptedBlockWindowCache"`
-	ContinuousProfilerConfig         profiler.Config `json:"continuousProfilerConfig"`
-	TargetBuildDuration              time.Duration   `json:"targetBuildDuration"`
-	ProcessingBuildSkip              int             `json:"processingBuildSkip"`
-	TargetGossipDuration             time.Duration   `json:"targetGossipDuration"`
-	BlockCompactionFrequency         int             `json:"blockCompactionFrequency"`
-	// Config is defined by the Controller
-	Config json.RawMessage `json:"config"`
-}
-
-func NewConfig() Config {
-	return Config{
-		TraceConfig:                      trace.Config{Enabled: false},
-		MempoolSize:                      2_048,
-		AuthVerificationCores:            1,
-		VerifyAuth:                       true,
-		RootGenerationCores:              1,
-		TransactionExecutionCores:        1,
-		StateFetchConcurrency:            1,
-		MempoolSponsorSize:               32,
-		StateHistoryLength:               256,
-		IntermediateNodeCacheSize:        4 * units.GiB,
-		StateIntermediateWriteBufferSize: 32 * units.MiB,
-		StateIntermediateWriteBatchSize:  4 * units.MiB,
-		ValueNodeCacheSize:               2 * units.GiB,
-		AcceptorSize:                     64,
-		StateSyncParallelism:             4,
-		StateSyncMinBlocks:               768, // set to max int for archive nodes to ensure no skips
-		StateSyncServerDelay:             0,   // used for testing
-		ParsedBlockCacheSize:             128,
-		AcceptedBlockWindow:              50_000, // ~3.5hr with 250ms block time (100GB at 2MB)
-		AcceptedBlockWindowCache:         128,    // 256MB at 2MB blocks
-		ContinuousProfilerConfig:         profiler.Config{Enabled: false},
-		TargetBuildDuration:              100 * time.Millisecond,
-		ProcessingBuildSkip:              16,
-		TargetGossipDuration:             20 * time.Millisecond,
-		BlockCompactionFrequency:         32, // 64 MB of deletion if 2 MB blocks
-	}
-}
 
 type AuthEngine interface {
 	GetBatchVerifier(cores int, count int) chain.AuthBatchVerifier

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -249,15 +249,8 @@ func (vm *VM) Initialize(
 	vm.builder = builder.NewTime(vm)
 	vm.gossiper = txGossiper
 
-	namespacedConfig := make(map[string]json.RawMessage)
-	if len(vm.config.Config) > 0 {
-		if err := json.Unmarshal(vm.config.Config, &namespacedConfig); err != nil {
-			return fmt.Errorf("failed to unmarshal namespaced config: %w", err)
-		}
-	}
-
 	for _, Option := range vm.options {
-		config := namespacedConfig[Option.Namespace]
+		config := vm.config.ServiceConfig[Option.Namespace]
 		if err := Option.optionFunc(vm, config); err != nil {
 			return err
 		}


### PR DESCRIPTION
This PR renames the VM-specific config from `config` to `services` so that it's specific to the optional services added to the VM.