### PR TITLE
Indexer upgrades

### DIFF
--- a/api/indexer/client.go
+++ b/api/indexer/client.go
@@ -105,8 +105,8 @@ func (c *Client) WaitForTransaction(ctx context.Context, txCheckInterval time.Du
 		if err != nil {
 			return false, err
 		}
-		success = response.Success
-		fee = response.Fee
+		success = response.Result.Success
+		fee = response.Result.Fee
 		return found, nil
 	}); err != nil {
 		return false, 0, err

--- a/api/indexer/indexer.go
+++ b/api/indexer/indexer.go
@@ -174,6 +174,7 @@ func (i *Indexer) storeTransactions(blk *chain.ExecutedBlock) error {
 			result.Units,
 			result.Fee,
 			result.Outputs,
+			result.Error,
 		); err != nil {
 			return err
 		}
@@ -190,6 +191,7 @@ func (*Indexer) storeTransaction(
 	units fees.Dimensions,
 	fee uint64,
 	outputs [][]byte,
+	errorBytes []byte,
 ) error {
 	outputLength := consts.ByteLen // Single byte containing number of outputs
 	for _, output := range outputs {
@@ -206,19 +208,20 @@ func (*Indexer) storeTransaction(
 	for _, output := range outputs {
 		writer.PackBytes(output)
 	}
+	writer.PackBytes(errorBytes)
 	if err := writer.Err(); err != nil {
 		return err
 	}
 	return batch.Put(txID[:], writer.Bytes())
 }
 
-func (i *Indexer) GetTransaction(txID ids.ID) (bool, int64, bool, fees.Dimensions, uint64, [][]byte, error) {
+func (i *Indexer) GetTransaction(txID ids.ID) (bool, int64, bool, fees.Dimensions, uint64, [][]byte, []byte, error) {
 	v, err := i.txDB.Get(txID[:])
 	if errors.Is(err, database.ErrNotFound) {
-		return false, 0, false, fees.Dimensions{}, 0, nil, nil
+		return false, 0, false, fees.Dimensions{}, 0, nil, nil, nil
 	}
 	if err != nil {
-		return false, 0, false, fees.Dimensions{}, 0, nil, err
+		return false, 0, false, fees.Dimensions{}, 0, nil, nil, err
 	}
 	reader := codec.NewReader(v, consts.NetworkSizeLimit)
 	timestamp := reader.UnpackUint64(true)
@@ -231,14 +234,19 @@ func (i *Indexer) GetTransaction(txID ids.ID) (bool, int64, bool, fees.Dimension
 	for i := range outputs {
 		outputs[i] = reader.UnpackLimitedBytes(consts.NetworkSizeLimit)
 	}
+
+	var errorBytes []byte = nil
+	errorBytes = make([]byte, consts.NetworkSizeLimit)
+	reader.UnpackBytes(int(consts.NetworkSizeLimit), false, &errorBytes)
+
 	if err := reader.Err(); err != nil {
-		return false, 0, false, fees.Dimensions{}, 0, nil, err
+		return false, 0, false, fees.Dimensions{}, 0, nil, nil, err
 	}
 	dimensions, err := fees.UnpackDimensions(dimensionsBytes)
 	if err != nil {
-		return false, 0, false, fees.Dimensions{}, 0, nil, err
+		return false, 0, false, fees.Dimensions{}, 0, nil, nil, err
 	}
-	return true, int64(timestamp), success, dimensions, fee, outputs, nil
+	return true, int64(timestamp), success, dimensions, fee, outputs, errorBytes, nil
 }
 
 func (i *Indexer) Close() error {

--- a/api/indexer/indexer.go
+++ b/api/indexer/indexer.go
@@ -181,7 +181,10 @@ func (i *Indexer) storeTransactions(blk *chain.ExecutedBlock) error {
 		}
 
 		txID := tx.ID()
-		batch.Put(txID[:], p.Bytes())
+		err = batch.Put(txID[:], p.Bytes())
+		if err != nil {
+			return fmt.Errorf("failed to store transaction: %w", err)
+		}
 	}
 
 	return batch.Write()

--- a/api/indexer/server.go
+++ b/api/indexer/server.go
@@ -105,7 +105,8 @@ type GetTxRequest struct {
 }
 
 type GetTxResponse struct {
-	chain.Result
+	Result      chain.Result       `json:"result"`
+	Transaction *chain.Transaction `json:"transaction"`
 }
 
 type Server struct {
@@ -117,7 +118,7 @@ func (s *Server) GetTx(req *http.Request, args *GetTxRequest, reply *GetTxRespon
 	_, span := s.tracer.Start(req.Context(), "Indexer.GetTx")
 	defer span.End()
 
-	found, _, success, units, fee, outputs, errBytes, err := s.indexer.GetTransaction(args.TxID)
+	found, tx, result, err := s.indexer.GetTransaction(args.TxID)
 	if err != nil {
 		return err
 	}
@@ -125,10 +126,8 @@ func (s *Server) GetTx(req *http.Request, args *GetTxRequest, reply *GetTxRespon
 	if !found {
 		return ErrTxNotFound
 	}
-	reply.Success = success
-	reply.Units = units
-	reply.Fee = fee
-	reply.Outputs = outputs
-	reply.Error = errBytes
+
+	reply.Result = *result
+	reply.Transaction = tx
 	return nil
 }

--- a/api/indexer/server.go
+++ b/api/indexer/server.go
@@ -117,7 +117,7 @@ func (s *Server) GetTx(req *http.Request, args *GetTxRequest, reply *GetTxRespon
 	_, span := s.tracer.Start(req.Context(), "Indexer.GetTx")
 	defer span.End()
 
-	found, _, success, units, fee, outputs, err := s.indexer.GetTransaction(args.TxID)
+	found, _, success, units, fee, outputs, errBytes, err := s.indexer.GetTransaction(args.TxID)
 	if err != nil {
 		return err
 	}
@@ -129,5 +129,6 @@ func (s *Server) GetTx(req *http.Request, args *GetTxRequest, reply *GetTxRespon
 	reply.Units = units
 	reply.Fee = fee
 	reply.Outputs = outputs
+	reply.Error = errBytes
 	return nil
 }

--- a/chain/result.go
+++ b/chain/result.go
@@ -10,15 +10,15 @@ import (
 )
 
 type Result struct {
-	Success bool
-	Error   []byte
+	Success bool   `json:"success"`
+	Error   []byte `json:"error"`
 
-	Outputs [][]byte
+	Outputs [][]byte `json:"outputs"`
 
 	// Computing [Units] requires access to [StateManager], so it is returned
 	// to make life easier for indexers.
-	Units fees.Dimensions
-	Fee   uint64
+	Units fees.Dimensions `json:"units"`
+	Fee   uint64          `json:"fee"`
 }
 
 func (r *Result) Size() int {

--- a/chain/result.go
+++ b/chain/result.go
@@ -10,8 +10,8 @@ import (
 )
 
 type Result struct {
-	Success bool   `json:"success"`
-	Error   []byte `json:"error"`
+	Success bool               `json:"success"`
+	Error   codec.UnicodeBytes `json:"error"`
 
 	Outputs [][]byte `json:"outputs"`
 
@@ -57,7 +57,9 @@ func UnmarshalResult(p *codec.Packer) (*Result, error) {
 	result := &Result{
 		Success: p.UnpackBool(),
 	}
-	p.UnpackBytes(consts.MaxInt, false, &result.Error)
+	var errorBytes []byte
+	p.UnpackBytes(consts.MaxInt, false, &errorBytes)
+	result.Error = errorBytes
 	outputs := [][]byte{}
 	numActions := p.UnpackByte()
 	for i := uint8(0); i < numActions; i++ {

--- a/chain/transaction.go
+++ b/chain/transaction.go
@@ -37,7 +37,7 @@ type Transaction struct {
 	digest    []byte
 	bytes     []byte
 	size      int
-	id        ids.ID
+	Id        ids.ID `json:"id"`
 	stateKeys state.Keys
 }
 
@@ -106,7 +106,7 @@ func (t *Transaction) Bytes() []byte { return t.bytes }
 
 func (t *Transaction) Size() int { return t.size }
 
-func (t *Transaction) ID() ids.ID { return t.id }
+func (t *Transaction) ID() ids.ID { return t.Id }
 
 func (t *Transaction) Expiry() int64 { return t.Base.Timestamp }
 
@@ -477,7 +477,7 @@ func UnmarshalTx(
 	tx.digest = codecBytes[start:digest]
 	tx.bytes = codecBytes[start:p.Offset()] // ensure errors handled before grabbing memory
 	tx.size = len(tx.bytes)
-	tx.id = utils.ToID(tx.bytes)
+	tx.Id = utils.ToID(tx.bytes)
 	return &tx, nil
 }
 

--- a/codec/unicode.go
+++ b/codec/unicode.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package codec
 
 type UnicodeBytes []byte

--- a/codec/unicode.go
+++ b/codec/unicode.go
@@ -1,0 +1,12 @@
+package codec
+
+type UnicodeBytes []byte
+
+func (b UnicodeBytes) MarshalText() ([]byte, error) {
+	return []byte(b), nil
+}
+
+func (b *UnicodeBytes) UnmarshalText(text []byte) error {
+	*b = text
+	return nil
+}

--- a/codec/unicode_test.go
+++ b/codec/unicode_test.go
@@ -1,0 +1,32 @@
+package codec
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnicodeBytes(t *testing.T) {
+	require := require.New(t)
+
+	original := UnicodeBytes("Hello, 世界!")
+
+	marshalledBytes, err := original.MarshalText()
+	require.NoError(err)
+	require.Equal([]byte("Hello, 世界!"), marshalledBytes)
+
+	var unmarshalled UnicodeBytes
+	err = unmarshalled.UnmarshalText(marshalledBytes)
+	require.NoError(err)
+	require.Equal(original, unmarshalled)
+
+	jsonBytes, err := json.Marshal(original)
+	require.NoError(err)
+	require.Equal([]byte(`"Hello, 世界!"`), jsonBytes)
+
+	var jsonUnmarshalled UnicodeBytes
+	err = json.Unmarshal(jsonBytes, &jsonUnmarshalled)
+	require.NoError(err)
+	require.Equal(original, jsonUnmarshalled)
+}

--- a/codec/unicode_test.go
+++ b/codec/unicode_test.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package codec
 
 import (

--- a/crypto/ed25519/ed25519.go
+++ b/crypto/ed25519/ed25519.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hdevalence/ed25519consensus"
 
+	"github.com/ava-labs/hypersdk/codec"
 	"github.com/ava-labs/hypersdk/crypto"
 )
 
@@ -97,4 +98,30 @@ func (b *Batch) VerifyAsync() func() error {
 		}
 		return nil
 	}
+}
+
+func (p PublicKey) MarshalText() ([]byte, error) {
+	return []byte(codec.ToHex(p[:])), nil
+}
+
+func (p *PublicKey) UnmarshalText(text []byte) error {
+	bytes, err := codec.LoadHex(string(text), PublicKeyLen)
+	if err != nil {
+		return err
+	}
+	copy(p[:], bytes)
+	return nil
+}
+
+func (s Signature) MarshalText() ([]byte, error) {
+	return []byte(codec.ToHex(s[:])), nil
+}
+
+func (s *Signature) UnmarshalText(text []byte) error {
+	bytes, err := codec.LoadHex(string(text), SignatureLen)
+	if err != nil {
+		return err
+	}
+	copy(s[:], bytes)
+	return nil
 }

--- a/examples/morpheusvm/tests/workload/workload.go
+++ b/examples/morpheusvm/tests/workload/workload.go
@@ -240,9 +240,9 @@ func confirmTx(ctx context.Context, require *require.Assertions, uri string, txI
 	txRes, _, err := indexerCli.GetTx(ctx, txID)
 	require.NoError(err)
 	// TODO: perform exact expected fee, units check, and output check
-	require.NotZero(txRes.Fee)
-	require.Len(txRes.Outputs, 1)
-	transferOutputBytes := []byte(txRes.Outputs[0])
+	require.NotZero(txRes.Result.Fee)
+	require.Len(txRes.Result.Outputs, 1)
+	transferOutputBytes := []byte(txRes.Result.Outputs[0])
 	require.Equal(consts.TransferID, transferOutputBytes[0])
 	reader := codec.NewReader(transferOutputBytes, len(transferOutputBytes))
 	transferOutputTyped, err := vm.OutputParser.Unmarshal(reader)


### PR DESCRIPTION
Provide changes for [GetBlock](https://github.com/ava-labs/hypersdk/pull/1606#issuecomment-2387672897) and [GetTX](https://github.com/ava-labs/hypersdk/pull/1606#issuecomment-2387680901) required by the TypeScript Client, except for marshaling actions as bytes or JSONs with type ID.