### PR TITLE
Update ActionBenchmark to use single ExpectedOutput

### DIFF
--- a/chain/chaintest/action_test_helpers.go
+++ b/chain/chaintest/action_test_helpers.go
@@ -95,8 +95,8 @@ type ActionBenchmark struct {
 	Actor       codec.Address
 	ActionID    ids.ID
 
-	ExpectedOutputs []codec.Typed
-	ExpectedErr     error
+	ExpectedOutput codec.Typed
+	ExpectedErr    error
 
 	Assertion func(context.Context, *testing.B, state.Mutable)
 }
@@ -115,7 +115,7 @@ func (test *ActionBenchmark) Run(ctx context.Context, b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		output, err := test.Action.Execute(ctx, test.Rules, states[i], test.Timestamp, test.Actor, test.ActionID)
 		require.NoError(err)
-		require.Equal(test.ExpectedOutputs[i], output)
+		require.Equal(test.ExpectedOutput, output)
 	}
 
 	b.StopTimer()

--- a/examples/morpheusvm/actions/transfer_test.go
+++ b/examples/morpheusvm/actions/transfer_test.go
@@ -131,7 +131,7 @@ func TestTransferAction(t *testing.T) {
 }
 
 func BenchmarkSimpleTransfer(b *testing.B) {
-	require := require.New(b)
+	setupRequire := require.New(b)
 	to := codec.CreateAddress(0, ids.GenerateTestID())
 	from := codec.CreateAddress(0, ids.GenerateTestID())
 
@@ -142,23 +142,18 @@ func BenchmarkSimpleTransfer(b *testing.B) {
 			To:    to,
 			Value: 1,
 		},
-		ExpectedOutputs: func() []codec.Typed {
-			outputs := make([]codec.Typed, 0)
-			for i := 0; i < b.N; i++ {
-				outputs = append(outputs, &TransferResult{
-					SenderBalance:   0,
-					ReceiverBalance: 1,
-				})
-			}
-			return outputs
-		}(),
+		ExpectedOutput: &TransferResult{
+			SenderBalance:   0,
+			ReceiverBalance: 1,
+		},
 		CreateState: func() state.Mutable {
 			store := chaintest.NewInMemoryStore()
 			err := storage.SetBalance(context.Background(), store, from, 1)
-			require.NoError(err)
+			setupRequire.NoError(err)
 			return store
 		},
 		Assertion: func(ctx context.Context, b *testing.B, store state.Mutable) {
+			require := require.New(b)
 			toBalance, err := storage.GetBalance(ctx, store, to)
 			require.NoError(err)
 			require.Equal(uint64(1), toBalance)


### PR DESCRIPTION
This PR fixes the `ActionBenchmark` struct to use a single value for `ExpectedOutput` since there is only one value that should be re-used across each execution.