### PR TITLE
Reduce simulator API surface

### DIFF
--- a/x/contracts/simulator/state/state.go
+++ b/x/contracts/simulator/state/state.go
@@ -28,7 +28,7 @@ type Mutable = C.Mutable
 
 func NewSimulatorState(db unsafe.Pointer) *Mutable {
 	// convert unsafe pointer to C.Mutable
-	mutable := (*C.Mutable)(db)
+	mutable := (*Mutable)(db)
 	return mutable
 }
 


### PR DESCRIPTION
There was some redundant code in here that I cleaned up. Originally, I was trying to simplify the calls between Go and Rust, but the mutual dependency made that difficult.

