### PR TITLE
Remove `StateKeysMaxChunks()`

### DIFF
--- a/api/jsonrpc/server.go
+++ b/api/jsonrpc/server.go
@@ -188,7 +188,7 @@ func (j *JSONRPCServer) Execute(
 	now := time.Now().UnixMilli()
 
 	// Get expected state keys
-	stateKeysWithPermissions := action.StateKeys(args.Actor, ids.Empty)
+	stateKeysWithPermissions := action.StateKeys(args.Actor)
 
 	// flatten the map to a slice of keys
 	storageKeysToRead := make([][]byte, 0)

--- a/auth/bls.go
+++ b/auth/bls.go
@@ -111,6 +111,10 @@ func (*BLSFactory) MaxUnits() (uint64, uint64) {
 	return BLSSize, BLSComputeUnits
 }
 
+func (b *BLSFactory) Address() codec.Address {
+	return NewBLSAddress(bls.PublicFromPrivateKey(b.priv))
+}
+
 func NewBLSAddress(pk *bls.PublicKey) codec.Address {
 	return codec.CreateAddress(BLSID, utils.ToID(bls.PublicKeyToBytes(pk)))
 }

--- a/auth/ed25519.go
+++ b/auth/ed25519.go
@@ -98,6 +98,10 @@ func (*ED25519Factory) MaxUnits() (uint64, uint64) {
 	return ED25519Size, ED25519ComputeUnits
 }
 
+func (d *ED25519Factory) Address() codec.Address {
+	return NewED25519Address(d.priv.PublicKey())
+}
+
 type ED25519AuthEngine struct{}
 
 func (*ED25519AuthEngine) GetBatchVerifier(cores int, count int) chain.AuthBatchVerifier {

--- a/auth/secp256r1.go
+++ b/auth/secp256r1.go
@@ -101,6 +101,10 @@ func (*SECP256R1Factory) MaxUnits() (uint64, uint64) {
 	return SECP256R1Size, SECP256R1ComputeUnits
 }
 
+func (d *SECP256R1Factory) Address() codec.Address {
+	return NewSECP256R1Address(d.priv.PublicKey())
+}
+
 func NewSECP256R1Address(pk secp256r1.PublicKey) codec.Address {
 	return codec.CreateAddress(SECP256R1ID, utils.ToID(pk[:]))
 }

--- a/chain/dependencies.go
+++ b/chain/dependencies.go
@@ -216,11 +216,6 @@ type Action interface {
 	// whether the [Action] can be included in a given block and to compute the required fee to execute.
 	ComputeUnits(Rules) uint64
 
-	// StateKeysMaxChunks is used to estimate the fee a transaction should pay. It includes the max
-	// chunks each state key could use without requiring the state keys to actually be provided (may
-	// not be known until execution).
-	StateKeysMaxChunks() []uint16
-
 	// StateKeys is a full enumeration of all database keys that could be touched during execution
 	// of an [Action]. This is used to prefetch state and will be used to parallelize execution (making
 	// an execution tree is trivial).
@@ -229,7 +224,7 @@ type Action interface {
 	// key (formatted as a big-endian uint16). This is used to automatically calculate storage usage.
 	//
 	// If any key is removed and then re-created, this will count as a creation instead of a modification.
-	StateKeys(actor codec.Address, actionID ids.ID) state.Keys
+	StateKeys(actor codec.Address) state.Keys
 
 	// Execute actually runs the [Action]. Any state changes that the [Action] performs should
 	// be done here.
@@ -290,4 +285,5 @@ type AuthFactory interface {
 	// Sign is used by helpers, auth object should store internally to be ready for marshaling
 	Sign(msg []byte) (Auth, error)
 	MaxUnits() (bandwidth uint64, compute uint64)
+	Address() codec.Address
 }

--- a/chain/transaction.go
+++ b/chain/transaction.go
@@ -203,8 +203,6 @@ func EstimateUnits(r Rules, actions []Action, authFactory AuthFactory) (fees.Dim
 		readsOp            = math.NewUint64Operator(0)
 		allocatesOp        = math.NewUint64Operator(0)
 		writesOp           = math.NewUint64Operator(0)
-
-		message = []byte{}
 	)
 
 	// Calculate over action/auth
@@ -215,11 +213,8 @@ func EstimateUnits(r Rules, actions []Action, authFactory AuthFactory) (fees.Dim
 			return fees.Dimensions{}, err
 		}
 
-		auth, err := authFactory.Sign(message)
-		if err != nil {
-			return fees.Dimensions{}, err
-		}
-		stateKeys := action.StateKeys(auth.Actor())
+		actor := authFactory.Address()
+		stateKeys := action.StateKeys(actor)
 		actionStateKeysMaxChunks, ok := stateKeys.ChunkSizes()
 		if !ok {
 			return fees.Dimensions{}, ErrInvalidKeyValue

--- a/chain/transaction.go
+++ b/chain/transaction.go
@@ -222,7 +222,6 @@ func EstimateUnits(r Rules, actions []Action, authFactory AuthFactory) (fees.Dim
 		stateKeys := action.StateKeys(auth.Actor())
 		actionStateKeysMaxChunks, ok := stateKeys.ChunkSizes()
 		if !ok {
-			// TODO: return more descriptive error
 			return fees.Dimensions{}, ErrInvalidKeyValue
 		}
 		bandwidth += consts.ByteLen + uint64(actionSize)

--- a/chain/transaction_test.go
+++ b/chain/transaction_test.go
@@ -32,11 +32,7 @@ func (*abstractMockAction) Execute(_ context.Context, _ chain.Rules, _ state.Mut
 	panic("unimplemented")
 }
 
-func (*abstractMockAction) StateKeys(_ codec.Address, _ ids.ID) state.Keys {
-	panic("unimplemented")
-}
-
-func (*abstractMockAction) StateKeysMaxChunks() []uint16 {
+func (*abstractMockAction) StateKeys(_ codec.Address) state.Keys {
 	panic("unimplemented")
 }
 

--- a/docs/tutorials/morpheusvm/morpheusvm.md
+++ b/docs/tutorials/morpheusvm/morpheusvm.md
@@ -179,10 +179,6 @@ func (t *Transfer) StateKeys(actor codec.Address, actionID ids.ID) state.Keys {
 	panic("unimplemented")
 }
 
-func (t *Transfer) StateKeysMaxChunks() []uint16 {
-	panic("unimplemented")
-}
-
 func (t *Transfer) Execute(ctx context.Context, r chain.Rules, mu state.Mutable, timestamp int64, actor codec.Address, actionID ids.ID) (output codec.Typed, err error) {
 	panic("unimplemented")
 }
@@ -661,23 +657,6 @@ func (t *Transfer) StateKeys(actor codec.Address, _ ids.ID) state.Keys {
 		string(storage.BalanceKey(actor)): state.Read | state.Write,
 		string(storage.BalanceKey(t.To)):  state.All,
 	}
-}
-```
-
-### `StateKeysMaxChunks()`
-
-Remember handling "chunk size" for the `BalanceKey` implementation?
-
-We implement `StateKeysMaxChunks()` to provide the exact same idea to HyperSDK:
-
-This function returns a slice of `uint16` values (one for each state key) and they
-both update a single balance key-value pair, so we'll use `BalanceChunks` as before.
-
-Let's update the function like so:
-
-```golang
-func (*Transfer) StateKeysMaxChunks() []uint16 {
-	return []uint16{storage.BalanceChunks, storage.BalanceChunks}
 }
 ```
 

--- a/examples/morpheusvm/actions/transfer.go
+++ b/examples/morpheusvm/actions/transfer.go
@@ -44,15 +44,11 @@ func (*Transfer) GetTypeID() uint8 {
 	return mconsts.TransferID
 }
 
-func (t *Transfer) StateKeys(actor codec.Address, _ ids.ID) state.Keys {
+func (t *Transfer) StateKeys(actor codec.Address) state.Keys {
 	return state.Keys{
 		string(storage.BalanceKey(actor)): state.Read | state.Write,
 		string(storage.BalanceKey(t.To)):  state.All,
 	}
-}
-
-func (*Transfer) StateKeysMaxChunks() []uint16 {
-	return []uint16{storage.BalanceChunks, storage.BalanceChunks}
 }
 
 func (t *Transfer) Execute(

--- a/examples/vmwithcontracts/actions/call.go
+++ b/examples/vmwithcontracts/actions/call.go
@@ -52,18 +52,10 @@ func (*Call) GetTypeID() uint8 {
 	return mconsts.CallContractID
 }
 
-func (t *Call) StateKeys(_ codec.Address, _ ids.ID) state.Keys {
+func (t *Call) StateKeys(_ codec.Address) state.Keys {
 	result := state.Keys{}
 	for _, stateKeyPermission := range t.SpecifiedStateKeys {
 		result.Add(stateKeyPermission.Key, stateKeyPermission.Permission)
-	}
-	return result
-}
-
-func (t *Call) StateKeysMaxChunks() []uint16 {
-	result := make([]uint16, 0, len(t.SpecifiedStateKeys))
-	for range t.SpecifiedStateKeys {
-		result = append(result, 1)
 	}
 	return result
 }

--- a/examples/vmwithcontracts/actions/deploy.go
+++ b/examples/vmwithcontracts/actions/deploy.go
@@ -33,7 +33,7 @@ func (*Deploy) GetTypeID() uint8 {
 	return mconsts.DeployID
 }
 
-func (d *Deploy) StateKeys(_ codec.Address, _ ids.ID) state.Keys {
+func (d *Deploy) StateKeys(_ codec.Address) state.Keys {
 	if d.address == codec.EmptyAddress {
 		d.address = storage.GetAddressForDeploy(0, d.CreationInfo)
 	}
@@ -41,10 +41,6 @@ func (d *Deploy) StateKeys(_ codec.Address, _ ids.ID) state.Keys {
 	return state.Keys{
 		string(stateKey): state.All,
 	}
-}
-
-func (*Deploy) StateKeysMaxChunks() []uint16 {
-	return []uint16{storage.BalanceChunks}
 }
 
 func (d *Deploy) Execute(

--- a/examples/vmwithcontracts/actions/publish.go
+++ b/examples/vmwithcontracts/actions/publish.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/ava-labs/hypersdk/chain"
 	"github.com/ava-labs/hypersdk/codec"
-	"github.com/ava-labs/hypersdk/consts"
 	"github.com/ava-labs/hypersdk/examples/vmwithcontracts/storage"
 	"github.com/ava-labs/hypersdk/keys"
 	"github.com/ava-labs/hypersdk/state"
@@ -34,7 +33,7 @@ func (*Publish) GetTypeID() uint8 {
 	return mconsts.PublishID
 }
 
-func (t *Publish) StateKeys(_ codec.Address, _ ids.ID) state.Keys {
+func (t *Publish) StateKeys(_ codec.Address) state.Keys {
 	if t.id == nil {
 		hashedID := sha256.Sum256(t.ContractBytes)
 		t.id, _ = keys.Encode(storage.ContractsKey(hashedID[:]), len(t.ContractBytes))
@@ -42,13 +41,6 @@ func (t *Publish) StateKeys(_ codec.Address, _ ids.ID) state.Keys {
 	return state.Keys{
 		string(t.id): state.Write | state.Allocate,
 	}
-}
-
-func (t *Publish) StateKeysMaxChunks() []uint16 {
-	if chunks, ok := keys.NumChunks(t.ContractBytes); ok {
-		return []uint16{chunks}
-	}
-	return []uint16{consts.MaxUint16}
 }
 
 func (t *Publish) Execute(

--- a/examples/vmwithcontracts/actions/transfer.go
+++ b/examples/vmwithcontracts/actions/transfer.go
@@ -44,15 +44,11 @@ func (*Transfer) GetTypeID() uint8 {
 	return mconsts.TransferID
 }
 
-func (t *Transfer) StateKeys(actor codec.Address, _ ids.ID) state.Keys {
+func (t *Transfer) StateKeys(actor codec.Address) state.Keys {
 	return state.Keys{
 		string(storage.BalanceKey(actor)): state.Read | state.Write,
 		string(storage.BalanceKey(t.To)):  state.All,
 	}
-}
-
-func (*Transfer) StateKeysMaxChunks() []uint16 {
-	return []uint16{storage.BalanceChunks, storage.BalanceChunks}
 }
 
 func (t *Transfer) Execute(

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -73,3 +73,10 @@ func Encode(key []byte, maxSize int) ([]byte, bool) {
 func EncodeChunks(key []byte, maxChunks uint16) []byte {
 	return binary.BigEndian.AppendUint16(key, maxChunks)
 }
+
+func DecodeChunks(key []byte) (uint16, bool) {
+	if len(key) < 2 {
+		return 0, false
+	}
+	return binary.BigEndian.Uint16(key[len(key)-2:]), true
+}

--- a/state/keys.go
+++ b/state/keys.go
@@ -37,6 +37,19 @@ func (k Keys) Add(key string, permission Permissions) bool {
 	return true
 }
 
+// Returns the chunk sizes of each key
+func (k Keys) ChunkSizes() ([]uint16, bool) {
+	chunks := make([]uint16, 0, len(k))
+	for key := range k {
+		chunk, ok := keys.DecodeChunks([]byte(key))
+		if !ok {
+			return nil, false
+		}
+		chunks = append(chunks, chunk)
+	}
+	return chunks, true
+}
+
 // Has returns true if [p] has all the permissions that are contained in require
 func (p Permissions) Has(require Permissions) bool {
 	return require&^p == 0


### PR DESCRIPTION
As detailed in #1599, this PR removes the `StateKeysMaxChunks()` method from the `chain.Action` interface. 

The following are the changes related to this PR:

- Removed `StateKeysMaxChunks()` from the `chain.Action` interface
    - Removed `StateKeysMaxChunks()` from both MorpheusVM and VMWithContracts
- Modified `StateKeys()` by removing the action ID parameter
- Added a `ChunkSizes()` method to `state.Keys`
- Modified `EstimateUnits()` in `chain/transaction.go` to use `ChunkSizes()`
- Added a `DecodeChunks()` function to get chunk sizes from keys
- Added an `Address()` method to `AuthFactory()`
    - Added `Address()` to `ed25519`, `secp256r1`, and `bls`
- Updated docs to remove references to `StateKeysMaxChunks()`