### PR TITLE
Add JSON marshalling for fee dimensions

### DIFF
--- a/fees/dimension.go
+++ b/fees/dimension.go
@@ -5,6 +5,7 @@ package fees
 
 import (
 	"encoding/binary"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
@@ -137,6 +138,38 @@ func (d *Dimensions) UnmarshalText(b []byte) error {
 	if n != FeeDimensions {
 		return fmt.Errorf("failed to parse %d successive dimensions, found %d", FeeDimensions, n)
 	}
+	return nil
+}
+
+type DimensionJSON struct {
+	Bandwidth       uint64 `json:"bandwidth"`
+	Compute         uint64 `json:"compute"`
+	StorageRead     uint64 `json:"storageRead"`
+	StorageAllocate uint64 `json:"storageAllocate"`
+	StorageWrite    uint64 `json:"storageWrite"`
+}
+
+func (d Dimensions) MarshalJSON() ([]byte, error) {
+	dimensionJSON := DimensionJSON{
+		Bandwidth:       d[Bandwidth],
+		Compute:         d[Compute],
+		StorageRead:     d[StorageRead],
+		StorageAllocate: d[StorageAllocate],
+		StorageWrite:    d[StorageWrite],
+	}
+	return json.Marshal(dimensionJSON)
+}
+
+func (d *Dimensions) UnmarshalJSON(b []byte) error {
+	dimensionJSON := DimensionJSON{}
+	if err := json.Unmarshal(b, &dimensionJSON); err != nil {
+		return err
+	}
+	d[Bandwidth] = dimensionJSON.Bandwidth
+	d[Compute] = dimensionJSON.Compute
+	d[StorageRead] = dimensionJSON.StorageRead
+	d[StorageAllocate] = dimensionJSON.StorageAllocate
+	d[StorageWrite] = dimensionJSON.StorageWrite
 	return nil
 }
 

--- a/fees/dimension_test.go
+++ b/fees/dimension_test.go
@@ -25,3 +25,21 @@ func TestDimensionsMarshalText(t *testing.T) {
 	require.NoError(parsedDimText.UnmarshalText(dimTextBytes))
 	require.Equal(dim, parsedDimText)
 }
+
+func TestDimensionsMarshalJSON(t *testing.T) {
+	require := require.New(t)
+	var dim Dimensions
+	dim[Bandwidth] = 1
+	dim[Compute] = 2
+	dim[StorageRead] = 3
+	dim[StorageAllocate] = 4
+	dim[StorageWrite] = 5
+
+	dimJSONBytes, err := dim.MarshalJSON()
+	require.NoError(err)
+	require.JSONEq(`{"bandwidth":1,"compute":2,"storageRead":3,"storageAllocate":4,"storageWrite":5}`, string(dimJSONBytes))
+
+	var parsedDimJSON Dimensions
+	require.NoError(parsedDimJSON.UnmarshalJSON(dimJSONBytes))
+	require.Equal(dim, parsedDimJSON)
+}


### PR DESCRIPTION
Add JSON marshaller/unmarshaller for `fees.Dimensions` type.

This improves the JSON output of the block index API: https://github.com/ava-labs/hypersdk/pull/1606#issuecomment-2387672897