### PR TITLE
Switch from bech32 to hex address format

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -15,11 +15,9 @@ type Controller interface {
 	DatabasePath() string
 	Symbol() string
 	Decimals() uint8
-	Address(codec.Address) string
-	ParseAddress(string) (codec.Address, error)
 	GetParser(string) (chain.Parser, error)
 	HandleTx(*chain.Transaction, *chain.Result)
-	LookupBalance(address string, uri string) (uint64, error)
+	LookupBalance(address codec.Address, uri string) (uint64, error)
 }
 
 type Handler struct {

--- a/cli/key.go
+++ b/cli/key.go
@@ -27,7 +27,7 @@ func (h *Handler) SetKey() error {
 	}
 	utils.Outf("{{cyan}}stored keys:{{/}} %d\n", len(keys))
 	for i := 0; i < len(keys); i++ {
-		addrStr := h.c.Address(keys[i].Address)
+		addrStr := keys[i].Address
 		balance, err := h.c.LookupBalance(addrStr, uris[0])
 		if err != nil {
 			return err
@@ -66,14 +66,13 @@ func (h *Handler) Balance(checkAllChains bool) error {
 	}
 	for _, uri := range uris[:max] {
 		utils.Outf("{{yellow}}uri:{{/}} %s\n", uri)
-		addrStr := h.c.Address(addr)
-		balance, err := h.c.LookupBalance(addrStr, uris[0])
+		balance, err := h.c.LookupBalance(addr, uris[0])
 		if err != nil {
 			return err
 		}
 		utils.Outf(
 			"{{cyan}}address:{{/}} %s {{cyan}}balance:{{/}} %s %s\n",
-			addrStr,
+			addr,
 			utils.FormatBalance(balance, h.c.Decimals()),
 			h.c.Symbol(),
 		)

--- a/cli/spam.go
+++ b/cli/spam.go
@@ -76,7 +76,7 @@ type SpamHelper interface {
 	// interface for the HyperSDK.
 	CreateClient(uri string) error
 	GetParser(ctx context.Context) (chain.Parser, error)
-	LookupBalance(choice int, address string) (uint64, error)
+	LookupBalance(choice int, address codec.Address) (uint64, error)
 
 	// GetTransfer returns a list of actions that sends [amount] to a given [address].
 	//
@@ -112,8 +112,7 @@ func (h *Handler) Spam(sh SpamHelper) error {
 		return err
 	}
 	for i := 0; i < len(keys); i++ {
-		address := h.c.Address(keys[i].Address)
-		balance, err := sh.LookupBalance(i, address)
+		balance, err := sh.LookupBalance(i, keys[i].Address)
 		if err != nil {
 			return err
 		}
@@ -415,7 +414,7 @@ func (h *Handler) Spam(sh SpamHelper) error {
 	issuerWg.Wait()
 
 	// Return funds
-	utils.Outf("{{yellow}}returning funds to %s{{/}}\n", h.c.Address(key.Address))
+	utils.Outf("{{yellow}}returning funds to %s{{/}}\n", key.Address)
 	unitPrices, err = cli.UnitPrices(ctx, false)
 	if err != nil {
 		return err

--- a/cli/storage.go
+++ b/cli/storage.go
@@ -135,7 +135,7 @@ func (h *Handler) GetDefaultKey(log bool) (codec.Address, []byte, error) {
 		return codec.EmptyAddress, nil, err
 	}
 	if log {
-		utils.Outf("{{yellow}}address:{{/}} %s\n", h.c.Address(addr))
+		utils.Outf("{{yellow}}address:{{/}} %s\n", addr)
 	}
 	return addr, priv, nil
 }

--- a/codec/address_test.go
+++ b/codec/address_test.go
@@ -4,45 +4,38 @@
 package codec
 
 import (
-	"bytes"
+	"encoding/json"
 	"testing"
 
 	"github.com/ava-labs/avalanchego/ids"
-	"github.com/btcsuite/btcd/btcutil/bech32"
 	"github.com/stretchr/testify/require"
 )
 
-const hrp = "blah"
-
-func TestIDAddress(t *testing.T) {
+func TestAddress(t *testing.T) {
 	require := require.New(t)
+	typeID := byte(0)
+	addrID := ids.GenerateTestID()
 
-	id := ids.GenerateTestID()
-	addrBytes := CreateAddress(0, id)
-	addr, err := AddressBech32(hrp, addrBytes)
+	addr := CreateAddress(typeID, addrID)
+	addrStr, err := addr.MarshalText()
 	require.NoError(err)
 
-	sb, err := ParseAddressBech32(hrp, addr)
+	var parsedAddr Address
+	require.NoError(parsedAddr.UnmarshalText([]byte(addrStr)))
+	require.Equal(addr, parsedAddr)
+}
+
+func TestAddressJSON(t *testing.T) {
+	require := require.New(t)
+	typeID := byte(0)
+	addrID := ids.GenerateTestID()
+
+	addr := CreateAddress(typeID, addrID)
+
+	addrJSONBytes, err := json.Marshal(addr)
 	require.NoError(err)
-	require.True(bytes.Equal(addrBytes[:], sb[:]))
-}
 
-func TestInvalidAddressHRP(t *testing.T) {
-	require := require.New(t)
-	addr := "blah1859dz2uwazfgahey3j53ef2kqrans0c8cv4l78tda3rjkfw0txns8u2e8k"
-
-	_, err := ParseAddressBech32("test", addr)
-	require.ErrorIs(err, ErrIncorrectHRP)
-}
-
-func TestInvalidAddressChecksum(t *testing.T) {
-	require := require.New(t)
-	addr := "blah1859dz2uwazfgahey3j53ef2kqrans0c8cv4l78tda3rjkfw0txns8u2e7k"
-
-	_, err := ParseAddressBech32(hrp, addr)
-	require.ErrorIs(err, bech32.ErrInvalidChecksum{
-		Expected:  "8u2e8k",
-		ExpectedM: "8u2e8kjq64z5",
-		Actual:    "8u2e7k",
-	})
+	var parsedAddr Address
+	require.NoError(json.Unmarshal(addrJSONBytes, &parsedAddr))
+	require.Equal(addr, parsedAddr)
 }

--- a/codec/codectest/codec_test_helpers.go
+++ b/codec/codectest/codec_test_helpers.go
@@ -4,17 +4,15 @@
 package codectest
 
 import (
-	"crypto/rand"
+	"github.com/ava-labs/avalanchego/ids"
 
 	"github.com/ava-labs/hypersdk/codec"
 )
 
 // NewRandomAddress returns a random address
 // for use during testing
-func NewRandomAddress() (codec.Address, error) {
-	b := make([]byte, codec.AddressLen)
-	if _, err := rand.Read(b); err != nil {
-		return codec.EmptyAddress, err
-	}
-	return codec.ToAddress(b)
+func NewRandomAddress() codec.Address {
+	typeID := byte(0)
+	addr := ids.GenerateTestID()
+	return codec.CreateAddress(typeID, addr)
 }

--- a/examples/morpheusvm/actions/transfer_test.go
+++ b/examples/morpheusvm/actions/transfer_test.go
@@ -19,8 +19,7 @@ import (
 )
 
 func TestTransferAction(t *testing.T) {
-	addr, err := codectest.NewRandomAddress()
-	require.NoError(t, err)
+	addr := codectest.NewRandomAddress()
 
 	tests := []chaintest.ActionTest{
 		{

--- a/examples/morpheusvm/cmd/morpheus-cli/cmd/action.go
+++ b/examples/morpheusvm/cmd/morpheus-cli/cmd/action.go
@@ -42,10 +42,7 @@ var transferCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		recipient, err := codec.ParseAddressBech32(consts.HRP, receipientStr)
-		if err != nil {
-			return err
-		}
+		recipient := codec.HexToAddress(receipientStr)
 
 		// Select amount
 		amount, err := prompt.Amount("amount", consts.Decimals, balance, nil)

--- a/examples/morpheusvm/cmd/morpheus-cli/cmd/handler.go
+++ b/examples/morpheusvm/cmd/morpheus-cli/cmd/handler.go
@@ -87,17 +87,13 @@ func (*Handler) GetBalance(
 	cli *vm.JSONRPCClient,
 	addr codec.Address,
 ) (uint64, error) {
-	saddr, err := codec.AddressBech32(consts.HRP, addr)
-	if err != nil {
-		return 0, err
-	}
-	balance, err := cli.Balance(ctx, saddr)
+	balance, err := cli.Balance(ctx, addr)
 	if err != nil {
 		return 0, err
 	}
 	if balance == 0 {
 		utils.Outf("{{red}}balance:{{/}} 0 %s\n", consts.Symbol)
-		utils.Outf("{{red}}please send funds to %s{{/}}\n", saddr)
+		utils.Outf("{{red}}please send funds to %s{{/}}\n", addr)
 		utils.Outf("{{red}}exiting...{{/}}\n")
 		return 0, nil
 	}
@@ -129,14 +125,6 @@ func (*Controller) Decimals() uint8 {
 	return consts.Decimals
 }
 
-func (*Controller) Address(addr codec.Address) string {
-	return codec.MustAddressBech32(consts.HRP, addr)
-}
-
-func (*Controller) ParseAddress(addr string) (codec.Address, error) {
-	return codec.ParseAddressBech32(consts.HRP, addr)
-}
-
 func (*Controller) GetParser(uri string) (chain.Parser, error) {
 	cli := vm.NewJSONRPCClient(uri)
 	return cli.Parser(context.TODO())
@@ -146,7 +134,7 @@ func (*Controller) HandleTx(tx *chain.Transaction, result *chain.Result) {
 	handleTx(tx, result)
 }
 
-func (*Controller) LookupBalance(address string, uri string) (uint64, error) {
+func (*Controller) LookupBalance(address codec.Address, uri string) (uint64, error) {
 	cli := vm.NewJSONRPCClient(uri)
 	balance, err := cli.Balance(context.TODO(), address)
 	return balance, err

--- a/examples/morpheusvm/cmd/morpheus-cli/cmd/key.go
+++ b/examples/morpheusvm/cmd/morpheus-cli/cmd/key.go
@@ -10,11 +10,9 @@ import (
 
 	"github.com/ava-labs/hypersdk/auth"
 	"github.com/ava-labs/hypersdk/cli"
-	"github.com/ava-labs/hypersdk/codec"
 	"github.com/ava-labs/hypersdk/crypto/bls"
 	"github.com/ava-labs/hypersdk/crypto/ed25519"
 	"github.com/ava-labs/hypersdk/crypto/secp256r1"
-	"github.com/ava-labs/hypersdk/examples/morpheusvm/consts"
 	"github.com/ava-labs/hypersdk/utils"
 )
 
@@ -136,7 +134,7 @@ var genKeyCmd = &cobra.Command{
 		}
 		utils.Outf(
 			"{{green}}created address:{{/}} %s",
-			codec.MustAddressBech32(consts.HRP, priv.Address),
+			priv.Address,
 		)
 		return nil
 	},
@@ -163,7 +161,7 @@ var importKeyCmd = &cobra.Command{
 		}
 		utils.Outf(
 			"{{green}}imported address:{{/}} %s",
-			codec.MustAddressBech32(consts.HRP, priv.Address),
+			priv.Address,
 		)
 		return nil
 	},

--- a/examples/morpheusvm/cmd/morpheus-cli/cmd/resolutions.go
+++ b/examples/morpheusvm/cmd/morpheus-cli/cmd/resolutions.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ava-labs/hypersdk/api/jsonrpc"
 	"github.com/ava-labs/hypersdk/api/ws"
 	"github.com/ava-labs/hypersdk/chain"
-	"github.com/ava-labs/hypersdk/codec"
 	"github.com/ava-labs/hypersdk/examples/morpheusvm/actions"
 	"github.com/ava-labs/hypersdk/examples/morpheusvm/consts"
 	"github.com/ava-labs/hypersdk/examples/morpheusvm/vm"
@@ -68,7 +67,7 @@ func handleTx(tx *chain.Transaction, result *chain.Result) {
 			"%s {{yellow}}%s{{/}} {{yellow}}actor:{{/}} %s {{yellow}}error:{{/}} [%s] {{yellow}}fee (max %.2f%%):{{/}} %s %s {{yellow}}consumed:{{/}} [%s]\n",
 			"❌",
 			tx.ID(),
-			codec.MustAddressBech32(consts.HRP, actor),
+			actor,
 			result.Error,
 			float64(result.Fee)/float64(tx.Base.MaxFee)*100,
 			utils.FormatBalance(result.Fee, consts.Decimals),
@@ -82,13 +81,13 @@ func handleTx(tx *chain.Transaction, result *chain.Result) {
 		var summaryStr string
 		switch act := action.(type) { //nolint:gocritic
 		case *actions.Transfer:
-			summaryStr = fmt.Sprintf("%s %s -> %s\n", utils.FormatBalance(act.Value, consts.Decimals), consts.Symbol, codec.MustAddressBech32(consts.HRP, act.To))
+			summaryStr = fmt.Sprintf("%s %s -> %s\n", utils.FormatBalance(act.Value, consts.Decimals), consts.Symbol, actor)
 		}
 		utils.Outf(
 			"%s {{yellow}}%s{{/}} {{yellow}}actor:{{/}} %s {{yellow}}summary (%s):{{/}} [%s] {{yellow}}fee (max %.2f%%):{{/}} %s %s {{yellow}}consumed:{{/}} [%s]\n",
 			"✅",
 			tx.ID(),
-			codec.MustAddressBech32(consts.HRP, actor),
+			actor,
 			reflect.TypeOf(action),
 			summaryStr,
 			float64(result.Fee)/float64(tx.Base.MaxFee)*100,

--- a/examples/morpheusvm/cmd/morpheus-cli/cmd/spam.go
+++ b/examples/morpheusvm/cmd/morpheus-cli/cmd/spam.go
@@ -64,7 +64,7 @@ func (sh *SpamHelper) GetParser(ctx context.Context) (chain.Parser, error) {
 	return sh.cli.Parser(ctx)
 }
 
-func (sh *SpamHelper) LookupBalance(choice int, address string) (uint64, error) {
+func (sh *SpamHelper) LookupBalance(choice int, address codec.Address) (uint64, error) {
 	balance, err := sh.cli.Balance(context.TODO(), address)
 	if err != nil {
 		return 0, err

--- a/examples/morpheusvm/storage/storage.go
+++ b/examples/morpheusvm/storage/storage.go
@@ -16,7 +16,6 @@ import (
 	"github.com/ava-labs/hypersdk/state"
 
 	smath "github.com/ava-labs/avalanchego/utils/math"
-	mconsts "github.com/ava-labs/hypersdk/examples/morpheusvm/consts"
 )
 
 type ReadState func(context.Context, [][]byte) ([][]byte, []error)
@@ -141,7 +140,7 @@ func AddBalance(
 			"%w: could not add balance (bal=%d, addr=%v, amount=%d)",
 			ErrInvalidBalance,
 			bal,
-			codec.MustAddressBech32(mconsts.HRP, addr),
+			addr,
 			amount,
 		)
 	}
@@ -167,7 +166,7 @@ func SubBalance(
 			"%w: could not subtract balance (bal=%d, addr=%v, amount=%d)",
 			ErrInvalidBalance,
 			bal,
-			codec.MustAddressBech32(mconsts.HRP, addr),
+			addr,
 			amount,
 		)
 	}

--- a/examples/morpheusvm/tests/workload/workload.go
+++ b/examples/morpheusvm/tests/workload/workload.go
@@ -20,7 +20,6 @@ import (
 	"github.com/ava-labs/hypersdk/crypto/ed25519"
 	"github.com/ava-labs/hypersdk/crypto/secp256r1"
 	"github.com/ava-labs/hypersdk/examples/morpheusvm/actions"
-	"github.com/ava-labs/hypersdk/examples/morpheusvm/consts"
 	"github.com/ava-labs/hypersdk/examples/morpheusvm/vm"
 	"github.com/ava-labs/hypersdk/fees"
 	"github.com/ava-labs/hypersdk/genesis"
@@ -42,7 +41,6 @@ var (
 	ed25519PrivKeys      = make([]ed25519.PrivateKey, len(ed25519HexKeys))
 	ed25519Addrs         = make([]codec.Address, len(ed25519HexKeys))
 	ed25519AuthFactories = make([]*auth.ED25519Factory, len(ed25519HexKeys))
-	ed25519AddrStrs      = make([]string, len(ed25519HexKeys))
 )
 
 func init() {
@@ -56,7 +54,6 @@ func init() {
 		ed25519AuthFactories[i] = auth.NewED25519Factory(priv)
 		addr := auth.NewED25519Address(priv.PublicKey())
 		ed25519Addrs[i] = addr
-		ed25519AddrStrs[i] = codec.MustAddressBech32(consts.HRP, addr)
 	}
 }
 
@@ -66,10 +63,10 @@ type workloadFactory struct {
 }
 
 func New(minBlockGap int64) (*genesis.DefaultGenesis, workload.TxWorkloadFactory, error) {
-	customAllocs := make([]*genesis.CustomAllocation, 0, len(ed25519AddrStrs))
-	for _, prefundedAddrStr := range ed25519AddrStrs {
+	customAllocs := make([]*genesis.CustomAllocation, 0, len(ed25519Addrs))
+	for _, prefundedAddr := range ed25519Addrs {
 		customAllocs = append(customAllocs, &genesis.CustomAllocation{
-			Address: prefundedAddrStr,
+			Address: prefundedAddr,
 			Balance: initialBalance,
 		})
 	}
@@ -119,7 +116,6 @@ func (g *simpleTxWorkload) GenerateTxWithAssertion(ctx context.Context) (*chain.
 	}
 
 	aother := auth.NewED25519Address(other.PublicKey())
-	aotherStr := codec.MustAddressBech32(consts.HRP, aother)
 	parser, err := g.lcli.Parser(ctx)
 	if err != nil {
 		return nil, nil, err
@@ -143,7 +139,7 @@ func (g *simpleTxWorkload) GenerateTxWithAssertion(ctx context.Context) (*chain.
 		require.NoError(err)
 		require.True(success)
 		lcli := vm.NewJSONRPCClient(uri)
-		balance, err := lcli.Balance(ctx, aotherStr)
+		balance, err := lcli.Balance(ctx, aother)
 		require.NoError(err)
 		require.Equal(uint64(1), balance)
 	}, nil
@@ -213,7 +209,6 @@ func (g *mixedAuthWorkload) GenerateTxWithAssertion(ctx context.Context) (*chain
 
 	sender := g.addressAndFactories[g.count]
 	receiver := g.addressAndFactories[g.count+1]
-	receiverAddrStr := codec.MustAddressBech32(consts.HRP, receiver.address)
 	expectedBalance := g.balance - 1_000_000
 
 	parser, err := g.lcli.Parser(ctx)
@@ -240,7 +235,7 @@ func (g *mixedAuthWorkload) GenerateTxWithAssertion(ctx context.Context) (*chain
 		require.NoError(err)
 		require.True(success)
 		lcli := vm.NewJSONRPCClient(uri)
-		balance, err := lcli.Balance(ctx, receiverAddrStr)
+		balance, err := lcli.Balance(ctx, receiver.address)
 		require.NoError(err)
 		require.Equal(expectedBalance, balance)
 		// TODO check tx fee + units (not currently available via API)

--- a/examples/morpheusvm/vm/client.go
+++ b/examples/morpheusvm/vm/client.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ava-labs/hypersdk/api/jsonrpc"
 	"github.com/ava-labs/hypersdk/chain"
+	"github.com/ava-labs/hypersdk/codec"
 	"github.com/ava-labs/hypersdk/examples/morpheusvm/consts"
 	"github.com/ava-labs/hypersdk/examples/morpheusvm/storage"
 	"github.com/ava-labs/hypersdk/genesis"
@@ -52,7 +53,7 @@ func (cli *JSONRPCClient) Genesis(ctx context.Context) (*genesis.DefaultGenesis,
 	return resp.Genesis, nil
 }
 
-func (cli *JSONRPCClient) Balance(ctx context.Context, addr string) (uint64, error) {
+func (cli *JSONRPCClient) Balance(ctx context.Context, addr codec.Address) (uint64, error) {
 	resp := new(BalanceReply)
 	err := cli.requester.SendRequest(
 		ctx,
@@ -67,7 +68,7 @@ func (cli *JSONRPCClient) Balance(ctx context.Context, addr string) (uint64, err
 
 func (cli *JSONRPCClient) WaitForBalance(
 	ctx context.Context,
-	addr string,
+	addr codec.Address,
 	min uint64,
 ) error {
 	return jsonrpc.Wait(ctx, balanceCheckInterval, func(ctx context.Context) (bool, error) {

--- a/examples/morpheusvm/vm/server.go
+++ b/examples/morpheusvm/vm/server.go
@@ -45,7 +45,7 @@ func (j *JSONRPCServer) Genesis(_ *http.Request, _ *struct{}, reply *GenesisRepl
 }
 
 type BalanceArgs struct {
-	Address string `json:"address"`
+	Address codec.Address `json:"address"`
 }
 
 type BalanceReply struct {
@@ -56,11 +56,7 @@ func (j *JSONRPCServer) Balance(req *http.Request, args *BalanceArgs, reply *Bal
 	ctx, span := j.vm.Tracer().Start(req.Context(), "Server.Balance")
 	defer span.End()
 
-	addr, err := codec.ParseAddressBech32(consts.HRP, args.Address)
-	if err != nil {
-		return err
-	}
-	balance, err := storage.GetBalanceFromState(ctx, j.vm.ReadState, addr)
+	balance, err := storage.GetBalanceFromState(ctx, j.vm.ReadState, args.Address)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.21.12
 
 require (
 	github.com/ava-labs/avalanchego v1.11.11-0.20240827034238-fc892827880a
-	github.com/btcsuite/btcd/btcutil v1.1.3
 	github.com/bytecodealliance/wasmtime-go/v14 v14.0.0
 	github.com/cockroachdb/pebble v0.0.0-20230928194634-aa077af62593
 	github.com/gorilla/rpc v1.2.0
@@ -43,6 +42,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bits-and-blooms/bitset v1.10.0 // indirect
 	github.com/btcsuite/btcd/btcec/v2 v2.3.2 // indirect
+	github.com/btcsuite/btcd/btcutil v1.1.3 // indirect
 	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/chzyer/readline v1.5.1 // indirect


### PR DESCRIPTION
This PR switches from bech32 to a hex address format. Closes https://github.com/ava-labs/hypersdk/issues/1527.

Bech32 address format was intended to provide a UI improvement, however, I find it creates a worse UX and DevX.