### PR TITLE
Add JSON marshalling to Result

### DIFF
--- a/chain/result_test.go
+++ b/chain/result_test.go
@@ -1,0 +1,41 @@
+// Copyright (C) 2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package chain
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/hypersdk/codec"
+	"github.com/ava-labs/hypersdk/fees"
+)
+
+func TestResultJSON(t *testing.T) {
+	require := require.New(t)
+	errStrBytes := []byte("error")
+	outputBytes := []byte("output")
+	units := fees.Dimensions{1, 2, 3, 4, 5}
+	unitsJSON, err := json.Marshal(units)
+	require.NoError(err)
+	result := Result{
+		Success: true,
+		Error:   errStrBytes,
+		Outputs: [][]byte{outputBytes},
+		Units:   units,
+		Fee:     4,
+	}
+
+	resultJSON, err := json.Marshal(result)
+	require.NoError(err)
+
+	expectedJSON := fmt.Sprintf(`{"error":%q,"fee":4,"outputs":[%q],"success":true,"units":%s}`, codec.Bytes(errStrBytes), codec.Bytes(outputBytes), string(unitsJSON))
+	require.JSONEq(expectedJSON, string(resultJSON))
+
+	var unmarshalledResult Result
+	require.NoError(json.Unmarshal(resultJSON, &unmarshalledResult))
+	require.Equal(result, unmarshalledResult)
+}

--- a/codec/hex.go
+++ b/codec/hex.go
@@ -25,9 +25,13 @@ func LoadHex(s string, expectedSize int) ([]byte, error) {
 
 type Bytes []byte
 
+func (b Bytes) String() string {
+	return ToHex(b)
+}
+
 // MarshalText returns the hex representation of b.
 func (b Bytes) MarshalText() ([]byte, error) {
-	return []byte(ToHex(b)), nil
+	return []byte(b.String()), nil
 }
 
 // UnmarshalText sets b to the bytes represented by text.


### PR DESCRIPTION
This PR adds JSON marshalling support for `chain.Result` to improve JSON output per https://github.com/ava-labs/hypersdk/pull/1606#issuecomment-2389723597