### PR TITLE
Fix incorrect naming of stateless block

### DIFF
--- a/chain/block.go
+++ b/chain/block.go
@@ -153,7 +153,7 @@ func NewGenesisBlock(root ids.ID) *StatelessBlock {
 	}
 }
 
-// Stateless is defined separately from "Block"
+// StatefulBlock is defined separately from "StatelessBlock"
 // in case external packages need to use the stateless block
 // without mocking VM or parent block
 type StatefulBlock struct {
@@ -200,7 +200,7 @@ func ParseBlock(
 		return nil, err
 	}
 	// Not guaranteed that a parsed block is verified
-	return ParseStatelessBlock(ctx, blk, source, accepted, vm)
+	return ParseStatefulBlock(ctx, blk, source, accepted, vm)
 }
 
 // populateTxs is only called on blocks we did not build
@@ -246,14 +246,14 @@ func (b *StatefulBlock) populateTxs(ctx context.Context) error {
 	return nil
 }
 
-func ParseStatelessBlock(
+func ParseStatefulBlock(
 	ctx context.Context,
 	blk *StatelessBlock,
 	source []byte,
 	accepted bool,
 	vm VM,
 ) (*StatefulBlock, error) {
-	ctx, span := vm.Tracer().Start(ctx, "chain.ParseStatelessBlock")
+	ctx, span := vm.Tracer().Start(ctx, "chain.ParseStatefulBlock")
 	defer span.End()
 
 	// Perform basic correctness checks before doing any expensive work

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -371,7 +371,7 @@ func (vm *VM) Initialize(
 		snowCtx.Log.Info("genesis state created", zap.Stringer("root", root))
 
 		// Create genesis block
-		genesisBlk, err := chain.ParseStatelessBlock(
+		genesisBlk, err := chain.ParseStatefulBlock(
 			ctx,
 			chain.NewGenesisBlock(root),
 			nil,


### PR DESCRIPTION
This PR fixes a few places where we use the incorrect name of stateless/stateful that were missed in https://github.com/ava-labs/hypersdk/pull/1485