### PR TITLE
Add no internal linter for examples

### DIFF
--- a/.github/workflows/hypersdk-ci.yml
+++ b/.github/workflows/hypersdk-ci.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Run actionlint
         shell: bash
         run: scripts/tests.actionlint.sh
+      - name: Run noInternalLint
+        shell: bash
+        run: scripts/lint.no_internal.sh
 
   hypersdk-unit-tests:
     runs-on: ubuntu-20.04-32

--- a/scripts/lint.no_internal.sh
+++ b/scripts/lint.no_internal.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
+# Copyright (C) 2024, Ava Labs, Inc. All rights reserved.
+# See the file LICENSE for licensing terms.
 
-# Find all Go files in the /examples directory
 violations=0
 
 if ! [[ "$0" =~ scripts/lint.no_internal.sh ]]; then

--- a/scripts/lint.no_internal.sh
+++ b/scripts/lint.no_internal.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Find all Go files in the /examples directory
+violations=0
+
+if ! [[ "$0" =~ scripts/lint.no_internal.sh ]]; then
+  echo "must be run from repository root"
+  exit 255
+fi
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+EXAMPLES_DIR="${SCRIPT_DIR}/../examples"
+
+for file in $(find "$EXAMPLES_DIR" -type f -name "*.go"); do
+  if grep -q '"github.com/ava-labs/hypersdk/internal' "$file"; then
+    abs_file=$(realpath "$file")
+    clean_file=${abs_file/"$SCRIPT_DIR\/.."/"$SCRIPT_DIR"}
+    
+    echo "Violation: $clean_file imports from /internal"
+    violations=$((violations+1))
+  fi
+done
+
+if [ $violations -gt 0 ]; then
+  exit 1
+else
+  echo "Ok."
+fi


### PR DESCRIPTION
This PR revolves #1572 by adding a simple linter at checks for the use of `internal` packages within `examples/`

If the linter passes, it returns the following:
```bash
Ok.
```

If there is an instance of `internal` being used, it returns a similar message as seen below for each violation and exits with code 1:

```bash
Violation: /Users/rodrigo.villar/go/src/github.com/ava-labs/hypersdk/examples/morpheusvm/actions/transfer.go imports from /internal
```

This PR also adds the internal linter as part of the CI tests for HyperSDK