### PR TITLE
Update action Execute return type to single byte slice

### DIFF
--- a/chain/chaintest/action_test_helpers.go
+++ b/chain/chaintest/action_test_helpers.go
@@ -60,7 +60,7 @@ type ActionTest struct {
 	Actor     codec.Address
 	ActionID  ids.ID
 
-	ExpectedOutputs [][]byte
+	ExpectedOutputs []byte
 	ExpectedErr     error
 
 	Assertion func(context.Context, *testing.T, state.Mutable)

--- a/chain/dependencies.go
+++ b/chain/dependencies.go
@@ -243,7 +243,7 @@ type Action interface {
 		timestamp int64,
 		actor codec.Address,
 		actionID ids.ID,
-	) (result []byte, err error)
+	) ([]byte, error)
 }
 
 type Auth interface {

--- a/chain/dependencies.go
+++ b/chain/dependencies.go
@@ -243,7 +243,7 @@ type Action interface {
 		timestamp int64,
 		actor codec.Address,
 		actionID ids.ID,
-	) (outputs [][]byte, err error)
+	) (result []byte, err error)
 }
 
 type Auth interface {

--- a/chain/result.go
+++ b/chain/result.go
@@ -13,7 +13,7 @@ type Result struct {
 	Success bool
 	Error   []byte
 
-	Outputs [][][]byte
+	Outputs [][]byte
 
 	// Computing [Units] requires access to [StateManager], so it is returned
 	// to make life easier for indexers.
@@ -23,11 +23,8 @@ type Result struct {
 
 func (r *Result) Size() int {
 	outputSize := consts.Uint8Len // actions
-	for _, action := range r.Outputs {
-		outputSize += consts.Uint8Len
-		for _, output := range action {
-			outputSize += codec.BytesLen(output)
-		}
+	for _, actionOutput := range r.Outputs {
+		outputSize += codec.BytesLen(actionOutput)
 	}
 	return consts.BoolLen + codec.BytesLen(r.Error) + outputSize + fees.DimensionsLen + consts.Uint64Len
 }
@@ -36,11 +33,8 @@ func (r *Result) Marshal(p *codec.Packer) error {
 	p.PackBool(r.Success)
 	p.PackBytes(r.Error)
 	p.PackByte(uint8(len(r.Outputs)))
-	for _, outputs := range r.Outputs {
-		p.PackByte(uint8(len(outputs)))
-		for _, output := range outputs {
-			p.PackBytes(output)
-		}
+	for _, actionOutput := range r.Outputs {
+		p.PackBytes(actionOutput)
 	}
 	p.PackFixedBytes(r.Units.Bytes())
 	p.PackUint64(r.Fee)
@@ -64,17 +58,12 @@ func UnmarshalResult(p *codec.Packer) (*Result, error) {
 		Success: p.UnpackBool(),
 	}
 	p.UnpackBytes(consts.MaxInt, false, &result.Error)
-	outputs := [][][]byte{}
+	outputs := [][]byte{}
 	numActions := p.UnpackByte()
 	for i := uint8(0); i < numActions; i++ {
-		numOutputs := p.UnpackByte()
-		actionOutputs := [][]byte{}
-		for j := uint8(0); j < numOutputs; j++ {
-			var output []byte
-			p.UnpackBytes(consts.MaxInt, false, &output)
-			actionOutputs = append(actionOutputs, output)
-		}
-		outputs = append(outputs, actionOutputs)
+		var output []byte
+		p.UnpackBytes(consts.MaxInt, false, &output)
+		outputs = append(outputs, output)
 	}
 	result.Outputs = outputs
 	consumedRaw := make([]byte, fees.DimensionsLen)

--- a/chain/transaction_test.go
+++ b/chain/transaction_test.go
@@ -28,7 +28,7 @@ func (*abstractMockAction) ComputeUnits(chain.Rules) uint64 {
 	panic("unimplemented")
 }
 
-func (*abstractMockAction) Execute(_ context.Context, _ chain.Rules, _ state.Mutable, _ int64, _ codec.Address, _ ids.ID) (outputs [][]byte, err error) {
+func (*abstractMockAction) Execute(_ context.Context, _ chain.Rules, _ state.Mutable, _ int64, _ codec.Address, _ ids.ID) (outputs []byte, err error) {
 	panic("unimplemented")
 }
 

--- a/docs/tutorials/morpheusvm/morpheusvm.md
+++ b/docs/tutorials/morpheusvm/morpheusvm.md
@@ -183,7 +183,7 @@ func (t *Transfer) StateKeysMaxChunks() []uint16 {
 	panic("unimplemented")
 }
 
-func (t *Transfer) Execute(ctx context.Context, r chain.Rules, mu state.Mutable, timestamp int64, actor codec.Address, actionID ids.ID) (outputs [][]byte, err error) {
+func (t *Transfer) Execute(ctx context.Context, r chain.Rules, mu state.Mutable, timestamp int64, actor codec.Address, actionID ids.ID) (outputs []byte, err error) {
 	panic("unimplemented")
 }
 
@@ -705,7 +705,7 @@ func (t *Transfer) Execute(
 	_ int64,
 	actor codec.Address,
 	_ ids.ID,
-) ([][]byte, error) {
+) ([]byte, error) {
 	if t.Value == 0 {
 		return nil, ErrOutputValueZero
 	}

--- a/examples/morpheusvm/actions/transfer.go
+++ b/examples/morpheusvm/actions/transfer.go
@@ -62,7 +62,7 @@ func (t *Transfer) Execute(
 	_ int64,
 	actor codec.Address,
 	_ ids.ID,
-) ([][]byte, error) {
+) ([]byte, error) {
 	if t.Value == 0 {
 		return nil, ErrOutputValueZero
 	}

--- a/examples/vmwithcontracts/actions/call.go
+++ b/examples/vmwithcontracts/actions/call.go
@@ -75,8 +75,8 @@ func (t *Call) Execute(
 	timestamp int64,
 	actor codec.Address,
 	_ ids.ID,
-) ([][]byte, error) {
-	result, err := t.r.CallContract(ctx, &runtime.CallInfo{
+) ([]byte, error) {
+	return t.r.CallContract(ctx, &runtime.CallInfo{
 		Contract:     t.ContractAddress,
 		Actor:        actor,
 		State:        &storage.ContractStateManager{Mutable: mu},
@@ -86,11 +86,6 @@ func (t *Call) Execute(
 		Fuel:         t.Fuel,
 		Value:        t.Value,
 	})
-	var output [][]byte
-	if result != nil {
-		output = [][]byte{result}
-	}
-	return output, err
 }
 
 func (t *Call) ComputeUnits(chain.Rules) uint64 {

--- a/examples/vmwithcontracts/actions/deploy.go
+++ b/examples/vmwithcontracts/actions/deploy.go
@@ -54,10 +54,10 @@ func (d *Deploy) Execute(
 	_ int64,
 	_ codec.Address,
 	_ ids.ID,
-) ([][]byte, error) {
+) ([]byte, error) {
 	result, err := (&storage.ContractStateManager{Mutable: mu}).
 		NewAccountWithContract(ctx, d.ContractID, d.CreationInfo)
-	return [][]byte{result[:]}, err
+	return result[:], err
 }
 
 func (*Deploy) ComputeUnits(chain.Rules) uint64 {

--- a/examples/vmwithcontracts/actions/publish.go
+++ b/examples/vmwithcontracts/actions/publish.go
@@ -58,9 +58,8 @@ func (t *Publish) Execute(
 	_ int64,
 	_ codec.Address,
 	_ ids.ID,
-) ([][]byte, error) {
-	result, err := storage.StoreContract(ctx, mu, t.ContractBytes)
-	return [][]byte{result}, err
+) ([]byte, error) {
+	return storage.StoreContract(ctx, mu, t.ContractBytes)
 }
 
 func (*Publish) ComputeUnits(chain.Rules) uint64 {

--- a/examples/vmwithcontracts/actions/transfer.go
+++ b/examples/vmwithcontracts/actions/transfer.go
@@ -62,7 +62,7 @@ func (t *Transfer) Execute(
 	_ int64,
 	actor codec.Address,
 	_ ids.ID,
-) ([][]byte, error) {
+) ([]byte, error) {
 	if t.Value == 0 {
 		return nil, ErrOutputValueZero
 	}

--- a/examples/vmwithcontracts/cmd/vmwithcontracts-cli/cmd/action.go
+++ b/examples/vmwithcontracts/cmd/vmwithcontracts-cli/cmd/action.go
@@ -103,7 +103,7 @@ var publishFileCmd = &cobra.Command{
 		}}, cli, bcli, ws, factory)
 
 		if result != nil && result.Success {
-			utils.Outf(hexutils.BytesToHex(result.Outputs[0][0]) + "\n")
+			utils.Outf(hexutils.BytesToHex(result.Outputs[0]) + "\n")
 		}
 		return err
 	},
@@ -169,12 +169,12 @@ var callCmd = &cobra.Command{
 		result, err := sendAndWait(ctx, []chain.Action{action}, cli, bcli, ws, factory)
 
 		if result != nil && result.Success {
-			utils.Outf(hexutils.BytesToHex(result.Outputs[0][0]) + "\n")
+			utils.Outf(hexutils.BytesToHex(result.Outputs[0]) + "\n")
 			switch function {
 			case "balance":
 				{
 					var intValue uint64
-					err := borsh.Deserialize(&intValue, result.Outputs[0][0])
+					err := borsh.Deserialize(&intValue, result.Outputs[0])
 					if err != nil {
 						return err
 					}
@@ -183,7 +183,7 @@ var callCmd = &cobra.Command{
 			case "get_value":
 				{
 					var intValue int64
-					err := borsh.Deserialize(&intValue, result.Outputs[0][0])
+					err := borsh.Deserialize(&intValue, result.Outputs[0])
 					if err != nil {
 						return err
 					}
@@ -227,7 +227,7 @@ var deployCmd = &cobra.Command{
 		}}, cli, bcli, ws, factory)
 
 		if result != nil && result.Success {
-			address, err := codec.ToAddress(result.Outputs[0][0])
+			address, err := codec.ToAddress(result.Outputs[0])
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
This PR updates the return type of action execution to a single byte slice.

With the Action ABI introduced and read-only actions in progress, this switches to return a single byte slice, so that it's left to the action itself to provide the struct and serialization format for its own output.