### PR TITLE
Name network return values to make it easier for callers to know the output

### DIFF
--- a/api/jsonrpc/client.go
+++ b/api/jsonrpc/client.go
@@ -49,13 +49,13 @@ func (cli *JSONRPCClient) Ping(ctx context.Context) (bool, error) {
 	return resp.Success, err
 }
 
-func (cli *JSONRPCClient) Network(ctx context.Context) (uint32, ids.ID, ids.ID, error) {
+func (cli *JSONRPCClient) Network(ctx context.Context) (networkID uint32, subnetID ids.ID, chainID ids.ID, err error) {
 	if cli.chainID != ids.Empty {
 		return cli.networkID, cli.subnetID, cli.chainID, nil
 	}
 
 	resp := new(NetworkReply)
-	err := cli.requester.SendRequest(
+	err = cli.requester.SendRequest(
 		ctx,
 		"network",
 		nil,


### PR DESCRIPTION
This PR updates the `Network` jsonrpc client function to name each output. This is helpful for this call because it returns many output values including two `ids.ID` values for the `subnetID` and `blockchainID` which the caller otherwise may need to check how it's used elsewhere or refer back to the implementation to see what each of the returned values are.