### PR TITLE
Add support to define VM runtime

### DIFF
--- a/api/dependencies.go
+++ b/api/dependencies.go
@@ -10,30 +10,29 @@ import (
 	"github.com/ava-labs/avalanchego/snow/validators"
 	"github.com/ava-labs/avalanchego/trace"
 	"github.com/ava-labs/avalanchego/utils/logging"
-
 	"github.com/ava-labs/hypersdk/chain"
 	"github.com/ava-labs/hypersdk/fees"
 	"github.com/ava-labs/hypersdk/genesis"
 	"github.com/ava-labs/hypersdk/state"
 )
 
-type VM interface {
+type VM[T chain.RuntimeInterface] interface {
 	Genesis() genesis.Genesis
 	ChainID() ids.ID
 	NetworkID() uint32
 	SubnetID() ids.ID
 	Tracer() trace.Tracer
 	Logger() logging.Logger
-	ActionRegistry() chain.ActionRegistry
+	ActionRegistry() chain.ActionRegistry[T]
 	OutputRegistry() chain.OutputRegistry
 	AuthRegistry() chain.AuthRegistry
 	Rules(t int64) chain.Rules
 	Submit(
 		ctx context.Context,
 		verifySig bool,
-		txs []*chain.Transaction,
+		txs []*chain.Transaction[T],
 	) (errs []error)
-	LastAcceptedBlock() *chain.StatefulBlock
+	LastAcceptedBlock() *chain.StatefulBlock[T]
 	UnitPrices(context.Context) (fees.Dimensions, error)
 	CurrentValidators(
 		context.Context,
@@ -41,4 +40,5 @@ type VM interface {
 	GetVerifyAuth() bool
 	ReadState(ctx context.Context, keys [][]byte) ([][]byte, []error)
 	ImmutableState(ctx context.Context) (state.Immutable, error)
+	GetRuntime() T
 }

--- a/api/dependencies.go
+++ b/api/dependencies.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ava-labs/avalanchego/snow/validators"
 	"github.com/ava-labs/avalanchego/trace"
 	"github.com/ava-labs/avalanchego/utils/logging"
+
 	"github.com/ava-labs/hypersdk/chain"
 	"github.com/ava-labs/hypersdk/fees"
 	"github.com/ava-labs/hypersdk/genesis"

--- a/api/jsonrpc/option.go
+++ b/api/jsonrpc/option.go
@@ -3,7 +3,10 @@
 
 package jsonrpc
 
-import "github.com/ava-labs/hypersdk/vm"
+import (
+	"github.com/ava-labs/hypersdk/chain"
+	"github.com/ava-labs/hypersdk/vm"
+)
 
 const Namespace = "core"
 
@@ -17,12 +20,12 @@ func NewDefaultConfig() Config {
 	}
 }
 
-func With() vm.Option {
-	return vm.NewOption(Namespace, NewDefaultConfig(), func(v *vm.VM, config Config) error {
+func With[T chain.RuntimeInterface]() vm.Option[T] {
+	return vm.NewOption[T](Namespace, NewDefaultConfig(), func(v *vm.VM[T], config Config) error {
 		if !config.Enabled {
 			return nil
 		}
-		vm.WithVMAPIs(JSONRPCServerFactory{})(v)
+		vm.WithVMAPIs[T](JSONRPCServerFactory[T]{})(v)
 		return nil
 	})
 }

--- a/api/jsonrpc/server.go
+++ b/api/jsonrpc/server.go
@@ -184,8 +184,7 @@ func (j *JSONRPCServer[T]) Execute(
 	ctx, span := j.vm.Tracer().Start(req.Context(), "JSONRPCServer.ExecuteAction")
 	defer span.End()
 
-	var actionRegistry *codec.TypeParser[chain.Action[T]]
-	actionRegistry = j.vm.ActionRegistry()
+	var actionRegistry *codec.TypeParser[chain.Action[T]] = j.vm.ActionRegistry()
 	action, err := actionRegistry.Unmarshal(codec.NewReader(args.Action, len(args.Action)))
 	if err != nil {
 		return fmt.Errorf("failed to unmashal action: %w", err)

--- a/api/state/option.go
+++ b/api/state/option.go
@@ -3,7 +3,10 @@
 
 package state
 
-import "github.com/ava-labs/hypersdk/vm"
+import (
+	"github.com/ava-labs/hypersdk/chain"
+	"github.com/ava-labs/hypersdk/vm"
+)
 
 const Namespace = "corestate"
 
@@ -17,12 +20,12 @@ func NewDefaultConfig() Config {
 	}
 }
 
-func With() vm.Option {
-	return vm.NewOption(Namespace, NewDefaultConfig(), func(v *vm.VM, config Config) error {
+func With[T chain.RuntimeInterface]() vm.Option[T] {
+	return vm.NewOption(Namespace, NewDefaultConfig(), func(v *vm.VM[T], config Config) error {
 		if !config.Enabled {
 			return nil
 		}
-		vm.WithVMAPIs(JSONRPCStateServerFactory{})(v)
+		vm.WithVMAPIs[T](JSONRPCStateServerFactory[T]{})(v)
 		return nil
 	})
 }

--- a/api/ws/client.go
+++ b/api/ws/client.go
@@ -11,10 +11,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gorilla/websocket"
-
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/logging"
+	"github.com/gorilla/websocket"
 
 	"github.com/ava-labs/hypersdk/chain"
 	"github.com/ava-labs/hypersdk/fees"

--- a/api/ws/packer.go
+++ b/api/ws/packer.go
@@ -19,7 +19,7 @@ const (
 	TxMode    byte = 1
 )
 
-func PackBlockMessage(b *chain.StatefulBlock) ([]byte, error) {
+func PackBlockMessage[T chain.RuntimeInterface](b *chain.StatefulBlock[T]) ([]byte, error) {
 	results := b.Results()
 	size := codec.BytesLen(b.Bytes()) + consts.IntLen + codec.CummSize(results) + fees.DimensionsLen
 	p := codec.NewWriter(size, consts.MaxInt)
@@ -33,10 +33,10 @@ func PackBlockMessage(b *chain.StatefulBlock) ([]byte, error) {
 	return p.Bytes(), p.Err()
 }
 
-func UnpackBlockMessage(
+func UnpackBlockMessage[T chain.RuntimeInterface](
 	msg []byte,
-	parser chain.Parser,
-) (*chain.StatelessBlock, []*chain.Result, fees.Dimensions, error) {
+	parser chain.Parser[T],
+) (*chain.StatelessBlock[T], []*chain.Result, fees.Dimensions, error) {
 	p := codec.NewReader(msg, consts.MaxInt)
 	var blkMsg []byte
 	p.UnpackBytes(-1, true, &blkMsg)

--- a/api/ws/server.go
+++ b/api/ws/server.go
@@ -8,11 +8,10 @@ import (
 	"errors"
 	"sync"
 
-	"go.uber.org/zap"
-
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/trace"
 	"github.com/ava-labs/avalanchego/utils/logging"
+	"go.uber.org/zap"
 
 	"github.com/ava-labs/hypersdk/api"
 	"github.com/ava-labs/hypersdk/chain"

--- a/chain/block.go
+++ b/chain/block.go
@@ -10,14 +10,15 @@ import (
 	"fmt"
 	"time"
 
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/zap"
+
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow/consensus/snowman"
 	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/x/merkledb"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/trace"
-	"go.uber.org/zap"
 
 	"github.com/ava-labs/hypersdk/codec"
 	"github.com/ava-labs/hypersdk/consts"

--- a/chain/block.go
+++ b/chain/block.go
@@ -10,15 +10,14 @@ import (
 	"fmt"
 	"time"
 
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/trace"
-	"go.uber.org/zap"
-
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow/consensus/snowman"
 	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/x/merkledb"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/zap"
 
 	"github.com/ava-labs/hypersdk/codec"
 	"github.com/ava-labs/hypersdk/consts"

--- a/chain/block.go
+++ b/chain/block.go
@@ -10,14 +10,15 @@ import (
 	"fmt"
 	"time"
 
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/zap"
+
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow/consensus/snowman"
 	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/x/merkledb"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/trace"
-	"go.uber.org/zap"
 
 	"github.com/ava-labs/hypersdk/codec"
 	"github.com/ava-labs/hypersdk/consts"
@@ -29,16 +30,16 @@ import (
 )
 
 var (
-	_ snowman.Block      = (*StatefulBlock)(nil)
-	_ block.StateSummary = (*SyncableBlock)(nil)
+	_ snowman.Block      = (*StatefulBlock[RuntimeInterface])(nil)
+	_ block.StateSummary = (*SyncableBlock[RuntimeInterface])(nil)
 )
 
-type StatelessBlock struct {
+type StatelessBlock[T RuntimeInterface] struct {
 	Prnt   ids.ID `json:"parent"`
 	Tmstmp int64  `json:"timestamp"`
 	Hght   uint64 `json:"height"`
 
-	Txs []*Transaction `json:"txs"`
+	Txs []*Transaction[T] `json:"txs"`
 
 	// StateRoot is the root of the post-execution state
 	// of [Prnt].
@@ -57,11 +58,11 @@ type StatelessBlock struct {
 	authCounts map[uint8]int
 }
 
-func (b *StatelessBlock) Size() int {
+func (b *StatelessBlock[_]) Size() int {
 	return b.size
 }
 
-func (b *StatelessBlock) ID() (ids.ID, error) {
+func (b *StatelessBlock[_]) ID() (ids.ID, error) {
 	blk, err := b.Marshal()
 	if err != nil {
 		return ids.ID{}, err
@@ -69,7 +70,7 @@ func (b *StatelessBlock) ID() (ids.ID, error) {
 	return utils.ToID(blk), nil
 }
 
-func (b *StatelessBlock) Marshal() ([]byte, error) {
+func (b *StatelessBlock[_]) Marshal() ([]byte, error) {
 	size := ids.IDLen + consts.Uint64Len + consts.Uint64Len +
 		consts.Uint64Len + window.WindowSliceSize +
 		consts.IntLen + codec.CummSize(b.Txs) +
@@ -99,10 +100,10 @@ func (b *StatelessBlock) Marshal() ([]byte, error) {
 	return bytes, nil
 }
 
-func UnmarshalBlock(raw []byte, parser Parser) (*StatelessBlock, error) {
+func UnmarshalBlock[T RuntimeInterface](raw []byte, parser Parser[T]) (*StatelessBlock[T], error) {
 	var (
 		p = codec.NewReader(raw, consts.NetworkSizeLimit)
-		b StatelessBlock
+		b StatelessBlock[T]
 	)
 	b.size = len(raw)
 
@@ -113,10 +114,10 @@ func UnmarshalBlock(raw []byte, parser Parser) (*StatelessBlock, error) {
 	// Parse transactions
 	txCount := p.UnpackInt(false) // can produce empty blocks
 	actionRegistry, authRegistry := parser.ActionRegistry(), parser.AuthRegistry()
-	b.Txs = []*Transaction{} // don't preallocate all to avoid DoS
+	b.Txs = []*Transaction[T]{} // don't preallocate all to avoid DoS
 	b.authCounts = map[uint8]int{}
 	for i := uint32(0); i < txCount; i++ {
-		tx, err := UnmarshalTx(p, actionRegistry, authRegistry)
+		tx, err := UnmarshalTx[T](p, actionRegistry, authRegistry)
 		if err != nil {
 			return nil, err
 		}
@@ -133,8 +134,8 @@ func UnmarshalBlock(raw []byte, parser Parser) (*StatelessBlock, error) {
 	return &b, p.Err()
 }
 
-func NewGenesisBlock(root ids.ID) *StatelessBlock {
-	return &StatelessBlock{
+func NewGenesisBlock[T RuntimeInterface](root ids.ID) *StatelessBlock[T] {
+	return &StatelessBlock[T]{
 		// We set the genesis block timestamp to be after the ProposerVM fork activation.
 		//
 		// This prevents an issue (when using millisecond timestamps) during ProposerVM activation
@@ -153,8 +154,8 @@ func NewGenesisBlock(root ids.ID) *StatelessBlock {
 // Stateless is defined separately from "Block"
 // in case external packages need to use the stateless block
 // without mocking VM or parent block
-type StatefulBlock struct {
-	*StatelessBlock `json:"block"`
+type StatefulBlock[T RuntimeInterface] struct {
+	*StatelessBlock[T] `json:"block"`
 
 	id       ids.ID
 	accepted bool
@@ -165,15 +166,15 @@ type StatefulBlock struct {
 	results    []*Result
 	feeManager *fees.Manager
 
-	vm   VM
+	vm   VM[T]
 	view merkledb.View
 
 	sigJob workers.Job
 }
 
-func NewBlock(vm VM, parent snowman.Block, tmstp int64) *StatefulBlock {
-	return &StatefulBlock{
-		StatelessBlock: &StatelessBlock{
+func NewBlock[T RuntimeInterface](vm VM[T], parent snowman.Block, tmstp int64) *StatefulBlock[T] {
+	return &StatefulBlock[T]{
+		StatelessBlock: &StatelessBlock[T]{
 			Prnt:   parent.ID(),
 			Tmstmp: tmstp,
 			Hght:   parent.Height() + 1,
@@ -183,25 +184,25 @@ func NewBlock(vm VM, parent snowman.Block, tmstp int64) *StatefulBlock {
 	}
 }
 
-func ParseBlock(
+func ParseBlock[T RuntimeInterface](
 	ctx context.Context,
 	source []byte,
 	accepted bool,
-	vm VM,
-) (*StatefulBlock, error) {
+	vm VM[T],
+) (*StatefulBlock[T], error) {
 	ctx, span := vm.Tracer().Start(ctx, "chain.ParseBlock")
 	defer span.End()
 
-	blk, err := UnmarshalBlock(source, vm)
+	blk, err := UnmarshalBlock[T](source, vm)
 	if err != nil {
 		return nil, err
 	}
 	// Not guaranteed that a parsed block is verified
-	return ParseStatelessBlock(ctx, blk, source, accepted, vm)
+	return ParseStatelessBlock[T](ctx, blk, source, accepted, vm)
 }
 
 // populateTxs is only called on blocks we did not build
-func (b *StatefulBlock) populateTxs(ctx context.Context) error {
+func (b *StatefulBlock[_]) populateTxs(ctx context.Context) error {
 	ctx, span := b.vm.Tracer().Start(ctx, "StatefulBlock.populateTxs")
 	defer span.End()
 
@@ -243,13 +244,13 @@ func (b *StatefulBlock) populateTxs(ctx context.Context) error {
 	return nil
 }
 
-func ParseStatelessBlock(
+func ParseStatelessBlock[T RuntimeInterface](
 	ctx context.Context,
-	blk *StatelessBlock,
+	blk *StatelessBlock[T],
 	source []byte,
 	accepted bool,
-	vm VM,
-) (*StatefulBlock, error) {
+	vm VM[T],
+) (*StatefulBlock[T], error) {
 	ctx, span := vm.Tracer().Start(ctx, "chain.ParseStatelessBlock")
 	defer span.End()
 
@@ -265,7 +266,7 @@ func ParseStatelessBlock(
 		}
 		source = nsource
 	}
-	b := &StatefulBlock{
+	b := &StatefulBlock[T]{
 		StatelessBlock: blk,
 		t:              time.UnixMilli(blk.Tmstmp),
 		bytes:          source,
@@ -286,7 +287,7 @@ func ParseStatelessBlock(
 }
 
 // [initializeBuilt] is invoked after a block is built
-func (b *StatefulBlock) initializeBuilt(
+func (b *StatefulBlock[_]) initializeBuilt(
 	ctx context.Context,
 	view merkledb.View,
 	results []*Result,
@@ -313,10 +314,10 @@ func (b *StatefulBlock) initializeBuilt(
 }
 
 // implements "snowman.Block.choices.Decidable"
-func (b *StatefulBlock) ID() ids.ID { return b.id }
+func (b *StatefulBlock[_]) ID() ids.ID { return b.id }
 
 // implements "snowman.Block"
-func (b *StatefulBlock) Verify(ctx context.Context) error {
+func (b *StatefulBlock[_]) Verify(ctx context.Context) error {
 	start := time.Now()
 	defer func() {
 		b.vm.RecordBlockVerify(time.Since(start))
@@ -401,7 +402,7 @@ func (b *StatefulBlock) Verify(ctx context.Context) error {
 //  2. If the parent view is missing when verifying (dynamic state sync)
 //  3. If the view of a block we are accepting is missing (finishing dynamic
 //     state sync)
-func (b *StatefulBlock) innerVerify(ctx context.Context, vctx VerifyContext) error {
+func (b *StatefulBlock[T]) innerVerify(ctx context.Context, vctx VerifyContext[T]) error {
 	var (
 		log = b.vm.Logger()
 		r   = b.vm.Rules(b.Tmstmp)
@@ -483,7 +484,7 @@ func (b *StatefulBlock) innerVerify(ctx context.Context, vctx VerifyContext) err
 	}
 
 	// Process transactions
-	results, ts, err := b.Execute(ctx, b.vm.Tracer(), parentView, feeManager, r)
+	results, ts, err := b.Execute(ctx, b.vm.Tracer(), b.vm.GetRuntime(), parentView, feeManager, r)
 	if err != nil {
 		log.Error("failed to execute block", zap.Error(err))
 		return err
@@ -575,7 +576,7 @@ func (b *StatefulBlock) innerVerify(ctx context.Context, vctx VerifyContext) err
 }
 
 // implements "snowman.Block.choices.Decidable"
-func (b *StatefulBlock) Accept(ctx context.Context) error {
+func (b *StatefulBlock[_]) Accept(ctx context.Context) error {
 	start := time.Now()
 	defer func() {
 		b.vm.RecordBlockAccept(time.Since(start))
@@ -632,7 +633,7 @@ func (b *StatefulBlock) Accept(ctx context.Context) error {
 	return nil
 }
 
-func (b *StatefulBlock) MarkAccepted(ctx context.Context) {
+func (b *StatefulBlock[_]) MarkAccepted(ctx context.Context) {
 	// Accept block and free unnecessary memory
 	b.accepted = true
 	b.txsSet = nil // only used for replay protection when processing
@@ -645,7 +646,7 @@ func (b *StatefulBlock) MarkAccepted(ctx context.Context) {
 }
 
 // implements "snowman.Block.choices.Decidable"
-func (b *StatefulBlock) Reject(ctx context.Context) error {
+func (b *StatefulBlock[_]) Reject(ctx context.Context) error {
 	ctx, span := b.vm.Tracer().Start(ctx, "StatefulBlock.Reject")
 	defer span.End()
 
@@ -654,19 +655,19 @@ func (b *StatefulBlock) Reject(ctx context.Context) error {
 }
 
 // implements "snowman.Block"
-func (b *StatefulBlock) Parent() ids.ID { return b.StatelessBlock.Prnt }
+func (b *StatefulBlock[_]) Parent() ids.ID { return b.StatelessBlock.Prnt }
 
 // implements "snowman.Block"
-func (b *StatefulBlock) Bytes() []byte { return b.bytes }
+func (b *StatefulBlock[_]) Bytes() []byte { return b.bytes }
 
 // implements "snowman.Block"
-func (b *StatefulBlock) Height() uint64 { return b.StatelessBlock.Hght }
+func (b *StatefulBlock[_]) Height() uint64 { return b.StatelessBlock.Hght }
 
 // implements "snowman.Block"
-func (b *StatefulBlock) Timestamp() time.Time { return b.t }
+func (b *StatefulBlock[_]) Timestamp() time.Time { return b.t }
 
 // Used to determine if should notify listeners and/or pass to controller
-func (b *StatefulBlock) Processed() bool {
+func (b *StatefulBlock[_]) Processed() bool {
 	return b.view != nil
 }
 
@@ -683,7 +684,7 @@ func (b *StatefulBlock) Processed() bool {
 //
 // Invariant: [View] with [verify] == true should not be called concurrently, otherwise,
 // it will result in undefined behavior.
-func (b *StatefulBlock) View(ctx context.Context, verify bool) (state.View, error) {
+func (b *StatefulBlock[_]) View(ctx context.Context, verify bool) (state.View, error) {
 	ctx, span := b.vm.Tracer().Start(ctx, "StatefulBlock.View",
 		trace.WithAttributes(
 			attribute.Bool("processed", b.Processed()),
@@ -799,10 +800,10 @@ func (b *StatefulBlock) View(ctx context.Context, verify bool) (state.View, erro
 //
 // If [stop] is set to true, IsRepeat will return as soon as the first repeat
 // is found (useful for block verification).
-func (b *StatefulBlock) IsRepeat(
+func (b *StatefulBlock[T]) IsRepeat(
 	ctx context.Context,
 	oldestAllowed int64,
-	txs []*Transaction,
+	txs []*Transaction[T],
 	marker set.Bits,
 	stop bool,
 ) (set.Bits, error) {
@@ -842,7 +843,7 @@ func (b *StatefulBlock) IsRepeat(
 	return prnt.IsRepeat(ctx, oldestAllowed, txs, marker, stop)
 }
 
-func (b *StatefulBlock) GetVerifyContext(ctx context.Context, blockHeight uint64, parent ids.ID) (VerifyContext, error) {
+func (b *StatefulBlock[T]) GetVerifyContext(ctx context.Context, blockHeight uint64, parent ids.ID) (VerifyContext[T], error) {
 	// If [blockHeight] is 0, we throw an error because there is no pre-genesis verification context.
 	if blockHeight == 0 {
 		return nil, errors.New("cannot get context of genesis block")
@@ -856,7 +857,7 @@ func (b *StatefulBlock) GetVerifyContext(ctx context.Context, blockHeight uint64
 		if err != nil {
 			return nil, err
 		}
-		return &PendingVerifyContext{blk}, nil
+		return &PendingVerifyContext[T]{blk}, nil
 	}
 
 	// If the last accepted block is not yet processed, we can't use the accepted state for the
@@ -867,47 +868,47 @@ func (b *StatefulBlock) GetVerifyContext(ctx context.Context, blockHeight uint64
 	// Invariant: When [View] is called on [vm.lastAccepted], the block will be verified and the accepted
 	// state will be updated.
 	if !lastAcceptedBlock.Processed() && parent == lastAcceptedBlock.ID() {
-		return &PendingVerifyContext{lastAcceptedBlock}, nil
+		return &PendingVerifyContext[T]{lastAcceptedBlock}, nil
 	}
 
 	// If the parent block is accepted and processed, we should
 	// just use the accepted state as the verification context.
-	return &AcceptedVerifyContext{b.vm}, nil
+	return &AcceptedVerifyContext[T]{b.vm}, nil
 }
 
-func (b *StatefulBlock) GetTxs() []*Transaction {
+func (b *StatefulBlock[T]) GetTxs() []*Transaction[T] {
 	return b.Txs
 }
 
-func (b *StatefulBlock) GetTimestamp() int64 {
+func (b *StatefulBlock[_]) GetTimestamp() int64 {
 	return b.Tmstmp
 }
 
-func (b *StatefulBlock) Results() []*Result {
+func (b *StatefulBlock[_]) Results() []*Result {
 	return b.results
 }
 
-func (b *StatefulBlock) FeeManager() *fees.Manager {
+func (b *StatefulBlock[_]) FeeManager() *fees.Manager {
 	return b.feeManager
 }
 
-type SyncableBlock struct {
-	*StatefulBlock
+type SyncableBlock[T RuntimeInterface] struct {
+	*StatefulBlock[T]
 }
 
-func (sb *SyncableBlock) Accept(ctx context.Context) (block.StateSyncMode, error) {
+func (sb *SyncableBlock[_]) Accept(ctx context.Context) (block.StateSyncMode, error) {
 	return sb.vm.AcceptedSyncableBlock(ctx, sb)
 }
 
-func NewSyncableBlock(sb *StatefulBlock) *SyncableBlock {
-	return &SyncableBlock{sb}
+func NewSyncableBlock[T RuntimeInterface](sb *StatefulBlock[T]) *SyncableBlock[T] {
+	return &SyncableBlock[T]{sb}
 }
 
-func (sb *SyncableBlock) String() string {
+func (sb *SyncableBlock[_]) String() string {
 	return fmt.Sprintf("%d:%s root=%s", sb.Height(), sb.ID(), sb.StateRoot)
 }
 
 // Testing
-func (b *StatefulBlock) MarkUnprocessed() {
+func (b *StatefulBlock[_]) MarkUnprocessed() {
 	b.view = nil
 }

--- a/chain/builder.go
+++ b/chain/builder.go
@@ -11,13 +11,12 @@ import (
 	"sync"
 	"time"
 
-	"go.opentelemetry.io/otel/attribute"
-	"go.uber.org/zap"
-
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/set"
+	"go.opentelemetry.io/otel/attribute"
+	"go.uber.org/zap"
 
 	"github.com/ava-labs/hypersdk/internal/executor"
 	"github.com/ava-labs/hypersdk/internal/fees"

--- a/chain/chaintest/action_test_helpers.go
+++ b/chain/chaintest/action_test_helpers.go
@@ -7,9 +7,10 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/ids"
-	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/hypersdk/chain"
 	"github.com/ava-labs/hypersdk/codec"
@@ -49,13 +50,12 @@ func (i *InMemoryStore) Remove(_ context.Context, key []byte) error {
 
 // ActionTest is a single parameterized test. It calls Execute on the action with the passed parameters
 // and checks that all assertions pass.
-type ActionTest struct {
+type ActionTest[T chain.RuntimeInterface] struct {
 	Name string
 
-	Action chain.Action
+	Action chain.Action[T]
 
-	Rules     chain.Rules
-	State     state.Mutable
+	Runtime   chain.Runtime[T]
 	Timestamp int64
 	Actor     codec.Address
 	ActionID  ids.ID
@@ -63,21 +63,27 @@ type ActionTest struct {
 	ExpectedOutputs codec.Typed
 	ExpectedErr     error
 
-	Assertion func(context.Context, *testing.T, state.Mutable)
+	Assertion func(context.Context, *testing.T, chain.Runtime[T])
 }
 
 // Run executes the [ActionTest] and make sure all assertions pass.
-func (test *ActionTest) Run(ctx context.Context, t *testing.T) {
+func (test *ActionTest[T]) Run(ctx context.Context, t *testing.T) {
 	t.Run(test.Name, func(t *testing.T) {
 		require := require.New(t)
 
-		output, err := test.Action.Execute(ctx, test.Rules, test.State, test.Timestamp, test.Actor, test.ActionID)
+		output, err := test.Action.Execute(
+			ctx,
+			test.Runtime,
+			test.Timestamp,
+			test.Actor,
+			test.ActionID,
+		)
 
 		require.ErrorIs(err, test.ExpectedErr)
 		require.Equal(output, test.ExpectedOutputs)
 
 		if test.Assertion != nil {
-			test.Assertion(ctx, t, test.State)
+			test.Assertion(ctx, t, test.Runtime)
 		}
 	})
 }
@@ -85,12 +91,11 @@ func (test *ActionTest) Run(ctx context.Context, t *testing.T) {
 // ActionBenchmark is a parameterized benchmark. It calls Execute on the action with the passed parameters
 // and checks that all assertions pass. To avoid using shared state between runs, a new
 // state is created for each iteration using the provided `CreateState` function.
-type ActionBenchmark struct {
+type ActionBenchmark[T chain.RuntimeInterface] struct {
 	Name   string
-	Action chain.Action
+	Action chain.Action[T]
 
-	Rules       chain.Rules
-	CreateState func() state.Mutable
+	NewRuntimeF func() chain.Runtime[T]
 	Timestamp   int64
 	Actor       codec.Address
 	ActionID    ids.ID
@@ -98,22 +103,22 @@ type ActionBenchmark struct {
 	ExpectedOutputs []codec.Typed
 	ExpectedErr     error
 
-	Assertion func(context.Context, *testing.B, state.Mutable)
+	Assertion func(context.Context, *testing.B, chain.Runtime[T])
 }
 
 // Run executes the [ActionBenchmark] and make sure all the benchmark assertions pass.
-func (test *ActionBenchmark) Run(ctx context.Context, b *testing.B) {
+func (test *ActionBenchmark[T]) Run(ctx context.Context, b *testing.B) {
 	require := require.New(b)
 
 	// create a slice of b.N states
-	states := make([]state.Mutable, b.N)
+	runtimes := make([]chain.Runtime[T], b.N)
 	for i := 0; i < b.N; i++ {
-		states[i] = test.CreateState()
+		runtimes[i] = test.NewRuntimeF()
 	}
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		output, err := test.Action.Execute(ctx, test.Rules, states[i], test.Timestamp, test.Actor, test.ActionID)
+		output, err := test.Action.Execute(ctx, runtimes[i], test.Timestamp, test.Actor, test.ActionID)
 		require.NoError(err)
 		require.Equal(output, test.ExpectedOutputs)
 	}
@@ -122,7 +127,7 @@ func (test *ActionBenchmark) Run(ctx context.Context, b *testing.B) {
 	// check assertions
 	if test.Assertion != nil {
 		for i := 0; i < b.N; i++ {
-			test.Assertion(ctx, b, states[i])
+			test.Assertion(ctx, b, runtimes[i])
 		}
 	}
 }

--- a/chain/chaintest/action_test_helpers.go
+++ b/chain/chaintest/action_test_helpers.go
@@ -7,10 +7,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/hypersdk/chain"
 	"github.com/ava-labs/hypersdk/codec"

--- a/chain/dependencies.go
+++ b/chain/dependencies.go
@@ -22,14 +22,14 @@ import (
 )
 
 type (
-	ActionRegistry *codec.TypeParser[Action]
-	OutputRegistry *codec.TypeParser[codec.Typed]
-	AuthRegistry   *codec.TypeParser[Auth]
+	ActionRegistry[T RuntimeInterface] *codec.TypeParser[Action[T]]
+	OutputRegistry                     *codec.TypeParser[codec.Typed]
+	AuthRegistry                       *codec.TypeParser[Auth]
 )
 
-type Parser interface {
+type Parser[T RuntimeInterface] interface {
 	Rules(int64) Rules
-	ActionRegistry() ActionRegistry
+	ActionRegistry() ActionRegistry[T]
 	OutputRegistry() OutputRegistry
 	AuthRegistry() AuthRegistry
 }
@@ -55,10 +55,10 @@ type Monitoring interface {
 	Logger() logging.Logger
 }
 
-type VM interface {
+type VM[T RuntimeInterface] interface {
 	Metrics
 	Monitoring
-	Parser
+	Parser[T]
 
 	// We don't include this in registry because it would never be used
 	// by any client of the hypersdk.
@@ -67,50 +67,52 @@ type VM interface {
 	GetVerifyAuth() bool
 
 	IsBootstrapped() bool
-	LastAcceptedBlock() *StatefulBlock
-	GetStatefulBlock(context.Context, ids.ID) (*StatefulBlock, error)
+	LastAcceptedBlock() *StatefulBlock[T]
+	GetStatefulBlock(context.Context, ids.ID) (*StatefulBlock[T], error)
 
 	State() (merkledb.MerkleDB, error)
 	StateManager() StateManager
 
-	Mempool() Mempool
-	IsRepeat(context.Context, []*Transaction, set.Bits, bool) set.Bits
+	Mempool() Mempool[T]
+	IsRepeat(context.Context, []*Transaction[T], set.Bits, bool) set.Bits
 	GetTargetBuildDuration() time.Duration
 	GetTransactionExecutionCores() int
 	GetStateFetchConcurrency() int
 
-	Verified(context.Context, *StatefulBlock)
-	Rejected(context.Context, *StatefulBlock)
-	Accepted(context.Context, *StatefulBlock)
-	AcceptedSyncableBlock(context.Context, *SyncableBlock) (block.StateSyncMode, error)
+	Verified(context.Context, *StatefulBlock[T])
+	Rejected(context.Context, *StatefulBlock[T])
+	Accepted(context.Context, *StatefulBlock[T])
+	AcceptedSyncableBlock(context.Context, *SyncableBlock[T]) (block.StateSyncMode, error)
 
 	// UpdateSyncTarget returns a bool that is true if the root
 	// was updated and the sync is continuing with the new specified root
 	// and false if the sync completed with the previous root.
-	UpdateSyncTarget(*StatefulBlock) (bool, error)
+	UpdateSyncTarget(*StatefulBlock[T]) (bool, error)
 	StateReady() bool
+	// GetRuntime returns the application-defined runtime
+	GetRuntime() T
 }
 
-type VerifyContext interface {
+type VerifyContext[T RuntimeInterface] interface {
 	View(ctx context.Context, verify bool) (state.View, error)
-	IsRepeat(ctx context.Context, oldestAllowed int64, txs []*Transaction, marker set.Bits, stop bool) (set.Bits, error)
+	IsRepeat(ctx context.Context, oldestAllowed int64, txs []*Transaction[T], marker set.Bits, stop bool) (set.Bits, error)
 }
 
-type Mempool interface {
+type Mempool[T RuntimeInterface] interface {
 	Len(context.Context) int  // items
 	Size(context.Context) int // bytes
-	Add(context.Context, []*Transaction)
+	Add(context.Context, []*Transaction[T])
 
 	Top(
 		context.Context,
 		time.Duration,
-		func(context.Context, *Transaction) (cont bool, rest bool, err error),
+		func(context.Context, *Transaction[T]) (cont bool, rest bool, err error),
 	) error
 
 	StartStreaming(context.Context)
 	PrepareStream(context.Context, int)
-	Stream(context.Context, int) []*Transaction
-	FinishStreaming(context.Context, []*Transaction) int
+	Stream(context.Context, int) []*Transaction[T]
+	FinishStreaming(context.Context, []*Transaction[T]) int
 }
 
 // TODO: add fixed rules as a subset of this interface
@@ -205,7 +207,17 @@ type Marshaler interface {
 	Size() int
 }
 
-type Action interface {
+// TODO add explicit functions for child view processing + rolling back
+// pending runtime state
+type RuntimeInterface interface{}
+
+type Runtime[T RuntimeInterface] struct {
+	T     T
+	Rules Rules
+	State state.Mutable
+}
+
+type Action[T RuntimeInterface] interface {
 	Object
 
 	// ComputeUnits is the amount of compute required to call [Execute]. This is used to determine
@@ -236,8 +248,7 @@ type Action interface {
 	// If [Execute] returns an error, execution will halt and any state changes will revert.
 	Execute(
 		ctx context.Context,
-		r Rules,
-		mu state.Mutable,
+		runtime Runtime[T],
 		timestamp int64,
 		actor codec.Address,
 		actionID ids.ID,

--- a/chain/processor.go
+++ b/chain/processor.go
@@ -23,9 +23,10 @@ type fetchData struct {
 	chunks uint16
 }
 
-func (b *StatefulBlock) Execute(
+func (b *StatefulBlock[T]) Execute(
 	ctx context.Context,
 	tracer trace.Tracer, //nolint:interfacer
+	runtime T,
 	im state.Immutable,
 	feeManager *fees.Manager,
 	r Rules,
@@ -92,7 +93,7 @@ func (b *StatefulBlock) Execute(
 				return err
 			}
 
-			result, err := tx.Execute(ctx, feeManager, sm, r, tsv, t)
+			result, err := tx.Execute(ctx, feeManager, runtime, sm, r, tsv, t)
 			if err != nil {
 				return err
 			}

--- a/chain/transaction.go
+++ b/chain/transaction.go
@@ -337,14 +337,18 @@ func (t *Transaction[T]) Execute(
 		actionOutputs = [][]byte{}
 	)
 
-	rt := Runtime[T]{
-		T:     runtime,
-		Rules: r,
-		State: ts,
-	}
-
 	for i, action := range t.Actions {
-		actionOutput, err := action.Execute(ctx, rt, timestamp, t.Auth.Actor(), CreateActionID(t.ID(), uint8(i)))
+		actionOutput, err := action.Execute(
+			ctx,
+			Runtime[T]{
+				T:     runtime,
+				Rules: r,
+				State: ts,
+			},
+			timestamp,
+			t.Auth.Actor(),
+			CreateActionID(t.ID(), uint8(i)),
+		)
 		if err != nil {
 			ts.Rollback(ctx, actionStart)
 			return &Result{false, utils.ErrBytes(err), actionOutputs, units, fee}, nil

--- a/chain/transaction_test.go
+++ b/chain/transaction_test.go
@@ -7,9 +7,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/hypersdk/auth"
 	"github.com/ava-labs/hypersdk/chain"

--- a/chain/verify_context.go
+++ b/chain/verify_context.go
@@ -12,33 +12,33 @@ import (
 )
 
 var (
-	_ VerifyContext = (*AcceptedVerifyContext)(nil)
-	_ VerifyContext = (*PendingVerifyContext)(nil)
+	_ VerifyContext[RuntimeInterface] = (*AcceptedVerifyContext[RuntimeInterface])(nil)
+	_ VerifyContext[RuntimeInterface] = (*PendingVerifyContext[RuntimeInterface])(nil)
 )
 
-type PendingVerifyContext struct {
-	blk *StatefulBlock
+type PendingVerifyContext[T RuntimeInterface] struct {
+	blk *StatefulBlock[T]
 }
 
-func (p *PendingVerifyContext) View(ctx context.Context, verify bool) (state.View, error) {
+func (p *PendingVerifyContext[_]) View(ctx context.Context, verify bool) (state.View, error) {
 	return p.blk.View(ctx, verify)
 }
 
-func (p *PendingVerifyContext) IsRepeat(ctx context.Context, oldestAllowed int64, txs []*Transaction, marker set.Bits, stop bool) (set.Bits, error) {
+func (p *PendingVerifyContext[T]) IsRepeat(ctx context.Context, oldestAllowed int64, txs []*Transaction[T], marker set.Bits, stop bool) (set.Bits, error) {
 	return p.blk.IsRepeat(ctx, oldestAllowed, txs, marker, stop)
 }
 
-type AcceptedVerifyContext struct {
-	vm VM
+type AcceptedVerifyContext[T RuntimeInterface] struct {
+	vm VM[T]
 }
 
 // We disregard [verify] because [GetVerifyContext] ensures
 // we will never need to verify a block if [AcceptedVerifyContext] is returned.
-func (a *AcceptedVerifyContext) View(context.Context, bool) (state.View, error) {
+func (a *AcceptedVerifyContext[_]) View(context.Context, bool) (state.View, error) {
 	return a.vm.State()
 }
 
-func (a *AcceptedVerifyContext) IsRepeat(ctx context.Context, _ int64, txs []*Transaction, marker set.Bits, stop bool) (set.Bits, error) {
+func (a *AcceptedVerifyContext[T]) IsRepeat(ctx context.Context, _ int64, txs []*Transaction[T], marker set.Bits, stop bool) (set.Bits, error) {
 	bits := a.vm.IsRepeat(ctx, txs, marker, stop)
 	return bits, nil
 }

--- a/cli/chain.go
+++ b/cli/chain.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/ava-labs/avalanchego/utils/units"
+
 	"github.com/ava-labs/hypersdk/api/jsonrpc"
 	"github.com/ava-labs/hypersdk/api/ws"
 	"github.com/ava-labs/hypersdk/cli/prompt"

--- a/cli/chain.go
+++ b/cli/chain.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/ava-labs/avalanchego/utils/units"
-
 	"github.com/ava-labs/hypersdk/api/jsonrpc"
 	"github.com/ava-labs/hypersdk/api/ws"
 	"github.com/ava-labs/hypersdk/cli/prompt"
@@ -19,12 +18,12 @@ import (
 	"github.com/ava-labs/hypersdk/utils"
 )
 
-func (h *Handler) ImportChain() error {
+func (h *Handler[T]) ImportChain() error {
 	uri, err := prompt.String("uri", 0, consts.MaxInt)
 	if err != nil {
 		return err
 	}
-	client := jsonrpc.NewJSONRPCClient(uri)
+	client := jsonrpc.NewJSONRPCClient[T](uri)
 	_, _, chainID, err := client.Network(context.TODO())
 	if err != nil {
 		return err
@@ -38,7 +37,7 @@ func (h *Handler) ImportChain() error {
 	return nil
 }
 
-func (h *Handler) SetDefaultChain() error {
+func (h *Handler[_]) SetDefaultChain() error {
 	chains, err := h.GetChains()
 	if err != nil {
 		return err
@@ -50,7 +49,7 @@ func (h *Handler) SetDefaultChain() error {
 	return h.StoreDefaultChain(chainID)
 }
 
-func (h *Handler) PrintChainInfo() error {
+func (h *Handler[T]) PrintChainInfo() error {
 	chains, err := h.GetChains()
 	if err != nil {
 		return err
@@ -59,7 +58,7 @@ func (h *Handler) PrintChainInfo() error {
 	if err != nil {
 		return err
 	}
-	cli := jsonrpc.NewJSONRPCClient(uris[0])
+	cli := jsonrpc.NewJSONRPCClient[T](uris[0])
 	networkID, subnetID, chainID, err := cli.Network(context.Background())
 	if err != nil {
 		return err
@@ -73,7 +72,7 @@ func (h *Handler) PrintChainInfo() error {
 	return nil
 }
 
-func (h *Handler) WatchChain(hideTxs bool) error {
+func (h *Handler[T]) WatchChain(hideTxs bool) error {
 	ctx := context.Background()
 	chains, err := h.GetChains()
 	if err != nil {
@@ -91,7 +90,7 @@ func (h *Handler) WatchChain(hideTxs bool) error {
 	if err != nil {
 		return err
 	}
-	scli, err := ws.NewWebSocketClient(uris[0], ws.DefaultHandshakeTimeout, pubsub.MaxPendingMessages, pubsub.MaxReadMessageSize) // we write the max read
+	scli, err := ws.NewWebSocketClient[T](uris[0], ws.DefaultHandshakeTimeout, pubsub.MaxPendingMessages, pubsub.MaxReadMessageSize) // we write the max read
 	if err != nil {
 		return err
 	}

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -11,25 +11,25 @@ import (
 	"github.com/ava-labs/hypersdk/internal/pebble"
 )
 
-type Controller interface {
+type Controller[T chain.RuntimeInterface] interface {
 	DatabasePath() string
 	Symbol() string
 	Decimals() uint8
-	GetParser(string) (chain.Parser, error)
-	HandleTx(*chain.Transaction, *chain.Result)
+	GetParser(string) (chain.Parser[T], error)
+	HandleTx(*chain.Transaction[T], *chain.Result)
 	LookupBalance(address codec.Address, uri string) (uint64, error)
 }
 
-type Handler struct {
-	c Controller
+type Handler[T chain.RuntimeInterface] struct {
+	c Controller[T]
 
 	db database.Database
 }
 
-func New(c Controller) (*Handler, error) {
+func New[T chain.RuntimeInterface](c Controller[T]) (*Handler[T], error) {
 	db, _, err := pebble.New(c.DatabasePath(), pebble.NewDefaultConfig())
 	if err != nil {
 		return nil, err
 	}
-	return &Handler{c, db}, nil
+	return &Handler[T]{c, db}, nil
 }

--- a/cli/key.go
+++ b/cli/key.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ava-labs/hypersdk/utils"
 )
 
-func (h *Handler) SetKey() error {
+func (h *Handler[_]) SetKey() error {
 	keys, err := h.GetKeys()
 	if err != nil {
 		return err
@@ -50,7 +50,7 @@ func (h *Handler) SetKey() error {
 	return h.StoreDefaultKey(key.Address)
 }
 
-func (h *Handler) Balance(checkAllChains bool) error {
+func (h *Handler[_]) Balance(checkAllChains bool) error {
 	addr, _, err := h.GetDefaultKey(true)
 	if err != nil {
 		return err

--- a/cli/prometheus.go
+++ b/cli/prometheus.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ava-labs/hypersdk/internal/prometheus"
 )
 
-func (h *Handler) GeneratePrometheus(baseURI string, openBrowser bool, startPrometheus bool, prometheusFile string, prometheusData string) error {
+func (h *Handler[_]) GeneratePrometheus(baseURI string, openBrowser bool, startPrometheus bool, prometheusFile string, prometheusData string) error {
 	chains, err := h.GetChains()
 	if err != nil {
 		return err

--- a/cli/spam.go
+++ b/cli/spam.go
@@ -18,9 +18,8 @@ import (
 	"syscall"
 	"time"
 
-	"golang.org/x/sync/errgroup"
-
 	"github.com/ava-labs/avalanchego/utils/set"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/ava-labs/hypersdk/api/jsonrpc"
 	"github.com/ava-labs/hypersdk/api/ws"

--- a/cli/storage.go
+++ b/cli/storage.go
@@ -23,14 +23,14 @@ const (
 	defaultChainKey = "chain"
 )
 
-func (h *Handler) StoreDefault(key string, value []byte) error {
+func (h *Handler[_]) StoreDefault(key string, value []byte) error {
 	k := make([]byte, 1+len(key))
 	k[0] = defaultPrefix
 	copy(k[1:], []byte(key))
 	return h.db.Put(k, value)
 }
 
-func (h *Handler) GetDefault(key string) ([]byte, error) {
+func (h *Handler[_]) GetDefault(key string) ([]byte, error) {
 	k := make([]byte, 1+len(key))
 	k[0] = defaultPrefix
 	copy(k[1:], []byte(key))
@@ -44,11 +44,11 @@ func (h *Handler) GetDefault(key string) ([]byte, error) {
 	return v, nil
 }
 
-func (h *Handler) StoreDefaultChain(chainID ids.ID) error {
+func (h *Handler[_]) StoreDefaultChain(chainID ids.ID) error {
 	return h.StoreDefault(defaultChainKey, chainID[:])
 }
 
-func (h *Handler) GetDefaultChain(log bool) (ids.ID, []string, error) {
+func (h *Handler[_]) GetDefaultChain(log bool) (ids.ID, []string, error) {
 	v, err := h.GetDefault(defaultChainKey)
 	if err != nil {
 		return ids.Empty, nil, err
@@ -67,7 +67,7 @@ func (h *Handler) GetDefaultChain(log bool) (ids.ID, []string, error) {
 	return chainID, uris, nil
 }
 
-func (h *Handler) StoreKey(priv *PrivateKey) error {
+func (h *Handler[_]) StoreKey(priv *PrivateKey) error {
 	k := make([]byte, 1+codec.AddressLen)
 	k[0] = keyPrefix
 	copy(k[1:], priv.Address[:])
@@ -81,7 +81,7 @@ func (h *Handler) StoreKey(priv *PrivateKey) error {
 	return h.db.Put(k, priv.Bytes)
 }
 
-func (h *Handler) GetKey(addr codec.Address) ([]byte, error) {
+func (h *Handler[_]) GetKey(addr codec.Address) ([]byte, error) {
 	k := make([]byte, 1+codec.AddressLen)
 	k[0] = keyPrefix
 	copy(k[1:], addr[:])
@@ -101,7 +101,7 @@ type PrivateKey struct {
 	Bytes   []byte
 }
 
-func (h *Handler) GetKeys() ([]*PrivateKey, error) {
+func (h *Handler[_]) GetKeys() ([]*PrivateKey, error) {
 	iter := h.db.NewIteratorWithPrefix([]byte{keyPrefix})
 	defer iter.Release()
 
@@ -117,11 +117,11 @@ func (h *Handler) GetKeys() ([]*PrivateKey, error) {
 	return privateKeys, iter.Error()
 }
 
-func (h *Handler) StoreDefaultKey(addr codec.Address) error {
+func (h *Handler[_]) StoreDefaultKey(addr codec.Address) error {
 	return h.StoreDefault(defaultKeyKey, addr[:])
 }
 
-func (h *Handler) GetDefaultKey(log bool) (codec.Address, []byte, error) {
+func (h *Handler[_]) GetDefaultKey(log bool) (codec.Address, []byte, error) {
 	raddr, err := h.GetDefault(defaultKeyKey)
 	if err != nil {
 		return codec.EmptyAddress, nil, err
@@ -140,7 +140,7 @@ func (h *Handler) GetDefaultKey(log bool) (codec.Address, []byte, error) {
 	return addr, priv, nil
 }
 
-func (h *Handler) StoreChain(chainID ids.ID, rpc string) error {
+func (h *Handler[_]) StoreChain(chainID ids.ID, rpc string) error {
 	k := make([]byte, 1+ids.IDLen*2)
 	k[0] = chainPrefix
 	copy(k[1:], chainID[:])
@@ -157,7 +157,7 @@ func (h *Handler) StoreChain(chainID ids.ID, rpc string) error {
 	return h.db.Put(k, brpc)
 }
 
-func (h *Handler) GetChain(chainID ids.ID) ([]string, error) {
+func (h *Handler[_]) GetChain(chainID ids.ID) ([]string, error) {
 	k := make([]byte, 1+ids.IDLen)
 	k[0] = chainPrefix
 	copy(k[1:], chainID[:])
@@ -173,7 +173,7 @@ func (h *Handler) GetChain(chainID ids.ID) ([]string, error) {
 	return rpcs, iter.Error()
 }
 
-func (h *Handler) GetChains() (map[ids.ID][]string, error) {
+func (h *Handler[_]) GetChains() (map[ids.ID][]string, error) {
 	iter := h.db.NewIteratorWithPrefix([]byte{chainPrefix})
 	defer iter.Release()
 
@@ -193,7 +193,7 @@ func (h *Handler) GetChains() (map[ids.ID][]string, error) {
 	return chains, iter.Error()
 }
 
-func (h *Handler) DeleteChains() ([]ids.ID, error) {
+func (h *Handler[_]) DeleteChains() ([]ids.ID, error) {
 	chains, err := h.GetChains()
 	if err != nil {
 		return nil, err
@@ -216,7 +216,7 @@ func (h *Handler) DeleteChains() ([]ids.ID, error) {
 	return chainIDs, nil
 }
 
-func (h *Handler) CloseDatabase() error {
+func (h *Handler[_]) CloseDatabase() error {
 	if h.db == nil {
 		return nil
 	}

--- a/examples/morpheusvm/actions/transfer.go
+++ b/examples/morpheusvm/actions/transfer.go
@@ -26,7 +26,7 @@ const (
 var (
 	ErrOutputValueZero                           = errors.New("value is zero")
 	ErrOutputMemoTooLarge                        = errors.New("memo is too large")
-	_                     chain.Action[struct{}] = (*Transfer[struct{}])(nil)
+	_                     chain.Action[struct{}] = (*Transfer)(nil)
 )
 
 type Transfer struct {

--- a/examples/morpheusvm/actions/transfer.go
+++ b/examples/morpheusvm/actions/transfer.go
@@ -24,9 +24,9 @@ const (
 )
 
 var (
-	ErrOutputValueZero                 = errors.New("value is zero")
-	ErrOutputMemoTooLarge              = errors.New("memo is too large")
-	_                     chain.Action = (*Transfer)(nil)
+	ErrOutputValueZero                           = errors.New("value is zero")
+	ErrOutputMemoTooLarge                        = errors.New("memo is too large")
+	_                     chain.Action[struct{}] = (*Transfer[struct{}])(nil)
 )
 
 type Transfer struct {
@@ -57,8 +57,7 @@ func (*Transfer) StateKeysMaxChunks() []uint16 {
 
 func (t *Transfer) Execute(
 	ctx context.Context,
-	_ chain.Rules,
-	mu state.Mutable,
+	runtime chain.Runtime[struct{}],
 	_ int64,
 	actor codec.Address,
 	_ ids.ID,
@@ -69,11 +68,11 @@ func (t *Transfer) Execute(
 	if len(t.Memo) > MaxMemoSize {
 		return nil, ErrOutputMemoTooLarge
 	}
-	senderBalance, err := storage.SubBalance(ctx, mu, actor, t.Value)
+	senderBalance, err := storage.SubBalance(ctx, runtime.State, actor, t.Value)
 	if err != nil {
 		return nil, err
 	}
-	receiverBalance, err := storage.AddBalance(ctx, mu, t.To, t.Value, true)
+	receiverBalance, err := storage.AddBalance(ctx, runtime.State, t.To, t.Value, true)
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +105,7 @@ func (t *Transfer) Marshal(p *codec.Packer) {
 	p.PackBytes(t.Memo)
 }
 
-func UnmarshalTransfer(p *codec.Packer) (chain.Action, error) {
+func UnmarshalTransfer(p *codec.Packer) (chain.Action[struct{}], error) {
 	var transfer Transfer
 	p.UnpackAddress(&transfer.To)
 	transfer.Value = p.UnpackUint64(true)

--- a/examples/morpheusvm/actions/transfer_test.go
+++ b/examples/morpheusvm/actions/transfer_test.go
@@ -8,11 +8,10 @@ import (
 	"math"
 	"testing"
 
+	"github.com/ava-labs/avalanchego/ids"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/hypersdk/chain"
-
 	"github.com/ava-labs/hypersdk/chain/chaintest"
 	"github.com/ava-labs/hypersdk/codec"
 	"github.com/ava-labs/hypersdk/codec/codectest"

--- a/examples/morpheusvm/cmd/morpheus-cli/cmd/action.go
+++ b/examples/morpheusvm/cmd/morpheus-cli/cmd/action.go
@@ -55,7 +55,7 @@ var transferCmd = &cobra.Command{
 		}
 
 		// Generate transaction
-		_, _, err = sendAndWait(ctx, []chain.Action{&actions.Transfer{
+		_, _, err = sendAndWait(ctx, []chain.Action[struct{}]{&actions.Transfer{
 			To:    recipient,
 			Value: amount,
 		}}, cli, bcli, ws, factory, true)

--- a/examples/morpheusvm/cmd/morpheus-cli/cmd/handler.go
+++ b/examples/morpheusvm/cmd/morpheus-cli/cmd/handler.go
@@ -33,11 +33,11 @@ func NewHandler(h *cli.Handler[struct{}]) *Handler {
 	return &Handler{h}
 }
 
-func (h *Handler[_]) Root() *cli.Handler[struct{}] {
+func (h *Handler) Root() *cli.Handler[struct{}] {
 	return h.h
 }
 
-func (h *Handler[_]) DefaultActor() (
+func (h *Handler) DefaultActor() (
 	ids.ID, *cli.PrivateKey, chain.AuthFactory,
 	*jsonrpc.JSONRPCClient[struct{}], *vm.JSONRPCClient, *ws.WebSocketClient[struct{}], error,
 ) {

--- a/examples/morpheusvm/cmd/morpheus-cli/cmd/handler.go
+++ b/examples/morpheusvm/cmd/morpheus-cli/cmd/handler.go
@@ -23,23 +23,23 @@ import (
 	"github.com/ava-labs/hypersdk/utils"
 )
 
-var _ cli.Controller = (*Controller)(nil)
+var _ cli.Controller[struct{}] = (*Controller)(nil)
 
 type Handler struct {
-	h *cli.Handler
+	h *cli.Handler[struct{}]
 }
 
-func NewHandler(h *cli.Handler) *Handler {
+func NewHandler(h *cli.Handler[struct{}]) *Handler {
 	return &Handler{h}
 }
 
-func (h *Handler) Root() *cli.Handler {
+func (h *Handler[_]) Root() *cli.Handler[struct{}] {
 	return h.h
 }
 
-func (h *Handler) DefaultActor() (
+func (h *Handler[_]) DefaultActor() (
 	ids.ID, *cli.PrivateKey, chain.AuthFactory,
-	*jsonrpc.JSONRPCClient, *vm.JSONRPCClient, *ws.WebSocketClient, error,
+	*jsonrpc.JSONRPCClient[struct{}], *vm.JSONRPCClient, *ws.WebSocketClient[struct{}], error,
 ) {
 	addr, priv, err := h.h.GetDefaultKey(true)
 	if err != nil {
@@ -64,11 +64,11 @@ func (h *Handler) DefaultActor() (
 	if err != nil {
 		return ids.Empty, nil, nil, nil, nil, nil, err
 	}
-	jcli := jsonrpc.NewJSONRPCClient(uris[0])
+	jcli := jsonrpc.NewJSONRPCClient[struct{}](uris[0])
 	if err != nil {
 		return ids.Empty, nil, nil, nil, nil, nil, err
 	}
-	ws, err := ws.NewWebSocketClient(uris[0], ws.DefaultHandshakeTimeout, pubsub.MaxPendingMessages, pubsub.MaxReadMessageSize)
+	ws, err := ws.NewWebSocketClient[struct{}](uris[0], ws.DefaultHandshakeTimeout, pubsub.MaxPendingMessages, pubsub.MaxReadMessageSize)
 	if err != nil {
 		return ids.Empty, nil, nil, nil, nil, nil, err
 	}
@@ -125,12 +125,12 @@ func (*Controller) Decimals() uint8 {
 	return consts.Decimals
 }
 
-func (*Controller) GetParser(uri string) (chain.Parser, error) {
+func (*Controller) GetParser(uri string) (chain.Parser[struct{}], error) {
 	cli := vm.NewJSONRPCClient(uri)
 	return cli.Parser(context.TODO())
 }
 
-func (*Controller) HandleTx(tx *chain.Transaction, result *chain.Result) {
+func (*Controller) HandleTx(tx *chain.Transaction[struct{}], result *chain.Result) {
 	handleTx(tx, result)
 }
 

--- a/examples/morpheusvm/cmd/morpheus-cli/cmd/resolutions.go
+++ b/examples/morpheusvm/cmd/morpheus-cli/cmd/resolutions.go
@@ -21,8 +21,8 @@ import (
 
 // sendAndWait may not be used concurrently
 func sendAndWait(
-	ctx context.Context, actions []chain.Action, cli *jsonrpc.JSONRPCClient,
-	bcli *vm.JSONRPCClient, ws *ws.WebSocketClient, factory chain.AuthFactory, printStatus bool,
+	ctx context.Context, actions []chain.Action[struct{}], cli *jsonrpc.JSONRPCClient[struct{}],
+	bcli *vm.JSONRPCClient, ws *ws.WebSocketClient[struct{}], factory chain.AuthFactory, printStatus bool,
 ) (bool, ids.ID, error) {
 	parser, err := bcli.Parser(ctx)
 	if err != nil {
@@ -60,7 +60,7 @@ func sendAndWait(
 	return result.Success, tx.ID(), nil
 }
 
-func handleTx(tx *chain.Transaction, result *chain.Result) {
+func handleTx(tx *chain.Transaction[struct{}], result *chain.Result) {
 	actor := tx.Auth.Actor()
 	if !result.Success {
 		utils.Outf(

--- a/examples/morpheusvm/cmd/morpheus-cli/cmd/root.go
+++ b/examples/morpheusvm/cmd/morpheus-cli/cmd/root.go
@@ -62,7 +62,7 @@ func init() {
 	rootCmd.PersistentPreRunE = func(*cobra.Command, []string) error {
 		utils.Outf("{{yellow}}database:{{/}} %s\n", dbPath)
 		controller := NewController(dbPath)
-		root, err := cli.New(controller)
+		root, err := cli.New[struct{}](controller)
 		if err != nil {
 			return err
 		}

--- a/examples/morpheusvm/cmd/morpheus-cli/cmd/spam.go
+++ b/examples/morpheusvm/cmd/morpheus-cli/cmd/spam.go
@@ -26,7 +26,7 @@ import (
 type SpamHelper struct {
 	keyType string
 	cli     *vm.JSONRPCClient
-	ws      *ws.WebSocketClient
+	ws      *ws.WebSocketClient[struct{}]
 }
 
 func (sh *SpamHelper) CreateAccount() (*cli.PrivateKey, error) {
@@ -52,7 +52,7 @@ func (*SpamHelper) GetFactory(pk *cli.PrivateKey) (chain.AuthFactory, error) {
 
 func (sh *SpamHelper) CreateClient(uri string) error {
 	sh.cli = vm.NewJSONRPCClient(uri)
-	ws, err := ws.NewWebSocketClient(uri, ws.DefaultHandshakeTimeout, pubsub.MaxPendingMessages, pubsub.MaxReadMessageSize)
+	ws, err := ws.NewWebSocketClient[struct{}](uri, ws.DefaultHandshakeTimeout, pubsub.MaxPendingMessages, pubsub.MaxReadMessageSize)
 	if err != nil {
 		return err
 	}
@@ -60,7 +60,7 @@ func (sh *SpamHelper) CreateClient(uri string) error {
 	return nil
 }
 
-func (sh *SpamHelper) GetParser(ctx context.Context) (chain.Parser, error) {
+func (sh *SpamHelper) GetParser(ctx context.Context) (chain.Parser[struct{}], error) {
 	return sh.cli.Parser(ctx)
 }
 
@@ -79,8 +79,8 @@ func (sh *SpamHelper) LookupBalance(choice int, address codec.Address) (uint64, 
 	return balance, err
 }
 
-func (*SpamHelper) GetTransfer(address codec.Address, amount uint64, memo []byte) []chain.Action {
-	return []chain.Action{&actions.Transfer{
+func (*SpamHelper) GetTransfer(address codec.Address, amount uint64, memo []byte) []chain.Action[struct{}] {
+	return []chain.Action[struct{}]{&actions.Transfer{
 		To:    address,
 		Value: amount,
 		Memo:  memo,

--- a/examples/morpheusvm/tests/e2e/e2e_test.go
+++ b/examples/morpheusvm/tests/e2e/e2e_test.go
@@ -7,9 +7,8 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/ava-labs/avalanchego/tests/fixture/e2e"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/hypersdk/abi"
 	"github.com/ava-labs/hypersdk/examples/morpheusvm/consts"
@@ -17,9 +16,8 @@ import (
 	"github.com/ava-labs/hypersdk/examples/morpheusvm/vm"
 	"github.com/ava-labs/hypersdk/tests/fixture"
 
-	"github.com/onsi/ginkgo/v2"
-
 	he2e "github.com/ava-labs/hypersdk/tests/e2e"
+	ginkgo "github.com/onsi/ginkgo/v2"
 )
 
 const owner = "morpheusvm-e2e-tests"

--- a/examples/morpheusvm/tests/e2e/e2e_test.go
+++ b/examples/morpheusvm/tests/e2e/e2e_test.go
@@ -7,8 +7,9 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/ava-labs/avalanchego/tests/fixture/e2e"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/avalanchego/tests/fixture/e2e"
 
 	"github.com/ava-labs/hypersdk/abi"
 	"github.com/ava-labs/hypersdk/examples/morpheusvm/consts"
@@ -16,8 +17,9 @@ import (
 	"github.com/ava-labs/hypersdk/examples/morpheusvm/vm"
 	"github.com/ava-labs/hypersdk/tests/fixture"
 
+	"github.com/onsi/ginkgo/v2"
+
 	he2e "github.com/ava-labs/hypersdk/tests/e2e"
-	ginkgo "github.com/onsi/ginkgo/v2"
 )
 
 const owner = "morpheusvm-e2e-tests"

--- a/examples/morpheusvm/tests/workload/workload.go
+++ b/examples/morpheusvm/tests/workload/workload.go
@@ -8,8 +8,9 @@ import (
 	"math"
 	"time"
 
-	"github.com/ava-labs/avalanchego/ids"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/avalanchego/ids"
 
 	"github.com/ava-labs/hypersdk/api/indexer"
 	"github.com/ava-labs/hypersdk/api/jsonrpc"
@@ -32,9 +33,9 @@ const (
 )
 
 var (
-	_              workload.TxWorkloadFactory  = (*workloadFactory)(nil)
-	_              workload.TxWorkloadIterator = (*simpleTxWorkload)(nil)
-	ed25519HexKeys                             = []string{
+	_              workload.TxWorkloadFactory[struct{}]  = (*workloadFactory)(nil)
+	_              workload.TxWorkloadIterator[struct{}] = (*simpleTxWorkload)(nil)
+	ed25519HexKeys                                       = []string{
 		"323b1d8f4eed5f0da9da93071b034f2dce9d2d22692c172f3cb252a64ddfafd01b057de320297c29ad0c1f589ea216869cf1938d88c9fbd70d6748323dbf2fa7", //nolint:lll
 		"8a7be2e0c9a2d09ac2861c34326d6fe5a461d920ba9c2b345ae28e603d517df148735063f8d5d8ba79ea4668358943e5c80bc09e9b2b9a15b5b15db6c1862e88", //nolint:lll
 	}
@@ -62,7 +63,7 @@ type workloadFactory struct {
 	addrs     []codec.Address
 }
 
-func New(minBlockGap int64) (*genesis.DefaultGenesis, workload.TxWorkloadFactory, error) {
+func New(minBlockGap int64) (*genesis.DefaultGenesis, workload.TxWorkloadFactory[struct{}], error) {
 	customAllocs := make([]*genesis.CustomAllocation, 0, len(ed25519Addrs))
 	for _, prefundedAddr := range ed25519Addrs {
 		customAllocs = append(customAllocs, &genesis.CustomAllocation{
@@ -85,8 +86,8 @@ func New(minBlockGap int64) (*genesis.DefaultGenesis, workload.TxWorkloadFactory
 	}, nil
 }
 
-func (f *workloadFactory) NewSizedTxWorkload(uri string, size int) (workload.TxWorkloadIterator, error) {
-	cli := jsonrpc.NewJSONRPCClient(uri)
+func (f *workloadFactory) NewSizedTxWorkload(uri string, size int) (workload.TxWorkloadIterator[struct{}], error) {
+	cli := jsonrpc.NewJSONRPCClient[struct{}](uri)
 	lcli := vm.NewJSONRPCClient(uri)
 	return &simpleTxWorkload{
 		factory: f.factories[0],
@@ -98,7 +99,7 @@ func (f *workloadFactory) NewSizedTxWorkload(uri string, size int) (workload.TxW
 
 type simpleTxWorkload struct {
 	factory *auth.ED25519Factory
-	cli     *jsonrpc.JSONRPCClient
+	cli     *jsonrpc.JSONRPCClient[struct{}]
 	lcli    *vm.JSONRPCClient
 	count   int
 	size    int
@@ -108,7 +109,7 @@ func (g *simpleTxWorkload) Next() bool {
 	return g.count < g.size
 }
 
-func (g *simpleTxWorkload) GenerateTxWithAssertion(ctx context.Context) (*chain.Transaction, workload.TxAssertion, error) {
+func (g *simpleTxWorkload) GenerateTxWithAssertion(ctx context.Context) (*chain.Transaction[struct{}], workload.TxAssertion, error) {
 	g.count++
 	other, err := ed25519.GeneratePrivateKey()
 	if err != nil {
@@ -123,7 +124,7 @@ func (g *simpleTxWorkload) GenerateTxWithAssertion(ctx context.Context) (*chain.
 	_, tx, _, err := g.cli.GenerateTransaction(
 		ctx,
 		parser,
-		[]chain.Action{&actions.Transfer{
+		[]chain.Action[struct{}]{&actions.Transfer{
 			To:    aother,
 			Value: 1,
 		}},
@@ -146,7 +147,7 @@ func (g *simpleTxWorkload) GenerateTxWithAssertion(ctx context.Context) (*chain.
 	}, nil
 }
 
-func (f *workloadFactory) NewWorkloads(uri string) ([]workload.TxWorkloadIterator, error) {
+func (f *workloadFactory) NewWorkloads(uri string) ([]workload.TxWorkloadIterator[struct{}], error) {
 	blsPriv, err := bls.GeneratePrivateKey()
 	if err != nil {
 		return nil, err
@@ -163,7 +164,7 @@ func (f *workloadFactory) NewWorkloads(uri string) ([]workload.TxWorkloadIterato
 	secpAddr := auth.NewSECP256R1Address(secpPub)
 	secpFactory := auth.NewSECP256R1Factory(secpPriv)
 
-	cli := jsonrpc.NewJSONRPCClient(uri)
+	cli := jsonrpc.NewJSONRPCClient[struct{}](uri)
 	networkID, _, blockchainID, err := cli.Network(context.Background())
 	if err != nil {
 		return nil, err
@@ -183,7 +184,7 @@ func (f *workloadFactory) NewWorkloads(uri string) ([]workload.TxWorkloadIterato
 		chainID:   blockchainID,
 	}
 
-	return []workload.TxWorkloadIterator{generator}, nil
+	return []workload.TxWorkloadIterator[struct{}]{generator}, nil
 }
 
 type addressAndFactory struct {
@@ -194,7 +195,7 @@ type addressAndFactory struct {
 type mixedAuthWorkload struct {
 	addressAndFactories []addressAndFactory
 	balance             uint64
-	cli                 *jsonrpc.JSONRPCClient
+	cli                 *jsonrpc.JSONRPCClient[struct{}]
 	lcli                *vm.JSONRPCClient
 	networkID           uint32
 	chainID             ids.ID
@@ -205,7 +206,7 @@ func (g *mixedAuthWorkload) Next() bool {
 	return g.count < len(g.addressAndFactories)-1
 }
 
-func (g *mixedAuthWorkload) GenerateTxWithAssertion(ctx context.Context) (*chain.Transaction, workload.TxAssertion, error) {
+func (g *mixedAuthWorkload) GenerateTxWithAssertion(ctx context.Context) (*chain.Transaction[struct{}], workload.TxAssertion, error) {
 	defer func() { g.count++ }()
 
 	sender := g.addressAndFactories[g.count]
@@ -219,7 +220,7 @@ func (g *mixedAuthWorkload) GenerateTxWithAssertion(ctx context.Context) (*chain
 	_, tx, _, err := g.cli.GenerateTransaction(
 		ctx,
 		parser,
-		[]chain.Action{&actions.Transfer{
+		[]chain.Action[struct{}]{&actions.Transfer{
 			To:    receiver.address,
 			Value: expectedBalance,
 		}},

--- a/examples/morpheusvm/tests/workload/workload.go
+++ b/examples/morpheusvm/tests/workload/workload.go
@@ -8,9 +8,8 @@ import (
 	"math"
 	"time"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/hypersdk/api/indexer"
 	"github.com/ava-labs/hypersdk/api/jsonrpc"

--- a/examples/morpheusvm/vm/client.go
+++ b/examples/morpheusvm/vm/client.go
@@ -88,7 +88,7 @@ func (cli *JSONRPCClient) WaitForBalance(
 	})
 }
 
-func (cli *JSONRPCClient) Parser(ctx context.Context) (chain.Parser, error) {
+func (cli *JSONRPCClient) Parser(ctx context.Context) (chain.Parser[struct{}], error) {
 	g, err := cli.Genesis(ctx)
 	if err != nil {
 		return nil, err
@@ -96,7 +96,7 @@ func (cli *JSONRPCClient) Parser(ctx context.Context) (chain.Parser, error) {
 	return NewParser(g), nil
 }
 
-var _ chain.Parser = (*Parser)(nil)
+var _ chain.Parser[struct{}] = (*Parser)(nil)
 
 type Parser struct {
 	genesis *genesis.DefaultGenesis
@@ -106,7 +106,7 @@ func (p *Parser) Rules(_ int64) chain.Rules {
 	return p.genesis.Rules
 }
 
-func (*Parser) ActionRegistry() chain.ActionRegistry {
+func (*Parser) ActionRegistry() chain.ActionRegistry[struct{}] {
 	return ActionParser
 }
 
@@ -122,12 +122,12 @@ func (*Parser) StateManager() chain.StateManager {
 	return &storage.StateManager{}
 }
 
-func NewParser(genesis *genesis.DefaultGenesis) chain.Parser {
+func NewParser(genesis *genesis.DefaultGenesis) chain.Parser[struct{}] {
 	return &Parser{genesis: genesis}
 }
 
 // Used as a lambda function for creating ExternalSubscriberServer parser
-func CreateParser(genesisBytes []byte) (chain.Parser, error) {
+func CreateParser(genesisBytes []byte) (chain.Parser[struct{}], error) {
 	var genesis genesis.DefaultGenesis
 	if err := json.Unmarshal(genesisBytes, &genesis); err != nil {
 		return nil, err

--- a/examples/morpheusvm/vm/option.go
+++ b/examples/morpheusvm/vm/option.go
@@ -17,12 +17,12 @@ func NewDefaultConfig() Config {
 	}
 }
 
-func With() vm.Option {
-	return vm.NewOption(Namespace, NewDefaultConfig(), func(v *vm.VM, config Config) error {
+func With() vm.Option[struct{}] {
+	return vm.NewOption[struct{}](Namespace, NewDefaultConfig(), func(v *vm.VM[struct{}], config Config) error {
 		if !config.Enabled {
 			return nil
 		}
-		vm.WithVMAPIs(jsonRPCServerFactory{})(v)
+		vm.WithVMAPIs[struct{}](jsonRPCServerFactory{})(v)
 		return nil
 	})
 }

--- a/examples/morpheusvm/vm/server.go
+++ b/examples/morpheusvm/vm/server.go
@@ -15,11 +15,11 @@ import (
 
 const JSONRPCEndpoint = "/morpheusapi"
 
-var _ api.HandlerFactory[api.VM] = (*jsonRPCServerFactory)(nil)
+var _ api.HandlerFactory[api.VM[struct{}]] = (*jsonRPCServerFactory)(nil)
 
 type jsonRPCServerFactory struct{}
 
-func (jsonRPCServerFactory) New(vm api.VM) (api.Handler, error) {
+func (jsonRPCServerFactory) New(vm api.VM[struct{}]) (api.Handler, error) {
 	handler, err := api.NewJSONRPCHandler(consts.Name, NewJSONRPCServer(vm))
 	return api.Handler{
 		Path:    JSONRPCEndpoint,
@@ -28,10 +28,10 @@ func (jsonRPCServerFactory) New(vm api.VM) (api.Handler, error) {
 }
 
 type JSONRPCServer struct {
-	vm api.VM
+	vm api.VM[struct{}]
 }
 
-func NewJSONRPCServer(vm api.VM) *JSONRPCServer {
+func NewJSONRPCServer(vm api.VM[struct{}]) *JSONRPCServer {
 	return &JSONRPCServer{vm: vm}
 }
 

--- a/examples/morpheusvm/vm/vm.go
+++ b/examples/morpheusvm/vm/vm.go
@@ -49,7 +49,7 @@ func init() {
 
 // NewWithOptions returns a VM with the specified options
 func New(options ...vm.Option[struct{}]) (*vm.VM[struct{}], error) {
-	options = append(options, With[struct{}]()) // Add MorpheusVM API
+	options = append(options, With()) // Add MorpheusVM API
 	return defaultvm.New[struct{}](
 		struct{}{}, // MorpheusVM does not define a runtime
 		consts.Version,

--- a/examples/morpheusvm/vm/vm.go
+++ b/examples/morpheusvm/vm/vm.go
@@ -33,7 +33,7 @@ func init() {
 	errs.Add(
 		// When registering new actions, ALWAYS make sure to append at the end.
 		// Pass nil as second argument if manual marshalling isn't needed (if in doubt, you probably don't)
-		ActionParser.Register(&actions.Transfer{}, actions.UnmarshalTransfer[struct{}]),
+		ActionParser.Register(&actions.Transfer{}, actions.UnmarshalTransfer),
 
 		// When registering new auth, ALWAYS make sure to append at the end.
 		AuthParser.Register(&auth.ED25519{}, auth.UnmarshalED25519),

--- a/examples/morpheusvm/vm/vm.go
+++ b/examples/morpheusvm/vm/vm.go
@@ -18,14 +18,14 @@ import (
 )
 
 var (
-	ActionParser *codec.TypeParser[chain.Action]
+	ActionParser *codec.TypeParser[chain.Action[struct{}]]
 	AuthParser   *codec.TypeParser[chain.Auth]
 	OutputParser *codec.TypeParser[codec.Typed]
 )
 
 // Setup types
 func init() {
-	ActionParser = codec.NewTypeParser[chain.Action]()
+	ActionParser = codec.NewTypeParser[chain.Action[struct{}]]()
 	AuthParser = codec.NewTypeParser[chain.Auth]()
 	OutputParser = codec.NewTypeParser[codec.Typed]()
 
@@ -33,7 +33,7 @@ func init() {
 	errs.Add(
 		// When registering new actions, ALWAYS make sure to append at the end.
 		// Pass nil as second argument if manual marshalling isn't needed (if in doubt, you probably don't)
-		ActionParser.Register(&actions.Transfer{}, actions.UnmarshalTransfer),
+		ActionParser.Register(&actions.Transfer[struct{}]{}, actions.UnmarshalTransfer[struct{}]),
 
 		// When registering new auth, ALWAYS make sure to append at the end.
 		AuthParser.Register(&auth.ED25519{}, auth.UnmarshalED25519),
@@ -48,9 +48,10 @@ func init() {
 }
 
 // NewWithOptions returns a VM with the specified options
-func New(options ...vm.Option) (*vm.VM, error) {
-	options = append(options, With()) // Add MorpheusVM API
-	return defaultvm.New(
+func New(options ...vm.Option[struct{}]) (*vm.VM[struct{}], error) {
+	options = append(options, With[struct{}]()) // Add MorpheusVM API
+	return defaultvm.New[struct{}](
+		struct{}{}, // MorpheusVM does not define a runtime
 		consts.Version,
 		genesis.DefaultGenesisFactory{},
 		&storage.StateManager{},

--- a/examples/morpheusvm/vm/vm.go
+++ b/examples/morpheusvm/vm/vm.go
@@ -33,7 +33,7 @@ func init() {
 	errs.Add(
 		// When registering new actions, ALWAYS make sure to append at the end.
 		// Pass nil as second argument if manual marshalling isn't needed (if in doubt, you probably don't)
-		ActionParser.Register(&actions.Transfer[struct{}]{}, actions.UnmarshalTransfer[struct{}]),
+		ActionParser.Register(&actions.Transfer{}, actions.UnmarshalTransfer[struct{}]),
 
 		// When registering new auth, ALWAYS make sure to append at the end.
 		AuthParser.Register(&auth.ED25519{}, auth.UnmarshalED25519),

--- a/examples/vmwithcontracts/actions/call.go
+++ b/examples/vmwithcontracts/actions/call.go
@@ -19,7 +19,7 @@ import (
 	mconsts "github.com/ava-labs/hypersdk/examples/vmwithcontracts/consts"
 )
 
-var _ chain.Action = (*Call)(nil)
+var _ chain.Action[struct{}] = (*Call)(nil)
 
 const MaxCallDataSize = units.MiB
 
@@ -70,8 +70,7 @@ func (t *Call) StateKeysMaxChunks() []uint16 {
 
 func (t *Call) Execute(
 	ctx context.Context,
-	_ chain.Rules,
-	mu state.Mutable,
+	rt chain.Runtime[struct{}],
 	timestamp int64,
 	actor codec.Address,
 	_ ids.ID,
@@ -79,7 +78,7 @@ func (t *Call) Execute(
 	resutBytes, err := t.r.CallContract(ctx, &runtime.CallInfo{
 		Contract:     t.ContractAddress,
 		Actor:        actor,
-		State:        &storage.ContractStateManager{Mutable: mu},
+		State:        &storage.ContractStateManager{Mutable: rt.State},
 		FunctionName: t.Function,
 		Params:       t.CallData,
 		Timestamp:    uint64(timestamp),
@@ -114,8 +113,8 @@ func (t *Call) Marshal(p *codec.Packer) {
 	}
 }
 
-func UnmarshalCallContract(r *runtime.WasmRuntime) func(p *codec.Packer) (chain.Action, error) {
-	return func(p *codec.Packer) (chain.Action, error) {
+func UnmarshalCallContract(r *runtime.WasmRuntime) func(p *codec.Packer) (chain.Action[struct{}], error) {
+	return func(p *codec.Packer) (chain.Action[struct{}], error) {
 		callContract := Call{r: r}
 		callContract.Value = p.UnpackUint64(false)
 		callContract.Fuel = p.UnpackUint64(true)

--- a/examples/vmwithcontracts/actions/call.go
+++ b/examples/vmwithcontracts/actions/call.go
@@ -19,6 +19,7 @@ import (
 	mconsts "github.com/ava-labs/hypersdk/examples/vmwithcontracts/consts"
 )
 
+// TODO: inject runtime here instead of attaching to the action
 var _ chain.Action[struct{}] = (*Call)(nil)
 
 const MaxCallDataSize = units.MiB

--- a/examples/vmwithcontracts/actions/call_test.go
+++ b/examples/vmwithcontracts/actions/call_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 
 	"github.com/ava-labs/avalanchego/ids"
-	"github.com/ava-labs/hypersdk/chain"
 
+	"github.com/ava-labs/hypersdk/chain"
 	"github.com/ava-labs/hypersdk/chain/chaintest"
 	"github.com/ava-labs/hypersdk/codec"
 	"github.com/ava-labs/hypersdk/state"

--- a/examples/vmwithcontracts/actions/call_test.go
+++ b/examples/vmwithcontracts/actions/call_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/hypersdk/chain"
 
 	"github.com/ava-labs/hypersdk/chain/chaintest"
 	"github.com/ava-labs/hypersdk/codec"
@@ -18,7 +19,7 @@ import (
 func TestCallAction(t *testing.T) {
 	ts := tstate.New(1)
 	addr := codec.CreateAddress(0, ids.GenerateTestID())
-	tests := []chaintest.ActionTest{
+	tests := []chaintest.ActionTest[struct{}]{
 		{
 			Name:  "No Statekeys",
 			Actor: codec.EmptyAddress,
@@ -26,7 +27,10 @@ func TestCallAction(t *testing.T) {
 				ContractAddress: addr,
 				Value:           0,
 			},
-			State:       ts.NewView(make(state.Keys), map[string][]byte{}),
+			Runtime: chain.Runtime[struct{}]{
+				T:     struct{}{},
+				State: ts.NewView(make(state.Keys), map[string][]byte{}),
+			},
 			ExpectedErr: tstate.ErrInvalidKeyOrPermission,
 		},
 	}

--- a/examples/vmwithcontracts/actions/deploy.go
+++ b/examples/vmwithcontracts/actions/deploy.go
@@ -19,7 +19,7 @@ import (
 	mconsts "github.com/ava-labs/hypersdk/examples/vmwithcontracts/consts"
 )
 
-var _ chain.Action = (*Deploy)(nil)
+var _ chain.Action[struct{}] = (*Deploy)(nil)
 
 const MAXCREATIONSIZE = units.MiB
 
@@ -49,13 +49,12 @@ func (*Deploy) StateKeysMaxChunks() []uint16 {
 
 func (d *Deploy) Execute(
 	ctx context.Context,
-	_ chain.Rules,
-	mu state.Mutable,
+	runtime chain.Runtime[struct{}],
 	_ int64,
 	_ codec.Address,
 	_ ids.ID,
 ) (codec.Typed, error) {
-	result, err := (&storage.ContractStateManager{Mutable: mu}).
+	result, err := (&storage.ContractStateManager{Mutable: runtime.State}).
 		NewAccountWithContract(ctx, d.ContractID, d.CreationInfo)
 	return &AddressOutput{Address: result}, err
 }
@@ -73,7 +72,7 @@ func (d *Deploy) Marshal(p *codec.Packer) {
 	p.PackBytes(d.CreationInfo)
 }
 
-func UnmarshalDeployContract(p *codec.Packer) (chain.Action, error) {
+func UnmarshalDeployContract(p *codec.Packer) (chain.Action[struct{}], error) {
 	var deployContract Deploy
 	p.UnpackBytes(36, true, (*[]byte)(&deployContract.ContractID))
 	p.UnpackBytes(MAXCREATIONSIZE, false, &deployContract.CreationInfo)

--- a/examples/vmwithcontracts/actions/publish.go
+++ b/examples/vmwithcontracts/actions/publish.go
@@ -21,7 +21,7 @@ import (
 	mconsts "github.com/ava-labs/hypersdk/examples/vmwithcontracts/consts"
 )
 
-var _ chain.Action = (*Publish)(nil)
+var _ chain.Action[struct{}] = (*Publish)(nil)
 
 const MAXCONTRACTSIZE = 2 * units.MiB
 
@@ -53,13 +53,12 @@ func (t *Publish) StateKeysMaxChunks() []uint16 {
 
 func (t *Publish) Execute(
 	ctx context.Context,
-	_ chain.Rules,
-	mu state.Mutable,
+	runtime chain.Runtime[struct{}],
 	_ int64,
 	_ codec.Address,
 	_ ids.ID,
 ) (codec.Typed, error) {
-	resultBytes, err := storage.StoreContract(ctx, mu, t.ContractBytes)
+	resultBytes, err := storage.StoreContract(ctx, runtime.State, t.ContractBytes)
 	if err != nil {
 		return nil, err
 	}
@@ -78,7 +77,7 @@ func (t *Publish) Marshal(p *codec.Packer) {
 	p.PackBytes(t.ContractBytes)
 }
 
-func UnmarshalPublishContract(p *codec.Packer) (chain.Action, error) {
+func UnmarshalPublishContract(p *codec.Packer) (chain.Action[struct{}], error) {
 	var publishContract Publish
 	p.UnpackBytes(MAXCONTRACTSIZE, true, &publishContract.ContractBytes)
 	if err := p.Err(); err != nil {

--- a/examples/vmwithcontracts/cmd/vmwithcontracts-cli/cmd/action.go
+++ b/examples/vmwithcontracts/cmd/vmwithcontracts-cli/cmd/action.go
@@ -60,7 +60,7 @@ var transferCmd = &cobra.Command{
 		}
 
 		// Generate transaction
-		_, err = sendAndWait(ctx, []chain.Action{&actions.Transfer{
+		_, err = sendAndWait(ctx, []chain.Action[struct{}]{&actions.Transfer{
 			To:    recipient,
 			Value: amount,
 		}}, cli, bcli, ws, factory)
@@ -94,7 +94,7 @@ var publishFileCmd = &cobra.Command{
 		}
 
 		// Generate transaction
-		result, err := sendAndWait(ctx, []chain.Action{&actions.Publish{
+		result, err := sendAndWait(ctx, []chain.Action[struct{}]{&actions.Publish{
 			ContractBytes: bytes,
 		}}, cli, bcli, ws, factory)
 
@@ -162,7 +162,7 @@ var callCmd = &cobra.Command{
 		}
 
 		// Generate transaction
-		result, err := sendAndWait(ctx, []chain.Action{action}, cli, bcli, ws, factory)
+		result, err := sendAndWait(ctx, []chain.Action[struct{}]{action}, cli, bcli, ws, factory)
 
 		if result != nil && result.Success {
 			utils.Outf(hexutils.BytesToHex(result.Outputs[0]) + "\n")
@@ -217,7 +217,7 @@ var deployCmd = &cobra.Command{
 		}
 
 		// Generate transaction
-		result, err := sendAndWait(ctx, []chain.Action{&actions.Deploy{
+		result, err := sendAndWait(ctx, []chain.Action[struct{}]{&actions.Deploy{
 			ContractID:   contractID,
 			CreationInfo: creationInfo,
 		}}, cli, bcli, ws, factory)

--- a/examples/vmwithcontracts/cmd/vmwithcontracts-cli/cmd/handler.go
+++ b/examples/vmwithcontracts/cmd/vmwithcontracts-cli/cmd/handler.go
@@ -64,11 +64,11 @@ func (h *Handler) DefaultActor() (
 	if err != nil {
 		return ids.Empty, nil, nil, nil, nil, nil, err
 	}
-	jcli := jsonrpc.NewJSONRPCClient(uris[0])
+	jcli := jsonrpc.NewJSONRPCClient[struct{}](uris[0])
 	if err != nil {
 		return ids.Empty, nil, nil, nil, nil, nil, err
 	}
-	ws, err := ws.NewWebSocketClient(uris[0], ws.DefaultHandshakeTimeout, pubsub.MaxPendingMessages, pubsub.MaxReadMessageSize)
+	ws, err := ws.NewWebSocketClient[struct{}](uris[0], ws.DefaultHandshakeTimeout, pubsub.MaxPendingMessages, pubsub.MaxReadMessageSize)
 	if err != nil {
 		return ids.Empty, nil, nil, nil, nil, nil, err
 	}

--- a/examples/vmwithcontracts/cmd/vmwithcontracts-cli/cmd/handler.go
+++ b/examples/vmwithcontracts/cmd/vmwithcontracts-cli/cmd/handler.go
@@ -33,11 +33,11 @@ func NewHandler(h *cli.Handler) *Handler {
 	return &Handler{h}
 }
 
-func (h *Handler) Root() *cli.Handler {
+func (h *Handler[_]) Root() *cli.Handler {
 	return h.h
 }
 
-func (h *Handler) DefaultActor() (
+func (h *Handler[_]) DefaultActor() (
 	ids.ID, *cli.PrivateKey, chain.AuthFactory,
 	*jsonrpc.JSONRPCClient, *vm.JSONRPCClient, *ws.WebSocketClient, error,
 ) {

--- a/examples/vmwithcontracts/cmd/vmwithcontracts-cli/cmd/handler.go
+++ b/examples/vmwithcontracts/cmd/vmwithcontracts-cli/cmd/handler.go
@@ -23,23 +23,23 @@ import (
 	"github.com/ava-labs/hypersdk/utils"
 )
 
-var _ cli.Controller = (*Controller)(nil)
+var _ cli.Controller[struct{}] = (*Controller)(nil)
 
 type Handler struct {
-	h *cli.Handler
+	h *cli.Handler[struct{}]
 }
 
-func NewHandler(h *cli.Handler) *Handler {
+func NewHandler(h *cli.Handler[struct{}]) *Handler {
 	return &Handler{h}
 }
 
-func (h *Handler[_]) Root() *cli.Handler {
+func (h *Handler) Root() *cli.Handler[struct{}] {
 	return h.h
 }
 
-func (h *Handler[_]) DefaultActor() (
+func (h *Handler) DefaultActor() (
 	ids.ID, *cli.PrivateKey, chain.AuthFactory,
-	*jsonrpc.JSONRPCClient, *vm.JSONRPCClient, *ws.WebSocketClient, error,
+	*jsonrpc.JSONRPCClient[struct{}], *vm.JSONRPCClient, *ws.WebSocketClient[struct{}], error,
 ) {
 	addr, priv, err := h.h.GetDefaultKey(true)
 	if err != nil {
@@ -125,12 +125,12 @@ func (*Controller) Decimals() uint8 {
 	return consts.Decimals
 }
 
-func (*Controller) GetParser(uri string) (chain.Parser, error) {
+func (*Controller) GetParser(uri string) (chain.Parser[struct{}], error) {
 	cli := vm.NewJSONRPCClient(uri)
 	return cli.Parser(context.TODO())
 }
 
-func (*Controller) HandleTx(tx *chain.Transaction, result *chain.Result) {
+func (*Controller) HandleTx(tx *chain.Transaction[struct{}], result *chain.Result) {
 	handleTx(tx, result)
 }
 

--- a/examples/vmwithcontracts/cmd/vmwithcontracts-cli/cmd/resolutions.go
+++ b/examples/vmwithcontracts/cmd/vmwithcontracts-cli/cmd/resolutions.go
@@ -19,8 +19,8 @@ import (
 
 // sendAndWait may not be used concurrently
 func sendAndWait(
-	ctx context.Context, actions []chain.Action, cli *jsonrpc.JSONRPCClient,
-	bcli *vm.JSONRPCClient, ws *ws.WebSocketClient, factory chain.AuthFactory,
+	ctx context.Context, actions []chain.Action[struct{}], cli *jsonrpc.JSONRPCClient[struct{}],
+	bcli *vm.JSONRPCClient, ws *ws.WebSocketClient[struct{}], factory chain.AuthFactory,
 ) (*chain.Result, error) {
 	parser, err := bcli.Parser(ctx)
 	if err != nil {
@@ -57,7 +57,7 @@ func sendAndWait(
 	return result, nil
 }
 
-func handleTx(tx *chain.Transaction, result *chain.Result) {
+func handleTx(tx *chain.Transaction[struct{}], result *chain.Result) {
 	actor := tx.Auth.Actor()
 	if !result.Success {
 		utils.Outf(

--- a/examples/vmwithcontracts/cmd/vmwithcontracts-cli/cmd/spam.go
+++ b/examples/vmwithcontracts/cmd/vmwithcontracts-cli/cmd/spam.go
@@ -26,7 +26,7 @@ import (
 type SpamHelper struct {
 	keyType string
 	cli     *vm.JSONRPCClient
-	ws      *ws.WebSocketClient
+	ws      *ws.WebSocketClient[struct{}]
 }
 
 func (sh *SpamHelper) CreateAccount() (*cli.PrivateKey, error) {
@@ -52,7 +52,7 @@ func (*SpamHelper) GetFactory(pk *cli.PrivateKey) (chain.AuthFactory, error) {
 
 func (sh *SpamHelper) CreateClient(uri string) error {
 	sh.cli = vm.NewJSONRPCClient(uri)
-	ws, err := ws.NewWebSocketClient(uri, ws.DefaultHandshakeTimeout, pubsub.MaxPendingMessages, pubsub.MaxReadMessageSize)
+	ws, err := ws.NewWebSocketClient[struct{}](uri, ws.DefaultHandshakeTimeout, pubsub.MaxPendingMessages, pubsub.MaxReadMessageSize)
 	if err != nil {
 		return err
 	}
@@ -60,7 +60,7 @@ func (sh *SpamHelper) CreateClient(uri string) error {
 	return nil
 }
 
-func (sh *SpamHelper) GetParser(ctx context.Context) (chain.Parser, error) {
+func (sh *SpamHelper) GetParser(ctx context.Context) (chain.Parser[struct{}], error) {
 	return sh.cli.Parser(ctx)
 }
 
@@ -79,8 +79,8 @@ func (sh *SpamHelper) LookupBalance(choice int, address codec.Address) (uint64, 
 	return balance, err
 }
 
-func (*SpamHelper) GetTransfer(address codec.Address, amount uint64, memo []byte) []chain.Action {
-	return []chain.Action{&actions.Transfer{
+func (*SpamHelper) GetTransfer(address codec.Address, amount uint64, memo []byte) []chain.Action[struct{}] {
+	return []chain.Action[struct{}]{&actions.Transfer{
 		To:    address,
 		Value: amount,
 		Memo:  memo,

--- a/examples/vmwithcontracts/vm/client.go
+++ b/examples/vmwithcontracts/vm/client.go
@@ -91,7 +91,7 @@ func (cli *JSONRPCClient) WaitForBalance(
 	})
 }
 
-func (cli *JSONRPCClient) Parser(ctx context.Context) (chain.Parser, error) {
+func (cli *JSONRPCClient) Parser(ctx context.Context) (chain.Parser[struct{}], error) {
 	g, err := cli.Genesis(ctx)
 	if err != nil {
 		return nil, err
@@ -99,7 +99,7 @@ func (cli *JSONRPCClient) Parser(ctx context.Context) (chain.Parser, error) {
 	return NewParser(g), nil
 }
 
-var _ chain.Parser = (*Parser)(nil)
+var _ chain.Parser[struct{}] = (*Parser)(nil)
 
 type Parser struct {
 	genesis *genesis.DefaultGenesis
@@ -109,7 +109,7 @@ func (p *Parser) Rules(_ int64) chain.Rules {
 	return p.genesis.Rules
 }
 
-func (*Parser) ActionRegistry() chain.ActionRegistry {
+func (*Parser) ActionRegistry() chain.ActionRegistry[struct{}] {
 	return ActionParser
 }
 
@@ -125,12 +125,12 @@ func (*Parser) StateManager() chain.StateManager {
 	return &storage.StateManager{}
 }
 
-func NewParser(genesis *genesis.DefaultGenesis) chain.Parser {
+func NewParser(genesis *genesis.DefaultGenesis) chain.Parser[struct{}] {
 	return &Parser{genesis: genesis}
 }
 
 // Used as a lambda function for creating ExternalSubscriberServer parser
-func CreateParser(genesisBytes []byte) (chain.Parser, error) {
+func CreateParser(genesisBytes []byte) (chain.Parser[struct{}], error) {
 	var genesis genesis.DefaultGenesis
 	if err := json.Unmarshal(genesisBytes, &genesis); err != nil {
 		return nil, err

--- a/examples/vmwithcontracts/vm/option.go
+++ b/examples/vmwithcontracts/vm/option.go
@@ -20,18 +20,18 @@ func NewDefaultConfig() Config {
 	}
 }
 
-func With() vm.Option {
-	return vm.NewOption(Namespace, NewDefaultConfig(), func(v *vm.VM, config Config) error {
+func With() vm.Option[struct{}] {
+	return vm.NewOption[struct{}](Namespace, NewDefaultConfig(), func(v *vm.VM[struct{}], config Config) error {
 		if !config.Enabled {
 			return nil
 		}
-		vm.WithVMAPIs(jsonRPCServerFactory{})(v)
+		vm.WithVMAPIs[struct{}](jsonRPCServerFactory{})(v)
 		return nil
 	})
 }
 
-func WithRuntime() vm.Option {
-	return vm.NewOption(Namespace+"runtime", *runtime.NewConfig(), func(v *vm.VM, cfg runtime.Config) error {
+func WithRuntime() vm.Option[struct{}] {
+	return vm.NewOption[struct{}](Namespace+"runtime", *runtime.NewConfig(), func(v *vm.VM[struct{}], cfg runtime.Config) error {
 		wasmRuntime = runtime.NewRuntime(&cfg, v.Logger())
 		return nil
 	})

--- a/examples/vmwithcontracts/vm/server.go
+++ b/examples/vmwithcontracts/vm/server.go
@@ -20,11 +20,11 @@ import (
 
 const JSONRPCEndpoint = "/vmwithcontractsapi"
 
-var _ api.HandlerFactory[api.VM] = (*jsonRPCServerFactory)(nil)
+var _ api.HandlerFactory[api.VM[struct{}]] = (*jsonRPCServerFactory)(nil)
 
 type jsonRPCServerFactory struct{}
 
-func (jsonRPCServerFactory) New(v api.VM) (api.Handler, error) {
+func (jsonRPCServerFactory) New(v api.VM[struct{}]) (api.Handler, error) {
 	handler, err := api.NewJSONRPCHandler(consts.Name, NewJSONRPCServer(v))
 	return api.Handler{
 		Path:    JSONRPCEndpoint,
@@ -33,10 +33,10 @@ func (jsonRPCServerFactory) New(v api.VM) (api.Handler, error) {
 }
 
 type JSONRPCServer struct {
-	vm api.VM
+	vm api.VM[struct{}]
 }
 
-func NewJSONRPCServer(vm api.VM) *JSONRPCServer {
+func NewJSONRPCServer(vm api.VM[struct{}]) *JSONRPCServer {
 	return &JSONRPCServer{vm: vm}
 }
 

--- a/examples/vmwithcontracts/vm/vm.go
+++ b/examples/vmwithcontracts/vm/vm.go
@@ -22,7 +22,7 @@ import (
 )
 
 var (
-	ActionParser *codec.TypeParser[chain.Action]
+	ActionParser *codec.TypeParser[chain.Action[struct{}]]
 	AuthParser   *codec.TypeParser[chain.Auth]
 	OutputParser *codec.TypeParser[codec.Typed]
 	wasmRuntime  *runtime.WasmRuntime
@@ -30,7 +30,7 @@ var (
 
 // Setup types
 func init() {
-	ActionParser = codec.NewTypeParser[chain.Action]()
+	ActionParser = codec.NewTypeParser[chain.Action[struct{}]]()
 	AuthParser = codec.NewTypeParser[chain.Auth]()
 	OutputParser = codec.NewTypeParser[codec.Typed]()
 
@@ -57,24 +57,25 @@ func init() {
 }
 
 // New returns a VM with the indexer, websocket, rpc, and external subscriber apis enabled.
-func New(options ...vm.Option) (*vm.VM, error) {
-	opts := append([]vm.Option{
-		indexer.With(),
-		ws.With(),
-		jsonrpc.With(),
+func New(options ...vm.Option[struct{}]) (*vm.VM[struct{}], error) {
+	opts := append([]vm.Option[struct{}]{
+		indexer.With[struct{}](),
+		ws.With[struct{}](),
+		jsonrpc.With[struct{}](),
 		With(), // Add Controller API
-		externalsubscriber.With(),
+		externalsubscriber.With[struct{}](),
 	}, options...)
 
 	return NewWithOptions(opts...)
 }
 
 // NewWithOptions returns a VM with the specified options
-func NewWithOptions(options ...vm.Option) (*vm.VM, error) {
-	opts := append([]vm.Option{
+func NewWithOptions(options ...vm.Option[struct{}]) (*vm.VM[struct{}], error) {
+	opts := append([]vm.Option[struct{}]{
 		WithRuntime(),
 	}, options...)
-	return vm.New(
+	return vm.New[struct{}](
+		struct{}{},
 		consts.Version,
 		genesis.DefaultGenesisFactory{},
 		&storage.StateManager{},

--- a/extension/externalsubscriber/client.go
+++ b/extension/externalsubscriber/client.go
@@ -17,20 +17,20 @@ import (
 	pb "github.com/ava-labs/hypersdk/proto/pb/externalsubscriber"
 )
 
-var _ event.Subscription[*chain.StatefulBlock] = (*ExternalSubscriberClient)(nil)
+var _ event.Subscription[*chain.StatefulBlock[chain.RuntimeInterface]] = (*ExternalSubscriberClient[chain.RuntimeInterface])(nil)
 
-type ExternalSubscriberClient struct {
+type ExternalSubscriberClient[T chain.RuntimeInterface] struct {
 	conn   *grpc.ClientConn
 	client pb.ExternalSubscriberClient
 	log    logging.Logger
 }
 
-func NewExternalSubscriberClient(
+func NewExternalSubscriberClient[T chain.RuntimeInterface](
 	ctx context.Context,
 	log logging.Logger,
 	serverAddr string,
 	genesisBytes []byte,
-) (*ExternalSubscriberClient, error) {
+) (*ExternalSubscriberClient[T], error) {
 	// Establish connection to server
 	conn, err := grpc.Dial(serverAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
@@ -48,14 +48,14 @@ func NewExternalSubscriberClient(
 		return nil, err
 	}
 	log.Debug("connected to external subscriber server", zap.String("address", serverAddr))
-	return &ExternalSubscriberClient{
+	return &ExternalSubscriberClient[T]{
 		conn:   conn,
 		client: client,
 		log:    log,
 	}, nil
 }
 
-func (e *ExternalSubscriberClient) Accept(blk *chain.StatefulBlock) error {
+func (e *ExternalSubscriberClient[T]) Accept(blk *chain.StatefulBlock[T]) error {
 	blockBytes, err := blk.Marshal()
 	if err != nil {
 		return err
@@ -77,6 +77,6 @@ func (e *ExternalSubscriberClient) Accept(blk *chain.StatefulBlock) error {
 	return err
 }
 
-func (e *ExternalSubscriberClient) Close() error {
+func (e *ExternalSubscriberClient[_]) Close() error {
 	return e.conn.Close()
 }

--- a/extension/externalsubscriber/server.go
+++ b/extension/externalsubscriber/server.go
@@ -7,10 +7,9 @@ import (
 	"context"
 	"errors"
 
+	"github.com/ava-labs/avalanchego/utils/logging"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/emptypb"
-
-	"github.com/ava-labs/avalanchego/utils/logging"
 
 	"github.com/ava-labs/hypersdk/chain"
 	"github.com/ava-labs/hypersdk/event"

--- a/extension/externalsubscriber/server.go
+++ b/extension/externalsubscriber/server.go
@@ -7,9 +7,10 @@ import (
 	"context"
 	"errors"
 
-	"github.com/ava-labs/avalanchego/utils/logging"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/emptypb"
+
+	"github.com/ava-labs/avalanchego/utils/logging"
 
 	"github.com/ava-labs/hypersdk/chain"
 	"github.com/ava-labs/hypersdk/event"
@@ -17,7 +18,7 @@ import (
 	pb "github.com/ava-labs/hypersdk/proto/pb/externalsubscriber"
 )
 
-type CreateParser func(genesisBytes []byte) (chain.Parser, error)
+type CreateParser[T chain.RuntimeInterface] func(genesisBytes []byte) (chain.Parser[T], error)
 
 var (
 	ErrParserNotInitialized     = errors.New("parser not initialized")
@@ -26,42 +27,42 @@ var (
 
 // TODO: switch to eventually using chain.Stateless block
 // Wrapper to pass blocks + results to subscribers
-type ExternalSubscriberSubscriptionData struct {
-	Blk     *chain.StatelessBlock
+type ExternalSubscriberSubscriptionData[T chain.RuntimeInterface] struct {
+	Blk     *chain.StatelessBlock[T]
 	Results []*chain.Result
 }
 
-func NewExternalSubscriberSubscriptionData(
-	blk *chain.StatelessBlock,
+func NewExternalSubscriberSubscriptionData[T chain.RuntimeInterface](
+	blk *chain.StatelessBlock[T],
 	results []*chain.Result,
-) *ExternalSubscriberSubscriptionData {
-	return &ExternalSubscriberSubscriptionData{
+) *ExternalSubscriberSubscriptionData[T] {
+	return &ExternalSubscriberSubscriptionData[T]{
 		Blk:     blk,
 		Results: results,
 	}
 }
 
-type ExternalSubscriberServer struct {
+type ExternalSubscriberServer[T chain.RuntimeInterface] struct {
 	pb.ExternalSubscriberServer
-	parser              chain.Parser
-	createParser        CreateParser
-	acceptedSubscribers []event.Subscription[*ExternalSubscriberSubscriptionData]
+	parser              chain.Parser[T]
+	createParser        CreateParser[T]
+	acceptedSubscribers []event.Subscription[*ExternalSubscriberSubscriptionData[T]]
 	log                 logging.Logger
 }
 
-func NewExternalSubscriberServer(
+func NewExternalSubscriberServer[T chain.RuntimeInterface](
 	logger logging.Logger,
-	createParser CreateParser,
-	acceptedSubscribers []event.Subscription[*ExternalSubscriberSubscriptionData],
-) *ExternalSubscriberServer {
-	return &ExternalSubscriberServer{
+	createParser CreateParser[T],
+	acceptedSubscribers []event.Subscription[*ExternalSubscriberSubscriptionData[T]],
+) *ExternalSubscriberServer[T] {
+	return &ExternalSubscriberServer[T]{
 		log:                 logger,
 		createParser:        createParser,
 		acceptedSubscribers: acceptedSubscribers,
 	}
 }
 
-func (e *ExternalSubscriberServer) Initialize(_ context.Context, initRequest *pb.InitializeRequest) (*emptypb.Empty, error) {
+func (e *ExternalSubscriberServer[_]) Initialize(_ context.Context, initRequest *pb.InitializeRequest) (*emptypb.Empty, error) {
 	if e.parser != nil {
 		return &emptypb.Empty{}, ErrParserAlreadyInitialized
 	}
@@ -75,7 +76,7 @@ func (e *ExternalSubscriberServer) Initialize(_ context.Context, initRequest *pb
 	return &emptypb.Empty{}, nil
 }
 
-func (e *ExternalSubscriberServer) AcceptBlock(_ context.Context, b *pb.BlockRequest) (*emptypb.Empty, error) {
+func (e *ExternalSubscriberServer[_]) AcceptBlock(_ context.Context, b *pb.BlockRequest) (*emptypb.Empty, error) {
 	// Continue only if we can parse
 	if e.parser == nil {
 		return &emptypb.Empty{}, ErrParserNotInitialized

--- a/internal/builder/dependencies.go
+++ b/internal/builder/dependencies.go
@@ -12,11 +12,11 @@ import (
 	"github.com/ava-labs/hypersdk/chain"
 )
 
-type VM interface {
+type VM[T chain.RuntimeInterface] interface {
 	StopChan() chan struct{}
 	EngineChan() chan<- common.Message
-	PreferredBlock(context.Context) (*chain.StatefulBlock, error)
+	PreferredBlock(context.Context) (*chain.StatefulBlock[T], error)
 	Logger() logging.Logger
-	Mempool() chain.Mempool
+	Mempool() chain.Mempool[T]
 	Rules(int64) chain.Rules
 }

--- a/internal/builder/manual.go
+++ b/internal/builder/manual.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	"github.com/ava-labs/avalanchego/snow/engine/common"
+
 	"github.com/ava-labs/hypersdk/chain"
 )
 

--- a/internal/builder/manual.go
+++ b/internal/builder/manual.go
@@ -7,30 +7,31 @@ import (
 	"context"
 
 	"github.com/ava-labs/avalanchego/snow/engine/common"
+	"github.com/ava-labs/hypersdk/chain"
 )
 
-var _ Builder = (*Manual)(nil)
+var _ Builder = (*Manual[chain.RuntimeInterface])(nil)
 
-type Manual struct {
-	vm        VM
+type Manual[T chain.RuntimeInterface] struct {
+	vm        VM[T]
 	doneBuild chan struct{}
 }
 
-func NewManual(vm VM) *Manual {
-	return &Manual{
+func NewManual[T chain.RuntimeInterface](vm VM[T]) *Manual[T] {
+	return &Manual[T]{
 		vm:        vm,
 		doneBuild: make(chan struct{}),
 	}
 }
 
-func (b *Manual) Run() {
+func (b *Manual[_]) Run() {
 	close(b.doneBuild)
 }
 
 // Queue is a no-op in [Manual].
-func (*Manual) Queue(context.Context) {}
+func (*Manual[_]) Queue(context.Context) {}
 
-func (b *Manual) Force(context.Context) error {
+func (b *Manual[_]) Force(context.Context) error {
 	select {
 	case b.vm.EngineChan() <- common.PendingTxs:
 	default:
@@ -39,6 +40,6 @@ func (b *Manual) Force(context.Context) error {
 	return nil
 }
 
-func (b *Manual) Done() {
+func (b *Manual[_]) Done() {
 	<-b.doneBuild
 }

--- a/internal/builder/time.go
+++ b/internal/builder/time.go
@@ -8,10 +8,9 @@ import (
 	"sync/atomic"
 	"time"
 
-	"go.uber.org/zap"
-
 	"github.com/ava-labs/avalanchego/snow/engine/common"
 	"github.com/ava-labs/avalanchego/utils/timer"
+	"go.uber.org/zap"
 
 	"github.com/ava-labs/hypersdk/chain"
 )

--- a/internal/gossiper/dependencies.go
+++ b/internal/gossiper/dependencies.go
@@ -15,22 +15,22 @@ import (
 	"github.com/ava-labs/hypersdk/chain"
 )
 
-type VM interface {
+type VM[T chain.RuntimeInterface] interface {
 	NetworkID() uint32
 	ChainID() ids.ID
 	StopChan() chan struct{}
 	Tracer() trace.Tracer
-	Mempool() chain.Mempool
+	Mempool() chain.Mempool[T]
 	GetTargetGossipDuration() time.Duration
 	Proposers(ctx context.Context, diff int, depth int) (set.Set[ids.NodeID], error)
 	IsValidator(context.Context, ids.NodeID) (bool, error)
 	Logger() logging.Logger
-	PreferredBlock(context.Context) (*chain.StatefulBlock, error)
-	ActionRegistry() chain.ActionRegistry
+	PreferredBlock(context.Context) (*chain.StatefulBlock[T], error)
+	ActionRegistry() chain.ActionRegistry[T]
 	AuthRegistry() chain.AuthRegistry
 	NodeID() ids.NodeID
 	Rules(int64) chain.Rules
-	Submit(ctx context.Context, verify bool, txs []*chain.Transaction) []error
+	Submit(ctx context.Context, verify bool, txs []*chain.Transaction[T]) []error
 	GetAuthBatchVerifier(authTypeID uint8, cores int, count int) (chain.AuthBatchVerifier, bool)
 	StateManager() chain.StateManager
 

--- a/internal/gossiper/manual.go
+++ b/internal/gossiper/manual.go
@@ -7,10 +7,9 @@ import (
 	"context"
 	"time"
 
-	"go.uber.org/zap"
-
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow/engine/common"
+	"go.uber.org/zap"
 
 	"github.com/ava-labs/hypersdk/chain"
 	"github.com/ava-labs/hypersdk/consts"

--- a/internal/gossiper/proposer.go
+++ b/internal/gossiper/proposer.go
@@ -11,13 +11,12 @@ import (
 	"sync/atomic"
 	"time"
 
-	"go.uber.org/zap"
-
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow/engine/common"
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/utils/timer"
 	"github.com/ava-labs/avalanchego/vms/proposervm/proposer"
+	"go.uber.org/zap"
 
 	"github.com/ava-labs/hypersdk/chain"
 	"github.com/ava-labs/hypersdk/consts"

--- a/internal/validators/proposer_monitor.go
+++ b/internal/validators/proposer_monitor.go
@@ -16,7 +16,6 @@ import (
 	"github.com/ava-labs/avalanchego/utils/crypto/bls"
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/vms/proposervm/proposer"
-
 	"go.uber.org/zap"
 )
 

--- a/internal/validators/proposer_monitor.go
+++ b/internal/validators/proposer_monitor.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ava-labs/avalanchego/utils/crypto/bls"
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/vms/proposervm/proposer"
+
 	"go.uber.org/zap"
 )
 

--- a/tests/e2e/e2e.go
+++ b/tests/e2e/e2e.go
@@ -76,7 +76,7 @@ var _ = ginkgo.Describe("[HyperSDK APIs]", func() {
 		blockchainID := e2e.GetEnv(tc).GetNetwork().GetSubnet(vmName).Chains[0].ChainID
 		ctx := tc.DefaultContext()
 		for _, uri := range getE2EURIs(tc, blockchainID) {
-			client := state.NewJSONRPCStateClient[struct{}](uri)
+			client := state.NewJSONRPCStateClient(uri)
 			values, readerrs, err := client.ReadState(ctx, [][]byte{
 				[]byte(`my-unknown-key`),
 			})

--- a/tests/e2e/e2e.go
+++ b/tests/e2e/e2e.go
@@ -8,13 +8,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/ava-labs/avalanchego/api/info"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/tests"
 	"github.com/ava-labs/avalanchego/tests/fixture/e2e"
 	"github.com/ava-labs/avalanchego/tests/fixture/tmpnet"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/hypersdk/abi"
 	"github.com/ava-labs/hypersdk/api/jsonrpc"
@@ -22,7 +21,7 @@ import (
 	"github.com/ava-labs/hypersdk/tests/workload"
 	"github.com/ava-labs/hypersdk/utils"
 
-	"github.com/onsi/ginkgo/v2"
+	ginkgo "github.com/onsi/ginkgo/v2"
 )
 
 var (

--- a/tests/e2e/e2e.go
+++ b/tests/e2e/e2e.go
@@ -43,7 +43,7 @@ var _ = ginkgo.Describe("[HyperSDK APIs]", func() {
 
 	ginkgo.It("Ping", func() {
 		expectedBlockchainID := e2e.GetEnv(tc).GetNetwork().GetSubnet(vmName).Chains[0].ChainID
-		workload.Ping(tc.DefaultContext(), require, getE2EURIs(tc, expectedBlockchainID))
+		workload.Ping[struct{}](tc.DefaultContext(), require, getE2EURIs(tc, expectedBlockchainID))
 	})
 
 	ginkgo.It("StableNetworkIdentity", func() {

--- a/tests/e2e/e2e.go
+++ b/tests/e2e/e2e.go
@@ -50,7 +50,7 @@ var _ = ginkgo.Describe("[HyperSDK APIs]", func() {
 		hardcodedHostPort := "http://localhost:9650"
 		fixedNodeURL := hardcodedHostPort + "/ext/bc/" + vmName
 
-		c := jsonrpc.NewJSONRPCClient(fixedNodeURL)
+		c := jsonrpc.NewJSONRPCClient[struct{}](fixedNodeURL)
 		_, _, chainIDFromRPC, err := c.Network(tc.DefaultContext())
 		require.NoError(err)
 		expectedBlockchainID := e2e.GetEnv(tc).GetNetwork().GetSubnet(vmName).Chains[0].ChainID
@@ -76,7 +76,7 @@ var _ = ginkgo.Describe("[HyperSDK APIs]", func() {
 		blockchainID := e2e.GetEnv(tc).GetNetwork().GetSubnet(vmName).Chains[0].ChainID
 		ctx := tc.DefaultContext()
 		for _, uri := range getE2EURIs(tc, blockchainID) {
-			client := state.NewJSONRPCStateClient(uri)
+			client := state.NewJSONRPCStateClient[struct{}](uri)
 			values, readerrs, err := client.ReadState(ctx, [][]byte{
 				[]byte(`my-unknown-key`),
 			})
@@ -141,7 +141,7 @@ var _ = ginkgo.Describe("[HyperSDK Syncing]", func() {
 			syncNodeURI = formatURI(syncNode.URI, blockchainID)
 			uris = append(uris, syncNodeURI)
 			utils.Outf("{{blue}}sync node uri: %s{{/}}\n", syncNodeURI)
-			c := jsonrpc.NewJSONRPCClient(syncNodeURI)
+			c := jsonrpc.NewJSONRPCClient[struct{}](syncNodeURI)
 			_, _, _, err := c.Network(tc.DefaultContext())
 			require.NoError(err)
 		})
@@ -156,7 +156,7 @@ var _ = ginkgo.Describe("[HyperSDK Syncing]", func() {
 			require.NoError(syncNode.Stop(tc.DefaultContext()))
 
 			// TODO: remove extra Ping check and rely on tmpnet to stop the node correctly
-			c := jsonrpc.NewJSONRPCClient(syncNodeURI)
+			c := jsonrpc.NewJSONRPCClient[struct{}](syncNodeURI)
 			ok, err := c.Ping(tc.DefaultContext())
 			require.Error(err) //nolint:forbidigo
 			require.False(ok)
@@ -173,7 +173,7 @@ var _ = ginkgo.Describe("[HyperSDK Syncing]", func() {
 
 			utils.Outf("{{blue}}sync node reporting healthy: %s{{/}}\n", syncNodeURI)
 
-			c := jsonrpc.NewJSONRPCClient(syncNodeURI)
+			c := jsonrpc.NewJSONRPCClient[struct{}](syncNodeURI)
 			_, _, _, err := c.Network(tc.DefaultContext())
 			require.NoError(err)
 		})
@@ -206,7 +206,7 @@ var _ = ginkgo.Describe("[HyperSDK Syncing]", func() {
 			syncConcurrentNode := e2e.CheckBootstrapIsPossible(tc, e2e.GetEnv(tc).GetNetwork())
 			syncConcurrentNodeURI := formatURI(syncConcurrentNode.URI, blockchainID)
 			uris = append(uris, syncConcurrentNodeURI)
-			c := jsonrpc.NewJSONRPCClient(syncConcurrentNodeURI)
+			c := jsonrpc.NewJSONRPCClient[struct{}](syncConcurrentNodeURI)
 			_, _, _, err := c.Network(tc.DefaultContext())
 			require.NoError(err)
 		})

--- a/tests/integration/integration.go
+++ b/tests/integration/integration.go
@@ -11,9 +11,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
-
 	"github.com/ava-labs/avalanchego/api/metrics"
 	"github.com/ava-labs/avalanchego/database/memdb"
 	"github.com/ava-labs/avalanchego/ids"
@@ -25,6 +22,8 @@ import (
 	"github.com/ava-labs/avalanchego/utils/crypto/bls"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/vms/rpcchainvm/grpcutils"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 
 	"github.com/ava-labs/hypersdk/abi"
 	"github.com/ava-labs/hypersdk/api/jsonrpc"
@@ -39,10 +38,9 @@ import (
 	"github.com/ava-labs/hypersdk/tests/workload"
 	"github.com/ava-labs/hypersdk/vm"
 
-	"github.com/onsi/ginkgo/v2"
-
 	pb "github.com/ava-labs/hypersdk/proto/pb/externalsubscriber"
 	hutils "github.com/ava-labs/hypersdk/utils"
+	ginkgo "github.com/onsi/ginkgo/v2"
 )
 
 // TODO integration tests require MinBlockGap to be 0, so that BuildBlock can be called

--- a/tests/workload/apis.go
+++ b/tests/workload/apis.go
@@ -7,12 +7,11 @@ import (
 	"context"
 
 	"github.com/ava-labs/avalanchego/ids"
-	"github.com/ava-labs/hypersdk/chain"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/hypersdk/abi"
 	"github.com/ava-labs/hypersdk/api/jsonrpc"
+	"github.com/ava-labs/hypersdk/chain"
 )
 
 func Ping[T chain.RuntimeInterface](ctx context.Context, require *require.Assertions, uris []string) {

--- a/tests/workload/apis.go
+++ b/tests/workload/apis.go
@@ -7,24 +7,26 @@ import (
 	"context"
 
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/hypersdk/chain"
+
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/hypersdk/abi"
 	"github.com/ava-labs/hypersdk/api/jsonrpc"
 )
 
-func Ping(ctx context.Context, require *require.Assertions, uris []string) {
+func Ping[T chain.RuntimeInterface](ctx context.Context, require *require.Assertions, uris []string) {
 	for _, uri := range uris {
-		client := jsonrpc.NewJSONRPCClient(uri)
+		client := jsonrpc.NewJSONRPCClient[T](uri)
 		ok, err := client.Ping(ctx)
 		require.NoError(err)
 		require.True(ok)
 	}
 }
 
-func GetNetwork(ctx context.Context, require *require.Assertions, uris []string, expectedNetworkID uint32, expectedChainID ids.ID) {
+func GetNetwork[T chain.RuntimeInterface](ctx context.Context, require *require.Assertions, uris []string, expectedNetworkID uint32, expectedChainID ids.ID) {
 	for _, uri := range uris {
-		client := jsonrpc.NewJSONRPCClient(uri)
+		client := jsonrpc.NewJSONRPCClient[T](uri)
 		networkID, _, chainID, err := client.Network(ctx)
 		require.NoError(err)
 		require.Equal(expectedNetworkID, networkID)
@@ -32,9 +34,9 @@ func GetNetwork(ctx context.Context, require *require.Assertions, uris []string,
 	}
 }
 
-func GetABI(ctx context.Context, require *require.Assertions, uris []string, expectedABI abi.ABI) {
+func GetABI[T chain.RuntimeInterface](ctx context.Context, require *require.Assertions, uris []string, expectedABI abi.ABI) {
 	for _, uri := range uris {
-		client := jsonrpc.NewJSONRPCClient(uri)
+		client := jsonrpc.NewJSONRPCClient[T](uri)
 		actualABI, err := client.GetABI(ctx)
 		require.NoError(err)
 

--- a/vm/defaultvm/vm.go
+++ b/vm/defaultvm/vm.go
@@ -20,29 +20,31 @@ import (
 // DefaultOptions provides the default set of options to include
 // when constructing a new VM including the indexer, websocket,
 // JSONRPC, and external subscriber options.
-func NewDefaultOptions() []vm.Option {
-	return []vm.Option{
-		indexer.With(),
-		ws.With(),
-		jsonrpc.With(),
-		externalsubscriber.With(),
-		staterpc.With(),
+func NewDefaultOptions[T chain.RuntimeInterface]() []vm.Option[T] {
+	return []vm.Option[T]{
+		indexer.With[T](),
+		ws.With[T](),
+		jsonrpc.With[T](),
+		externalsubscriber.With[T](),
+		staterpc.With[T](),
 	}
 }
 
 // New returns a VM with DefaultOptions pre-supplied
-func New(
+func New[T chain.RuntimeInterface](
+	runtime T,
 	v *version.Semantic,
 	genesisFactory genesis.GenesisAndRuleFactory,
 	stateManager chain.StateManager,
-	actionRegistry chain.ActionRegistry,
+	actionRegistry chain.ActionRegistry[T],
 	authRegistry chain.AuthRegistry,
 	outputRegistry chain.OutputRegistry,
 	authEngine map[uint8]vm.AuthEngine,
-	options ...vm.Option,
-) (*vm.VM, error) {
-	options = append(options, NewDefaultOptions()...)
+	options ...vm.Option[T],
+) (*vm.VM[T], error) {
+	options = append(options, NewDefaultOptions[T]()...)
 	return vm.New(
+		runtime,
 		v,
 		genesisFactory,
 		stateManager,

--- a/vm/network_state_sync.go
+++ b/vm/network_state_sync.go
@@ -9,17 +9,18 @@ import (
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/version"
+	"github.com/ava-labs/hypersdk/chain"
 )
 
-type StateSyncHandler struct {
-	vm *VM
+type StateSyncHandler[T any] struct {
+	vm *VM[T]
 }
 
-func NewStateSyncHandler(vm *VM) *StateSyncHandler {
-	return &StateSyncHandler{vm}
+func NewStateSyncHandler[T chain.RuntimeInterface](vm *VM[T]) *StateSyncHandler[T] {
+	return &StateSyncHandler[T]{vm}
 }
 
-func (s *StateSyncHandler) Connected(
+func (s *StateSyncHandler[_]) Connected(
 	ctx context.Context,
 	nodeID ids.NodeID,
 	v *version.Application,
@@ -27,15 +28,15 @@ func (s *StateSyncHandler) Connected(
 	return s.vm.stateSyncNetworkClient.Connected(ctx, nodeID, v)
 }
 
-func (s *StateSyncHandler) Disconnected(ctx context.Context, nodeID ids.NodeID) error {
+func (s *StateSyncHandler[_]) Disconnected(ctx context.Context, nodeID ids.NodeID) error {
 	return s.vm.stateSyncNetworkClient.Disconnected(ctx, nodeID)
 }
 
-func (*StateSyncHandler) AppGossip(context.Context, ids.NodeID, []byte) error {
+func (*StateSyncHandler[_]) AppGossip(context.Context, ids.NodeID, []byte) error {
 	return nil
 }
 
-func (s *StateSyncHandler) AppRequest(
+func (s *StateSyncHandler[_]) AppRequest(
 	ctx context.Context,
 	nodeID ids.NodeID,
 	requestID uint32,
@@ -48,7 +49,7 @@ func (s *StateSyncHandler) AppRequest(
 	return s.vm.stateSyncNetworkServer.AppRequest(ctx, nodeID, requestID, deadline, request)
 }
 
-func (s *StateSyncHandler) AppRequestFailed(
+func (s *StateSyncHandler[_]) AppRequestFailed(
 	ctx context.Context,
 	nodeID ids.NodeID,
 	requestID uint32,
@@ -56,7 +57,7 @@ func (s *StateSyncHandler) AppRequestFailed(
 	return s.vm.stateSyncNetworkClient.AppRequestFailed(ctx, nodeID, requestID)
 }
 
-func (s *StateSyncHandler) AppResponse(
+func (s *StateSyncHandler[_]) AppResponse(
 	ctx context.Context,
 	nodeID ids.NodeID,
 	requestID uint32,
@@ -65,7 +66,7 @@ func (s *StateSyncHandler) AppResponse(
 	return s.vm.stateSyncNetworkClient.AppResponse(ctx, nodeID, requestID, response)
 }
 
-func (*StateSyncHandler) CrossChainAppRequest(
+func (*StateSyncHandler[_]) CrossChainAppRequest(
 	context.Context,
 	ids.ID,
 	uint32,
@@ -75,10 +76,10 @@ func (*StateSyncHandler) CrossChainAppRequest(
 	return nil
 }
 
-func (*StateSyncHandler) CrossChainAppRequestFailed(context.Context, ids.ID, uint32) error {
+func (*StateSyncHandler[_]) CrossChainAppRequestFailed(context.Context, ids.ID, uint32) error {
 	return nil
 }
 
-func (*StateSyncHandler) CrossChainAppResponse(context.Context, ids.ID, uint32, []byte) error {
+func (*StateSyncHandler[_]) CrossChainAppResponse(context.Context, ids.ID, uint32, []byte) error {
 	return nil
 }

--- a/vm/network_state_sync.go
+++ b/vm/network_state_sync.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/version"
+
 	"github.com/ava-labs/hypersdk/chain"
 )
 

--- a/vm/network_tx_gossip.go
+++ b/vm/network_tx_gossip.go
@@ -7,10 +7,9 @@ import (
 	"context"
 	"time"
 
-	"go.uber.org/zap"
-
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/version"
+	"go.uber.org/zap"
 )
 
 type TxGossipHandler[T any] struct {

--- a/vm/network_tx_gossip.go
+++ b/vm/network_tx_gossip.go
@@ -7,28 +7,29 @@ import (
 	"context"
 	"time"
 
+	"go.uber.org/zap"
+
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/version"
-	"go.uber.org/zap"
 )
 
-type TxGossipHandler struct {
-	vm *VM
+type TxGossipHandler[T any] struct {
+	vm *VM[T]
 }
 
-func NewTxGossipHandler(vm *VM) *TxGossipHandler {
-	return &TxGossipHandler{vm}
+func NewTxGossipHandler[T any](vm *VM[T]) *TxGossipHandler[T] {
+	return &TxGossipHandler[T]{vm}
 }
 
-func (*TxGossipHandler) Connected(context.Context, ids.NodeID, *version.Application) error {
+func (*TxGossipHandler[_]) Connected(context.Context, ids.NodeID, *version.Application) error {
 	return nil
 }
 
-func (*TxGossipHandler) Disconnected(context.Context, ids.NodeID) error {
+func (*TxGossipHandler[_]) Disconnected(context.Context, ids.NodeID) error {
 	return nil
 }
 
-func (t *TxGossipHandler) AppGossip(ctx context.Context, nodeID ids.NodeID, msg []byte) error {
+func (t *TxGossipHandler[_]) AppGossip(ctx context.Context, nodeID ids.NodeID, msg []byte) error {
 	if !t.vm.isReady() {
 		t.vm.snowCtx.Log.Warn("handle app gossip failed", zap.Error(ErrNotReady))
 		return nil
@@ -37,7 +38,7 @@ func (t *TxGossipHandler) AppGossip(ctx context.Context, nodeID ids.NodeID, msg 
 	return t.vm.gossiper.HandleAppGossip(ctx, nodeID, msg)
 }
 
-func (*TxGossipHandler) AppRequest(
+func (*TxGossipHandler[_]) AppRequest(
 	context.Context,
 	ids.NodeID,
 	uint32,
@@ -47,7 +48,7 @@ func (*TxGossipHandler) AppRequest(
 	return nil
 }
 
-func (*TxGossipHandler) AppRequestFailed(
+func (*TxGossipHandler[_]) AppRequestFailed(
 	context.Context,
 	ids.NodeID,
 	uint32,
@@ -55,7 +56,7 @@ func (*TxGossipHandler) AppRequestFailed(
 	return nil
 }
 
-func (*TxGossipHandler) AppResponse(
+func (*TxGossipHandler[_]) AppResponse(
 	context.Context,
 	ids.NodeID,
 	uint32,
@@ -64,7 +65,7 @@ func (*TxGossipHandler) AppResponse(
 	return nil
 }
 
-func (*TxGossipHandler) CrossChainAppRequest(
+func (*TxGossipHandler[_]) CrossChainAppRequest(
 	context.Context,
 	ids.ID,
 	uint32,
@@ -74,10 +75,10 @@ func (*TxGossipHandler) CrossChainAppRequest(
 	return nil
 }
 
-func (*TxGossipHandler) CrossChainAppRequestFailed(context.Context, ids.ID, uint32) error {
+func (*TxGossipHandler[_]) CrossChainAppRequestFailed(context.Context, ids.ID, uint32) error {
 	return nil
 }
 
-func (*TxGossipHandler) CrossChainAppResponse(context.Context, ids.ID, uint32, []byte) error {
+func (*TxGossipHandler[_]) CrossChainAppResponse(context.Context, ids.ID, uint32, []byte) error {
 	return nil
 }

--- a/vm/storage.go
+++ b/vm/storage.go
@@ -61,23 +61,23 @@ func PrefixBlockHeightIDKey(height uint64) []byte {
 	return k
 }
 
-func (vm *VM) HasGenesis() (bool, error) {
+func (vm *VM[_]) HasGenesis() (bool, error) {
 	return vm.HasDiskBlock(0)
 }
 
-func (vm *VM) GetGenesis(ctx context.Context) (*chain.StatefulBlock, error) {
+func (vm *VM[T]) GetGenesis(ctx context.Context) (*chain.StatefulBlock[T], error) {
 	return vm.GetDiskBlock(ctx, 0)
 }
 
-func (vm *VM) SetLastAcceptedHeight(height uint64) error {
+func (vm *VM[_]) SetLastAcceptedHeight(height uint64) error {
 	return vm.vmDB.Put(lastAccepted, binary.BigEndian.AppendUint64(nil, height))
 }
 
-func (vm *VM) HasLastAccepted() (bool, error) {
+func (vm *VM[_]) HasLastAccepted() (bool, error) {
 	return vm.vmDB.Has(lastAccepted)
 }
 
-func (vm *VM) GetLastAcceptedHeight() (uint64, error) {
+func (vm *VM[_]) GetLastAcceptedHeight() (uint64, error) {
 	b, err := vm.vmDB.Get(lastAccepted)
 	if err != nil {
 		return 0, err
@@ -85,15 +85,15 @@ func (vm *VM) GetLastAcceptedHeight() (uint64, error) {
 	return binary.BigEndian.Uint64(b), nil
 }
 
-func (vm *VM) SetLastProcessedHeight(height uint64) error {
+func (vm *VM[_]) SetLastProcessedHeight(height uint64) error {
 	return vm.vmDB.Put(lastProcessed, binary.BigEndian.AppendUint64(nil, height))
 }
 
-func (vm *VM) HasLastProcessed() (bool, error) {
+func (vm *VM[_]) HasLastProcessed() (bool, error) {
 	return vm.vmDB.Has(lastProcessed)
 }
 
-func (vm *VM) GetLastProcessedHeight() (uint64, error) {
+func (vm *VM[_]) GetLastProcessedHeight() (uint64, error) {
 	b, err := vm.vmDB.Get(lastProcessed)
 	if err != nil {
 		return 0, err
@@ -101,7 +101,7 @@ func (vm *VM) GetLastProcessedHeight() (uint64, error) {
 	return binary.BigEndian.Uint64(b), nil
 }
 
-func (vm *VM) shouldCompact(expiryHeight uint64) bool {
+func (vm *VM[_]) shouldCompact(expiryHeight uint64) bool {
 	if compactionOffset == -1 {
 		compactionOffset = rand.Intn(vm.config.BlockCompactionFrequency) //nolint:gosec
 		vm.Logger().Info("setting compaction offset", zap.Int("n", compactionOffset))
@@ -118,7 +118,7 @@ func (vm *VM) shouldCompact(expiryHeight uint64) bool {
 //
 // We store blocks by height because it doesn't cause nearly as much
 // compaction as storing blocks randomly on-disk (when using [block.ID]).
-func (vm *VM) UpdateLastAccepted(blk *chain.StatefulBlock) error {
+func (vm *VM[T]) UpdateLastAccepted(blk *chain.StatefulBlock[T]) error {
 	batch := vm.vmDB.NewBatch()
 	bigEndianHeight := binary.BigEndian.AppendUint64(nil, blk.Height())
 	if err := batch.Put(lastAccepted, bigEndianHeight); err != nil {
@@ -174,19 +174,19 @@ func (vm *VM) UpdateLastAccepted(blk *chain.StatefulBlock) error {
 	return nil
 }
 
-func (vm *VM) GetDiskBlock(ctx context.Context, height uint64) (*chain.StatefulBlock, error) {
+func (vm *VM[T]) GetDiskBlock(ctx context.Context, height uint64) (*chain.StatefulBlock[T], error) {
 	b, err := vm.vmDB.Get(PrefixBlockKey(height))
 	if err != nil {
 		return nil, err
 	}
-	return chain.ParseBlock(ctx, b, true, vm)
+	return chain.ParseBlock[T](ctx, b, true, vm)
 }
 
-func (vm *VM) HasDiskBlock(height uint64) (bool, error) {
+func (vm *VM[_]) HasDiskBlock(height uint64) (bool, error) {
 	return vm.vmDB.Has(PrefixBlockKey(height))
 }
 
-func (vm *VM) GetBlockHeightID(height uint64) (ids.ID, error) {
+func (vm *VM[_]) GetBlockHeightID(height uint64) (ids.ID, error) {
 	b, err := vm.vmDB.Get(PrefixBlockHeightIDKey(height))
 	if err != nil {
 		return ids.Empty, err
@@ -194,7 +194,7 @@ func (vm *VM) GetBlockHeightID(height uint64) (ids.ID, error) {
 	return ids.ID(b), nil
 }
 
-func (vm *VM) GetBlockIDHeight(blkID ids.ID) (uint64, error) {
+func (vm *VM[_]) GetBlockIDHeight(blkID ids.ID) (uint64, error) {
 	b, err := vm.vmDB.Get(PrefixBlockIDHeightKey(blkID))
 	if err != nil {
 		return 0, err
@@ -206,11 +206,11 @@ func (vm *VM) GetBlockIDHeight(blkID ids.ID) (uint64, error) {
 //
 // This can be used to ensure we clean up all large tombstoned keys on a regular basis instead
 // of waiting for the database to run a compaction (and potentially delete GBs of data at once).
-func (vm *VM) CompactDiskBlocks(lastExpired uint64) error {
+func (vm *VM[_]) CompactDiskBlocks(lastExpired uint64) error {
 	return vm.vmDB.Compact([]byte{blockPrefix}, PrefixBlockKey(lastExpired))
 }
 
-func (vm *VM) GetDiskIsSyncing() (bool, error) {
+func (vm *VM[_]) GetDiskIsSyncing() (bool, error) {
 	v, err := vm.vmDB.Get(isSyncing)
 	if errors.Is(err, database.ErrNotFound) {
 		return false, nil
@@ -221,7 +221,7 @@ func (vm *VM) GetDiskIsSyncing() (bool, error) {
 	return v[0] == 0x1, nil
 }
 
-func (vm *VM) PutDiskIsSyncing(v bool) error {
+func (vm *VM[_]) PutDiskIsSyncing(v bool) error {
 	if v {
 		return vm.vmDB.Put(isSyncing, []byte{0x1})
 	}

--- a/vm/syncervm_client.go
+++ b/vm/syncervm_client.go
@@ -19,14 +19,14 @@ import (
 	avasync "github.com/ava-labs/avalanchego/x/sync"
 )
 
-type stateSyncerClient struct {
-	vm          *VM
+type stateSyncerClient[T chain.RuntimeInterface] struct {
+	vm          *VM[T]
 	gatherer    avametrics.MultiGatherer
 	syncManager *avasync.Manager
 
 	// tracks the sync target so we can update last accepted
 	// block when sync completes.
-	target        *chain.StatefulBlock
+	target        *chain.StatefulBlock[T]
 	targetUpdated bool
 
 	// State Sync results
@@ -38,17 +38,17 @@ type stateSyncerClient struct {
 }
 
 // TODO: break out into own package
-func (vm *VM) NewStateSyncClient(
+func (vm *VM[T]) NewStateSyncClient(
 	gatherer avametrics.MultiGatherer,
-) *stateSyncerClient {
-	return &stateSyncerClient{
+) *stateSyncerClient[T] {
+	return &stateSyncerClient[T]{
 		vm:       vm,
 		gatherer: gatherer,
 		done:     make(chan struct{}),
 	}
 }
 
-func (*stateSyncerClient) StateSyncEnabled(context.Context) (bool, error) {
+func (*stateSyncerClient[_]) StateSyncEnabled(context.Context) (bool, error) {
 	// We always start the state syncer and may fallback to normal bootstrapping
 	// if we are close to tip.
 	//
@@ -56,7 +56,7 @@ func (*stateSyncerClient) StateSyncEnabled(context.Context) (bool, error) {
 	return true, nil
 }
 
-func (*stateSyncerClient) GetOngoingSyncStateSummary(
+func (*stateSyncerClient[_]) GetOngoingSyncStateSummary(
 	context.Context,
 ) (block.StateSummary, error) {
 	// Because the history of MerkleDB change proofs tends to be short, we always
@@ -67,9 +67,9 @@ func (*stateSyncerClient) GetOngoingSyncStateSummary(
 	return nil, database.ErrNotFound
 }
 
-func (s *stateSyncerClient) AcceptedSyncableBlock(
+func (s *stateSyncerClient[T]) AcceptedSyncableBlock(
 	_ context.Context,
-	sb *chain.SyncableBlock,
+	sb *chain.SyncableBlock[T],
 ) (block.StateSyncMode, error) {
 	s.init = true
 	s.vm.snowCtx.Log.Info("accepted syncable block",
@@ -199,7 +199,7 @@ func (s *stateSyncerClient) AcceptedSyncableBlock(
 }
 
 // finishSync is responsible for updating disk and memory pointers
-func (s *stateSyncerClient) finishSync() error {
+func (s *stateSyncerClient[_]) finishSync() error {
 	if s.targetUpdated {
 		// Will look like block on start accepted then last block before beginning
 		// bootstrapping is accepted.
@@ -211,14 +211,14 @@ func (s *stateSyncerClient) finishSync() error {
 	return s.vm.PutDiskIsSyncing(false)
 }
 
-func (s *stateSyncerClient) Started() bool {
+func (s *stateSyncerClient[_]) Started() bool {
 	return s.startedSync
 }
 
 // ForceDone is used by the [VM] to skip the sync process or to close the
 // channel if the sync process never started (i.e. [AcceptedSyncableBlock] will
 // never be called)
-func (s *stateSyncerClient) ForceDone() {
+func (s *stateSyncerClient[_]) ForceDone() {
 	if s.startedSync {
 		// If we started sync, we must wait for it to finish
 		return
@@ -229,7 +229,7 @@ func (s *stateSyncerClient) ForceDone() {
 }
 
 // Shutdown can be called to abort an ongoing sync.
-func (s *stateSyncerClient) Shutdown() error {
+func (s *stateSyncerClient[_]) Shutdown() error {
 	if s.syncManager != nil {
 		s.syncManager.Close()
 		<-s.done // wait for goroutine to exit
@@ -238,9 +238,9 @@ func (s *stateSyncerClient) Shutdown() error {
 }
 
 // Error returns a non-nil error if one occurred during the sync.
-func (s *stateSyncerClient) Error() error { return s.stateSyncErr }
+func (s *stateSyncerClient[_]) Error() error { return s.stateSyncErr }
 
-func (s *stateSyncerClient) StateReady() bool {
+func (s *stateSyncerClient[_]) StateReady() bool {
 	select {
 	case <-s.done:
 		return true
@@ -257,7 +257,7 @@ func (s *stateSyncerClient) StateReady() bool {
 
 // UpdateSyncTarget returns a boolean indicating if the root was
 // updated and an error if one occurred while updating the root.
-func (s *stateSyncerClient) UpdateSyncTarget(b *chain.StatefulBlock) (bool, error) {
+func (s *stateSyncerClient[T]) UpdateSyncTarget(b *chain.StatefulBlock[T]) (bool, error) {
 	err := s.syncManager.UpdateSyncTarget(b.StateRoot)
 	if errors.Is(err, avasync.ErrAlreadyClosed) {
 		<-s.done          // Wait for goroutine to exit for consistent return values with IsSyncing

--- a/vm/syncervm_server.go
+++ b/vm/syncervm_server.go
@@ -6,9 +6,8 @@ package vm
 import (
 	"context"
 
-	"go.uber.org/zap"
-
 	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
+	"go.uber.org/zap"
 
 	"github.com/ava-labs/hypersdk/chain"
 )

--- a/vm/syncervm_server.go
+++ b/vm/syncervm_server.go
@@ -6,15 +6,16 @@ package vm
 import (
 	"context"
 
-	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
 	"go.uber.org/zap"
+
+	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
 
 	"github.com/ava-labs/hypersdk/chain"
 )
 
 // GetLastStateSummary returns the latest state summary.
 // If no summary is available, [database.ErrNotFound] must be returned.
-func (vm *VM) GetLastStateSummary(context.Context) (block.StateSummary, error) {
+func (vm *VM[_]) GetLastStateSummary(context.Context) (block.StateSummary, error) {
 	summary := chain.NewSyncableBlock(vm.LastAcceptedBlock())
 	vm.Logger().Info("Serving syncable block at latest height", zap.Stringer("summary", summary))
 	return summary, nil
@@ -23,7 +24,7 @@ func (vm *VM) GetLastStateSummary(context.Context) (block.StateSummary, error) {
 // GetStateSummary implements StateSyncableVM and returns a summary corresponding
 // to the provided [height] if the node can serve state sync data for that key.
 // If not, [database.ErrNotFound] must be returned.
-func (vm *VM) GetStateSummary(ctx context.Context, height uint64) (block.StateSummary, error) {
+func (vm *VM[_]) GetStateSummary(ctx context.Context, height uint64) (block.StateSummary, error) {
 	id, err := vm.GetBlockIDAtHeight(ctx, height)
 	if err != nil {
 		return nil, err
@@ -40,8 +41,8 @@ func (vm *VM) GetStateSummary(ctx context.Context, height uint64) (block.StateSu
 	return summary, nil
 }
 
-func (vm *VM) ParseStateSummary(ctx context.Context, bytes []byte) (block.StateSummary, error) {
-	sb, err := chain.ParseBlock(ctx, bytes, false, vm)
+func (vm *VM[T]) ParseStateSummary(ctx context.Context, bytes []byte) (block.StateSummary, error) {
+	sb, err := chain.ParseBlock[T](ctx, bytes, false, vm)
 	if err != nil {
 		return nil, err
 	}

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -13,9 +13,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
-	"go.uber.org/zap"
-
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow"
@@ -26,6 +23,8 @@ import (
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/version"
 	"github.com/ava-labs/avalanchego/x/merkledb"
+	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/zap"
 
 	"github.com/ava-labs/hypersdk/api"
 	"github.com/ava-labs/hypersdk/chain"

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -169,6 +169,7 @@ func New[T chain.RuntimeInterface](
 	}
 
 	return &VM[T]{
+		runtime:               runtime,
 		v:                     v,
 		stateManager:          stateManager,
 		config:                NewConfig(),

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -49,7 +49,6 @@ import (
 	avatrace "github.com/ava-labs/avalanchego/trace"
 	avautils "github.com/ava-labs/avalanchego/utils"
 	avasync "github.com/ava-labs/avalanchego/x/sync"
-
 	internalfees "github.com/ava-labs/hypersdk/internal/fees"
 )
 

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -29,8 +29,8 @@ func TestBlockCache(t *testing.T) {
 	defer ctrl.Finish()
 
 	// create a block with "Unknown" status
-	blk := &chain.StatefulBlock{
-		StatelessBlock: &chain.StatelessBlock{
+	blk := &chain.StatefulBlock[struct{}]{
+		StatelessBlock: &chain.StatelessBlock[struct{}]{
 			Prnt: ids.GenerateTestID(),
 			Hght: 10000,
 		},
@@ -38,10 +38,10 @@ func TestBlockCache(t *testing.T) {
 	blkID := blk.ID()
 
 	tracer, _ := trace.New(&trace.Config{Enabled: false})
-	bByID, _ := cache.NewFIFO[ids.ID, *chain.StatefulBlock](3)
+	bByID, _ := cache.NewFIFO[ids.ID, *chain.StatefulBlock[struct{}]](3)
 	bByHeight, _ := cache.NewFIFO[uint64, ids.ID](3)
 	rules := chain.NewMockRules(ctrl)
-	vm := VM{
+	vm := VM[struct{}]{
 		snowCtx: &snow.Context{Log: logging.NoLog{}, Metrics: metrics.NewPrefixGatherer()},
 		config:  NewConfig(),
 		vmDB:    memdb.New(),
@@ -50,10 +50,10 @@ func TestBlockCache(t *testing.T) {
 		acceptedBlocksByID:     bByID,
 		acceptedBlocksByHeight: bByHeight,
 
-		verifiedBlocks: make(map[ids.ID]*chain.StatefulBlock),
-		seen:           emap.NewEMap[*chain.Transaction](),
-		mempool:        mempool.New[*chain.Transaction](tracer, 100, 32),
-		acceptedQueue:  make(chan *chain.StatefulBlock, 1024), // don't block on queue
+		verifiedBlocks: make(map[ids.ID]*chain.StatefulBlock[struct{}]),
+		seen:           emap.NewEMap[*chain.Transaction[struct{}]](),
+		mempool:        mempool.New[*chain.Transaction[struct{}]](tracer, 100, 32),
+		acceptedQueue:  make(chan *chain.StatefulBlock[struct{}], 1024), // don't block on queue
 		ruleFactory:    &genesis.ImmutableRuleFactory{Rules: rules},
 	}
 


### PR DESCRIPTION
Adds support to define action runtimes. This can be useful to avoid having to maintain runtime state inside of actions. In the future will expand this interface to support rollbacks/child views.