### PR TITLE
Fix benchmark script so it does not run unit tests

### DIFF
--- a/scripts/tests.benchmark.sh
+++ b/scripts/tests.benchmark.sh
@@ -20,4 +20,4 @@ while IFS= read -r line; do
     file_args+=("$line")
 done < <(find "$subdir" -type f -name "*.go" | grep -v "./examples/" | xargs -n1 dirname | sort -u)
 
-go test -timeout="10m" -bench=. -benchtime=1x "${file_args[@]}"
+go test -benchmem -run=^$ -timeout="10m" -bench=. -benchtime=1x "${file_args[@]}"


### PR DESCRIPTION
This PR fixes `./scripts/tests.benchmark.sh` so that it runs benchmarks, but does not run unit tests. This also updates to use `benchmem` so that it prints out memory statistics, which is a personal preference to have that little extra detail.