### PR TITLE
Ignore gas on mock-function-call

### DIFF
--- a/x/contracts/examples/counter-external/src/lib.rs
+++ b/x/contracts/examples/counter-external/src/lib.rs
@@ -41,7 +41,7 @@ mod tests {
 
         // mock `get_value` external contract call to return `value`
         let value = 5_u64;
-        ctx.mock_function_call(external, "get_value", of, 1_000_000, 0, value);
+        ctx.mock_function_call(external, "get_value", of, 0, value);
 
         let value = get_value(&mut ctx, external, of);
         assert_eq!(value, 5);


### PR DESCRIPTION
In the case where the amount of gas is explicitly set for an external contract-call, it does make sense to include this value for the mock-return, but I don't expect that to be the default case

