### PR TITLE
Fix transfer benchmark

### DIFF
--- a/chain/chaintest/action_test_helpers.go
+++ b/chain/chaintest/action_test_helpers.go
@@ -115,7 +115,7 @@ func (test *ActionBenchmark) Run(ctx context.Context, b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		output, err := test.Action.Execute(ctx, test.Rules, states[i], test.Timestamp, test.Actor, test.ActionID)
 		require.NoError(err)
-		require.Equal(output, test.ExpectedOutputs)
+		require.Equal(test.ExpectedOutputs[i], output)
 	}
 
 	b.StopTimer()

--- a/examples/morpheusvm/actions/transfer_test.go
+++ b/examples/morpheusvm/actions/transfer_test.go
@@ -142,6 +142,16 @@ func BenchmarkSimpleTransfer(b *testing.B) {
 			To:    to,
 			Value: 1,
 		},
+		ExpectedOutputs: func() []codec.Typed {
+			outputs := make([]codec.Typed, 0)
+			for i := 0; i < b.N; i++ {
+				outputs = append(outputs, &TransferResult{
+					SenderBalance:   0,
+					ReceiverBalance: 1,
+				})
+			}
+			return outputs
+		}(),
 		CreateState: func() state.Mutable {
 			store := chaintest.NewInMemoryStore()
 			err := storage.SetBalance(context.Background(), store, from, 1)


### PR DESCRIPTION
This PR fixes a current bug within the HyperSDK.

Currently, running `go test -bench=.` within the `actions/` directory of MorpheusVM fails as we are comparing `test.ExpectedOutput` (an array) to `output` (a single instance of `codec.Typed`). 

This PR fixes the bug above by populating the `ExpectedOutputs` field and correcting the comparison mentioned above (we now compare instances of `codec.Typed`)