### PR TITLE
Decouple State Manager

### DIFF
--- a/chain/block.go
+++ b/chain/block.go
@@ -424,7 +424,7 @@ func (b *StatefulBlock) innerVerify(ctx context.Context, vctx VerifyContext) err
 	}
 
 	// Fetch parent height key and ensure block height is valid
-	heightKey := HeightKey(b.vm.StateManager().HeightKey())
+	heightKey := HeightKey(b.vm.MetadataManager().HeightPrefix())
 	parentHeightRaw, err := parentView.GetValue(ctx, heightKey)
 	if err != nil {
 		return err
@@ -441,7 +441,7 @@ func (b *StatefulBlock) innerVerify(ctx context.Context, vctx VerifyContext) err
 	//
 	// Parent may not be available (if we preformed state sync), so we
 	// can't rely on being able to fetch it during verification.
-	timestampKey := TimestampKey(b.vm.StateManager().TimestampKey())
+	timestampKey := TimestampKey(b.vm.MetadataManager().TimestampPrefix())
 	parentTimestampRaw, err := parentView.GetValue(ctx, timestampKey)
 	if err != nil {
 		return err
@@ -484,7 +484,7 @@ func (b *StatefulBlock) innerVerify(ctx context.Context, vctx VerifyContext) err
 	}
 
 	// Compute next unit prices to use
-	feeKey := FeeKey(b.vm.StateManager().FeeKey())
+	feeKey := FeeKey(b.vm.MetadataManager().FeePrefix())
 	feeRaw, err := parentView.GetValue(ctx, feeKey)
 	if err != nil {
 		return err
@@ -737,7 +737,7 @@ func (b *StatefulBlock) View(ctx context.Context, verify bool) (state.View, erro
 		if err != nil {
 			return nil, err
 		}
-		acceptedHeightRaw, err := acceptedState.Get(HeightKey(b.vm.StateManager().HeightKey()))
+		acceptedHeightRaw, err := acceptedState.Get(HeightKey(b.vm.MetadataManager().HeightPrefix()))
 		if err != nil {
 			return nil, err
 		}

--- a/chain/builder.go
+++ b/chain/builder.go
@@ -92,7 +92,7 @@ func BuildBlock(
 	}
 
 	// Compute next unit prices to use
-	feeKey := FeeKey(vm.StateManager().FeeKey())
+	feeKey := FeeKey(vm.MetadataManager().FeePrefix())
 	feeRaw, err := parentView.GetValue(ctx, feeKey)
 	if err != nil {
 		return nil, err
@@ -128,7 +128,7 @@ func BuildBlock(
 		txsAttempted = 0
 		results      = []*Result{}
 
-		sm = vm.StateManager()
+		bh = vm.BalanceHandler()
 
 		// prepareStreamLock ensures we don't overwrite stream prefetching spawned
 		// asynchronously.
@@ -173,7 +173,7 @@ func BuildBlock(
 				continue
 			}
 
-			stateKeys, err := tx.StateKeys(sm)
+			stateKeys, err := tx.StateKeys(bh)
 			if err != nil {
 				// Drop bad transaction and continue
 				//
@@ -265,7 +265,7 @@ func BuildBlock(
 
 				// Execute block
 				tsv := ts.NewView(stateKeys, storage)
-				if err := tx.PreExecute(ctx, feeManager, sm, r, tsv, nextTime); err != nil {
+				if err := tx.PreExecute(ctx, feeManager, bh, r, tsv, nextTime); err != nil {
 					// We don't need to rollback [tsv] here because it will never
 					// be committed.
 					if HandlePreExecute(log, err) {
@@ -276,7 +276,7 @@ func BuildBlock(
 				result, err := tx.Execute(
 					ctx,
 					feeManager,
-					sm,
+					bh,
 					r,
 					tsv,
 					nextTime,
@@ -372,9 +372,9 @@ func BuildBlock(
 	}
 
 	// Update chain metadata
-	heightKey := HeightKey(sm.HeightKey())
+	heightKey := HeightKey(b.vm.MetadataManager().HeightPrefix())
 	heightKeyStr := string(heightKey)
-	timestampKey := TimestampKey(b.vm.StateManager().TimestampKey())
+	timestampKey := TimestampKey(b.vm.MetadataManager().TimestampPrefix())
 	timestampKeyStr := string(timestampKey)
 	feeKeyStr := string(feeKey)
 

--- a/chain/dependencies.go
+++ b/chain/dependencies.go
@@ -65,7 +65,8 @@ type VM interface {
 	GetStatefulBlock(context.Context, ids.ID) (*StatefulBlock, error)
 
 	State() (merkledb.MerkleDB, error)
-	StateManager() StateManager
+	BalanceHandler() BalanceHandler
+	MetadataManager() MetadataManager
 
 	Mempool() Mempool
 	IsRepeat(context.Context, []*Transaction, set.Bits, bool) set.Bits
@@ -149,9 +150,9 @@ type Rules interface {
 }
 
 type MetadataManager interface {
-	HeightKey() []byte
-	TimestampKey() []byte
-	FeeKey() []byte
+	HeightPrefix() []byte
+	TimestampPrefix() []byte
+	FeePrefix() []byte
 }
 
 type BalanceHandler interface {
@@ -171,17 +172,6 @@ type BalanceHandler interface {
 
 	// AddBalance adds [amount] to [addr].
 	AddBalance(ctx context.Context, addr codec.Address, mu state.Mutable, amount uint64, createAccount bool) error
-}
-
-// StateManager allows [Chain] to safely store certain types of items in state
-// in a structured manner. If we did not use [StateManager], we may overwrite
-// state written by actions or auth.
-//
-// None of these keys should be suffixed with the max amount of chunks they will
-// use. This will be handled by the hypersdk.
-type StateManager interface {
-	BalanceHandler
-	MetadataManager
 }
 
 type Object interface {

--- a/chain/processor.go
+++ b/chain/processor.go
@@ -34,7 +34,7 @@ func (b *StatefulBlock) Execute(
 	defer span.End()
 
 	var (
-		sm     = b.vm.StateManager()
+		bh     = b.vm.BalanceHandler()
 		numTxs = len(b.Txs)
 		t      = b.GetTimestamp()
 
@@ -49,7 +49,7 @@ func (b *StatefulBlock) Execute(
 		i := li
 		tx := ltx
 
-		stateKeys, err := tx.StateKeys(sm)
+		stateKeys, err := tx.StateKeys(bh)
 		if err != nil {
 			f.Stop()
 			e.Stop()
@@ -57,7 +57,7 @@ func (b *StatefulBlock) Execute(
 		}
 
 		// Ensure we don't consume too many units
-		units, err := tx.Units(sm, r)
+		units, err := tx.Units(bh, r)
 		if err != nil {
 			f.Stop()
 			e.Stop()
@@ -88,11 +88,11 @@ func (b *StatefulBlock) Execute(
 			tsv := ts.NewView(stateKeys, storage)
 
 			// Ensure we have enough funds to pay fees
-			if err := tx.PreExecute(ctx, feeManager, sm, r, tsv, t); err != nil {
+			if err := tx.PreExecute(ctx, feeManager, bh, r, tsv, t); err != nil {
 				return err
 			}
 
-			result, err := tx.Execute(ctx, feeManager, sm, r, tsv, t)
+			result, err := tx.Execute(ctx, feeManager, bh, r, tsv, t)
 			if err != nil {
 				return err
 			}

--- a/examples/morpheusvm/storage/state_manager.go
+++ b/examples/morpheusvm/storage/state_manager.go
@@ -11,29 +11,17 @@ import (
 	"github.com/ava-labs/hypersdk/state"
 )
 
-var _ (chain.StateManager) = (*StateManager)(nil)
+var _ (chain.BalanceHandler) = (*BalanceHandler)(nil)
 
-type StateManager struct{}
+type BalanceHandler struct{}
 
-func (*StateManager) HeightKey() []byte {
-	return HeightKey()
-}
-
-func (*StateManager) TimestampKey() []byte {
-	return TimestampKey()
-}
-
-func (*StateManager) FeeKey() []byte {
-	return FeeKey()
-}
-
-func (*StateManager) SponsorStateKeys(addr codec.Address) state.Keys {
+func (*BalanceHandler) SponsorStateKeys(addr codec.Address) state.Keys {
 	return state.Keys{
 		string(BalanceKey(addr)): state.Read | state.Write,
 	}
 }
 
-func (*StateManager) CanDeduct(
+func (*BalanceHandler) CanDeduct(
 	ctx context.Context,
 	addr codec.Address,
 	im state.Immutable,
@@ -49,7 +37,7 @@ func (*StateManager) CanDeduct(
 	return nil
 }
 
-func (*StateManager) Deduct(
+func (*BalanceHandler) Deduct(
 	ctx context.Context,
 	addr codec.Address,
 	mu state.Mutable,
@@ -59,7 +47,7 @@ func (*StateManager) Deduct(
 	return err
 }
 
-func (*StateManager) AddBalance(
+func (*BalanceHandler) AddBalance(
 	ctx context.Context,
 	addr codec.Address,
 	mu state.Mutable,

--- a/examples/morpheusvm/storage/storage.go
+++ b/examples/morpheusvm/storage/storage.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ava-labs/hypersdk/codec"
 	"github.com/ava-labs/hypersdk/consts"
 	"github.com/ava-labs/hypersdk/state"
+	"github.com/ava-labs/hypersdk/state/metadata"
 
 	smath "github.com/ava-labs/avalanchego/utils/math"
 )
@@ -21,29 +22,16 @@ import (
 type ReadState func(context.Context, [][]byte) ([][]byte, []error)
 
 // State
-// / (height) => store in root
-//   -> [heightPrefix] => height
-// 0x0/ (balance)
+// 0x0/ (hypersdk-height)
+// 0x1/ (hypersdk-timestamp)
+// 0x2/ (hypersdk-fee)
+//
+// 0x3/ (balance)
 //   -> [owner] => balance
-// 0x1/ (hypersdk-height)
-// 0x2/ (hypersdk-timestamp)
-// 0x3/ (hypersdk-fee)
 
-const (
-	// Active state
-	balancePrefix   = 0x0
-	heightPrefix    = 0x1
-	timestampPrefix = 0x2
-	feePrefix       = 0x3
-)
+const balancePrefix byte = metadata.DefaultMinimumPrefix
 
 const BalanceChunks uint16 = 1
-
-var (
-	heightKey    = []byte{heightPrefix}
-	timestampKey = []byte{timestampPrefix}
-	feeKey       = []byte{feePrefix}
-)
 
 // [balancePrefix] + [address]
 func BalanceKey(addr codec.Address) (k []byte) {
@@ -180,16 +168,4 @@ func SubBalance(
 		return 0, mu.Remove(ctx, key)
 	}
 	return nbal, setBalance(ctx, mu, key, nbal)
-}
-
-func HeightKey() (k []byte) {
-	return heightKey
-}
-
-func TimestampKey() (k []byte) {
-	return timestampKey
-}
-
-func FeeKey() (k []byte) {
-	return feeKey
 }

--- a/examples/morpheusvm/vm/client.go
+++ b/examples/morpheusvm/vm/client.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ava-labs/hypersdk/chain"
 	"github.com/ava-labs/hypersdk/codec"
 	"github.com/ava-labs/hypersdk/examples/morpheusvm/consts"
-	"github.com/ava-labs/hypersdk/examples/morpheusvm/storage"
 	"github.com/ava-labs/hypersdk/genesis"
 	"github.com/ava-labs/hypersdk/requester"
 	"github.com/ava-labs/hypersdk/utils"
@@ -116,10 +115,6 @@ func (*Parser) OutputCodec() *codec.TypeParser[codec.Typed] {
 
 func (*Parser) AuthCodec() *codec.TypeParser[chain.Auth] {
 	return AuthParser
-}
-
-func (*Parser) StateManager() chain.StateManager {
-	return &storage.StateManager{}
 }
 
 func NewParser(genesis *genesis.DefaultGenesis) chain.Parser {

--- a/examples/morpheusvm/vm/vm.go
+++ b/examples/morpheusvm/vm/vm.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ava-labs/hypersdk/examples/morpheusvm/consts"
 	"github.com/ava-labs/hypersdk/examples/morpheusvm/storage"
 	"github.com/ava-labs/hypersdk/genesis"
+	"github.com/ava-labs/hypersdk/state/metadata"
 	"github.com/ava-labs/hypersdk/vm"
 	"github.com/ava-labs/hypersdk/vm/defaultvm"
 )
@@ -53,7 +54,8 @@ func New(options ...vm.Option) (*vm.VM, error) {
 	return defaultvm.New(
 		consts.Version,
 		genesis.DefaultGenesisFactory{},
-		&storage.StateManager{},
+		&storage.BalanceHandler{},
+		metadata.NewDefaultManager(),
 		ActionParser,
 		AuthParser,
 		OutputParser,

--- a/examples/vmwithcontracts/storage/state_manager.go
+++ b/examples/vmwithcontracts/storage/state_manager.go
@@ -11,29 +11,17 @@ import (
 	"github.com/ava-labs/hypersdk/state"
 )
 
-var _ (chain.StateManager) = (*StateManager)(nil)
+var _ (chain.BalanceHandler) = (*BalanceHandler)(nil)
 
-type StateManager struct{}
+type BalanceHandler struct{}
 
-func (*StateManager) HeightKey() []byte {
-	return HeightKey()
-}
-
-func (*StateManager) TimestampKey() []byte {
-	return TimestampKey()
-}
-
-func (*StateManager) FeeKey() []byte {
-	return FeeKey()
-}
-
-func (*StateManager) SponsorStateKeys(addr codec.Address) state.Keys {
+func (*BalanceHandler) SponsorStateKeys(addr codec.Address) state.Keys {
 	return state.Keys{
 		string(BalanceKey(addr)): state.Read | state.Write,
 	}
 }
 
-func (*StateManager) CanDeduct(
+func (*BalanceHandler) CanDeduct(
 	ctx context.Context,
 	addr codec.Address,
 	im state.Immutable,
@@ -49,7 +37,7 @@ func (*StateManager) CanDeduct(
 	return nil
 }
 
-func (*StateManager) Deduct(
+func (*BalanceHandler) Deduct(
 	ctx context.Context,
 	addr codec.Address,
 	mu state.Mutable,
@@ -59,7 +47,7 @@ func (*StateManager) Deduct(
 	return err
 }
 
-func (*StateManager) AddBalance(
+func (*BalanceHandler) AddBalance(
 	ctx context.Context,
 	addr codec.Address,
 	mu state.Mutable,

--- a/examples/vmwithcontracts/storage/storage.go
+++ b/examples/vmwithcontracts/storage/storage.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ava-labs/hypersdk/codec"
 	"github.com/ava-labs/hypersdk/consts"
 	"github.com/ava-labs/hypersdk/state"
+	"github.com/ava-labs/hypersdk/state/metadata"
 
 	smath "github.com/ava-labs/avalanchego/utils/math"
 )
@@ -23,36 +24,26 @@ type ReadState func(context.Context, [][]byte) ([][]byte, []error)
 // State
 // / (height) => store in root
 //   -> [heightPrefix] => height
-// 0x0/ (balance)
+// 0x0/ (hypersdk-height)
+// 0x1/ (hypersdk-timestamp)
+// 0x2/ (hypersdk-fee)
+// 0x3/ (balance)
 //   -> [owner] => balance
-// 0x1/ (hypersdk-height)
-// 0x2/ (hypersdk-timestamp)
-// 0x3/ (hypersdk-fee)
 // 0x4/ (account-storage)
 // 0x4/address/0x1 (address associated contract)
 // 0x4/address/0x1 (address associated state)
 // 0x5/ (contracts-storage)
 
 const (
-	// Active state
-	balancePrefix   = 0x0
-	heightPrefix    = 0x1
-	timestampPrefix = 0x2
-	feePrefix       = 0x3
-	accountsPrefix  = 0x4
-	contractsPrefix = 0x5
+	balancePrefix byte = metadata.DefaultMinimumPrefix + iota
+	accountsPrefix
+	contractsPrefix
 
 	accountContractPrefix = 0x0
 	accountStatePrefix    = 0x1
 )
 
 const BalanceChunks uint16 = 1
-
-var (
-	heightKey    = []byte{heightPrefix}
-	timestampKey = []byte{timestampPrefix}
-	feeKey       = []byte{feePrefix}
-)
 
 // [balancePrefix] + [address]
 func BalanceKey(addr codec.Address) (k []byte) {
@@ -189,16 +180,4 @@ func SubBalance(
 		return 0, mu.Remove(ctx, key)
 	}
 	return nbal, setBalance(ctx, mu, key, nbal)
-}
-
-func HeightKey() (k []byte) {
-	return heightKey
-}
-
-func TimestampKey() (k []byte) {
-	return timestampKey
-}
-
-func FeeKey() (k []byte) {
-	return feeKey
 }

--- a/examples/vmwithcontracts/vm/client.go
+++ b/examples/vmwithcontracts/vm/client.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ava-labs/hypersdk/chain"
 	"github.com/ava-labs/hypersdk/codec"
 	"github.com/ava-labs/hypersdk/examples/vmwithcontracts/consts"
-	"github.com/ava-labs/hypersdk/examples/vmwithcontracts/storage"
 	"github.com/ava-labs/hypersdk/genesis"
 	"github.com/ava-labs/hypersdk/requester"
 	"github.com/ava-labs/hypersdk/utils"
@@ -116,10 +115,6 @@ func (*Parser) OutputCodec() *codec.TypeParser[codec.Typed] {
 
 func (*Parser) AuthCodec() *codec.TypeParser[chain.Auth] {
 	return AuthParser
-}
-
-func (*Parser) StateManager() chain.StateManager {
-	return &storage.StateManager{}
 }
 
 func NewParser(genesis *genesis.DefaultGenesis) chain.Parser {

--- a/examples/vmwithcontracts/vm/vm.go
+++ b/examples/vmwithcontracts/vm/vm.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ava-labs/hypersdk/examples/vmwithcontracts/storage"
 	"github.com/ava-labs/hypersdk/extension/externalsubscriber"
 	"github.com/ava-labs/hypersdk/genesis"
+	"github.com/ava-labs/hypersdk/state/metadata"
 	"github.com/ava-labs/hypersdk/vm"
 	"github.com/ava-labs/hypersdk/x/contracts/runtime"
 )
@@ -77,7 +78,8 @@ func NewWithOptions(options ...vm.Option) (*vm.VM, error) {
 	return vm.New(
 		consts.Version,
 		genesis.DefaultGenesisFactory{},
-		&storage.StateManager{},
+		&storage.BalanceHandler{},
+		metadata.NewDefaultManager(),
 		ActionParser,
 		AuthParser,
 		OutputParser,

--- a/internal/gossiper/dependencies.go
+++ b/internal/gossiper/dependencies.go
@@ -33,7 +33,8 @@ type VM interface {
 	Rules(int64) chain.Rules
 	Submit(ctx context.Context, verify bool, txs []*chain.Transaction) []error
 	GetAuthBatchVerifier(authTypeID uint8, cores int, count int) (chain.AuthBatchVerifier, bool)
-	StateManager() chain.StateManager
+	BalanceHandler() chain.BalanceHandler
+	MetadataManager() chain.MetadataManager
 
 	RecordTxsGossiped(int)
 	RecordSeenTxsReceived(int)

--- a/internal/gossiper/dependencies.go
+++ b/internal/gossiper/dependencies.go
@@ -33,8 +33,6 @@ type VM interface {
 	Rules(int64) chain.Rules
 	Submit(ctx context.Context, verify bool, txs []*chain.Transaction) []error
 	GetAuthBatchVerifier(authTypeID uint8, cores int, count int) (chain.AuthBatchVerifier, bool)
-	BalanceHandler() chain.BalanceHandler
-	MetadataManager() chain.MetadataManager
 
 	RecordTxsGossiped(int)
 	RecordSeenTxsReceived(int)

--- a/state/metadata/state_manager.go
+++ b/state/metadata/state_manager.go
@@ -27,6 +27,18 @@ type MetadataManager struct {
 	timestampPrefix []byte
 }
 
+func NewManager(
+	heightPrefix []byte,
+	feePrefix []byte,
+	timestampPrefix []byte,
+) MetadataManager {
+	return MetadataManager{
+		heightPrefix:    heightPrefix,
+		feePrefix:       feePrefix,
+		timestampPrefix: timestampPrefix,
+	}
+}
+
 func NewDefaultManager() MetadataManager {
 	return MetadataManager{
 		heightPrefix:    []byte{defaultHeightPrefix},

--- a/state/metadata/state_manager.go
+++ b/state/metadata/state_manager.go
@@ -19,7 +19,7 @@ const (
 	DefaultMinimumPrefix byte = 0x3
 )
 
-var _ chain.MetadataManager = &MetadataManager{}
+var _ chain.MetadataManager = (*MetadataManager)(nil)
 
 type MetadataManager struct {
 	heightPrefix    []byte

--- a/state/metadata/state_manager.go
+++ b/state/metadata/state_manager.go
@@ -1,0 +1,75 @@
+// Copyright (C) 2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package metadata
+
+import (
+	"bytes"
+
+	"github.com/ava-labs/avalanchego/utils/set"
+
+	"github.com/ava-labs/hypersdk/chain"
+)
+
+const (
+	defaultHeightPrefix    byte = 0x0
+	defaultTimestampPrefix byte = 0x1
+	defaultFeePrefix       byte = 0x2
+
+	DefaultMinimumPrefix byte = 0x3
+)
+
+var _ chain.MetadataManager = &MetadataManager{}
+
+type MetadataManager struct {
+	heightPrefix    []byte
+	feePrefix       []byte
+	timestampPrefix []byte
+}
+
+func NewDefaultManager() MetadataManager {
+	return MetadataManager{
+		heightPrefix:    []byte{defaultHeightPrefix},
+		feePrefix:       []byte{defaultFeePrefix},
+		timestampPrefix: []byte{defaultTimestampPrefix},
+	}
+}
+
+func (m MetadataManager) FeePrefix() []byte {
+	return m.feePrefix
+}
+
+func (m MetadataManager) HeightPrefix() []byte {
+	return m.heightPrefix
+}
+
+func (m MetadataManager) TimestampPrefix() []byte {
+	return m.timestampPrefix
+}
+
+// Returns true if all prefixes in `m` and `vmPrefixes` are unique
+func HasConflictingPrefixes(
+	m chain.MetadataManager,
+	vmPrefixes [][]byte,
+) bool {
+	prefixes := [][]byte{
+		m.HeightPrefix(),
+		m.FeePrefix(),
+		m.TimestampPrefix(),
+	}
+
+	prefixes = append(prefixes, vmPrefixes...)
+	verifiedPrefixes := set.Set[string]{}
+
+	for _, p := range prefixes {
+		for vp := range verifiedPrefixes {
+			if bytes.HasPrefix(p, []byte(vp)) || bytes.HasPrefix([]byte(vp), p) {
+				return true
+			}
+		}
+
+		verifiedPrefixes.Add(string(p))
+	}
+
+	return false
+}

--- a/state/metadata/state_manager.go
+++ b/state/metadata/state_manager.go
@@ -6,8 +6,6 @@ package metadata
 import (
 	"bytes"
 
-	"github.com/ava-labs/avalanchego/utils/set"
-
 	"github.com/ava-labs/hypersdk/chain"
 )
 
@@ -71,16 +69,16 @@ func HasConflictingPrefixes(
 	}
 
 	prefixes = append(prefixes, vmPrefixes...)
-	verifiedPrefixes := set.Set[string]{}
+	verifiedPrefixes := make([][]byte, 0)
 
 	for _, p := range prefixes {
-		for vp := range verifiedPrefixes {
-			if bytes.HasPrefix(p, []byte(vp)) || bytes.HasPrefix([]byte(vp), p) {
+		for _, vp := range verifiedPrefixes {
+			if bytes.HasPrefix(p, vp) || bytes.HasPrefix(vp, p) {
 				return true
 			}
 		}
 
-		verifiedPrefixes.Add(string(p))
+		verifiedPrefixes = append(verifiedPrefixes, p)
 	}
 
 	return false

--- a/state/metadata/state_manager_test.go
+++ b/state/metadata/state_manager_test.go
@@ -1,0 +1,72 @@
+// Copyright (C) 2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package metadata_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/hypersdk/state/metadata"
+)
+
+func TestConflictingPrefixes(t *testing.T) {
+	require := require.New(t)
+
+	metadataManager := metadata.NewDefaultManager()
+
+	// Test no conflicts
+	require.False(
+		metadata.HasConflictingPrefixes(
+			metadataManager,
+			[][]byte{
+				{metadata.DefaultMinimumPrefix},
+			},
+		),
+	)
+	// Test identical prefixes
+	require.True(
+		metadata.HasConflictingPrefixes(
+			metadataManager,
+			[][]byte{
+				metadataManager.HeightPrefix(),
+			},
+		),
+	)
+	// Test that prefixes (from metadataManager) contains a prefix of one of the vm prefixes
+	require.True(
+		metadata.HasConflictingPrefixes(
+			metadataManager,
+			[][]byte{
+				{0x1, 0x1},
+			},
+		),
+	)
+
+	customMetadataManager := metadata.NewManager(
+		[]byte{0x0, 0x1},
+		[]byte{0x1, 0x1},
+		[]byte{0x2, 0x1},
+	)
+
+	// Test that vmPrefix contains prefix of one of metadataPrefixes
+	require.True(
+		metadata.HasConflictingPrefixes(
+			customMetadataManager,
+			[][]byte{
+				{0x1},
+			},
+		),
+	)
+	// Test that vmPrefixes contains a duplicate
+	require.True(
+		metadata.HasConflictingPrefixes(
+			metadataManager,
+			[][]byte{
+				{metadata.DefaultMinimumPrefix},
+				{metadata.DefaultMinimumPrefix},
+			},
+		),
+	)
+}

--- a/state/metadata/state_manager_test.go
+++ b/state/metadata/state_manager_test.go
@@ -1,33 +1,31 @@
 // Copyright (C) 2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-package metadata_test
+package metadata
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
-	"github.com/ava-labs/hypersdk/state/metadata"
 )
 
 func TestConflictingPrefixes(t *testing.T) {
 	require := require.New(t)
 
-	metadataManager := metadata.NewDefaultManager()
+	metadataManager := NewDefaultManager()
 
 	// Test no conflicts
 	require.False(
-		metadata.HasConflictingPrefixes(
+		HasConflictingPrefixes(
 			metadataManager,
 			[][]byte{
-				{metadata.DefaultMinimumPrefix},
+				{DefaultMinimumPrefix},
 			},
 		),
 	)
 	// Test identical prefixes
 	require.True(
-		metadata.HasConflictingPrefixes(
+		HasConflictingPrefixes(
 			metadataManager,
 			[][]byte{
 				metadataManager.HeightPrefix(),
@@ -36,7 +34,7 @@ func TestConflictingPrefixes(t *testing.T) {
 	)
 	// Test that prefixes (from metadataManager) contains a prefix of one of the vm prefixes
 	require.True(
-		metadata.HasConflictingPrefixes(
+		HasConflictingPrefixes(
 			metadataManager,
 			[][]byte{
 				{0x1, 0x1},
@@ -44,7 +42,7 @@ func TestConflictingPrefixes(t *testing.T) {
 		),
 	)
 
-	customMetadataManager := metadata.NewManager(
+	customMetadataManager := NewManager(
 		[]byte{0x0, 0x1},
 		[]byte{0x1, 0x1},
 		[]byte{0x2, 0x1},
@@ -52,7 +50,7 @@ func TestConflictingPrefixes(t *testing.T) {
 
 	// Test that vmPrefix contains prefix of one of metadataPrefixes
 	require.True(
-		metadata.HasConflictingPrefixes(
+		HasConflictingPrefixes(
 			customMetadataManager,
 			[][]byte{
 				{0x1},
@@ -61,11 +59,11 @@ func TestConflictingPrefixes(t *testing.T) {
 	)
 	// Test that vmPrefixes contains a duplicate
 	require.True(
-		metadata.HasConflictingPrefixes(
+		HasConflictingPrefixes(
 			metadataManager,
 			[][]byte{
-				{metadata.DefaultMinimumPrefix},
-				{metadata.DefaultMinimumPrefix},
+				{DefaultMinimumPrefix},
+				{DefaultMinimumPrefix},
 			},
 		),
 	)

--- a/state/metadata/state_manager_test.go
+++ b/state/metadata/state_manager_test.go
@@ -9,20 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCompatiblePrefixes(t *testing.T) {
-	require := require.New(t)
-	metadataManager := NewDefaultManager()
-
-	require.False(
-		HasConflictingPrefixes(
-			metadataManager,
-			[][]byte{
-				{DefaultMinimumPrefix},
-			},
-		),
-	)
-}
-
 func TestConflictingPrefixes(t *testing.T) {
 	metadataManager := NewDefaultManager()
 
@@ -30,13 +16,22 @@ func TestConflictingPrefixes(t *testing.T) {
 		name            string
 		metadataManager MetadataManager
 		vmPrefixes      [][]byte
+		hasConflict     bool
 	}{
+		{
+			name:            "no conflicts",
+			metadataManager: metadataManager,
+			vmPrefixes: [][]byte{
+				{DefaultMinimumPrefix},
+			},
+		},
 		{
 			name:            "identical prefixes",
 			metadataManager: metadataManager,
 			vmPrefixes: [][]byte{
 				metadataManager.HeightPrefix(),
 			},
+			hasConflict: true,
 		},
 		{
 			name:            "metadataManager prefixes contains a prefix of one of the vm prefixes",
@@ -44,6 +39,7 @@ func TestConflictingPrefixes(t *testing.T) {
 			vmPrefixes: [][]byte{
 				{0x1, 0x1},
 			},
+			hasConflict: true,
 		},
 		{
 			name: "vmPrefix contains a prefix of one of metadataManager prefixes",
@@ -57,6 +53,7 @@ func TestConflictingPrefixes(t *testing.T) {
 			vmPrefixes: [][]byte{
 				{0x1},
 			},
+			hasConflict: true,
 		},
 		{
 			name:            "vmPrefixes contains a duplicate",
@@ -65,13 +62,15 @@ func TestConflictingPrefixes(t *testing.T) {
 				{DefaultMinimumPrefix},
 				{DefaultMinimumPrefix},
 			},
+			hasConflict: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
-			require.True(
+			require.Equal(
+				tt.hasConflict,
 				HasConflictingPrefixes(
 					tt.metadataManager,
 					tt.vmPrefixes,

--- a/vm/defaultvm/vm.go
+++ b/vm/defaultvm/vm.go
@@ -35,7 +35,8 @@ func NewDefaultOptions() []vm.Option {
 func New(
 	v *version.Semantic,
 	genesisFactory genesis.GenesisAndRuleFactory,
-	stateManager chain.StateManager,
+	balanceHandler chain.BalanceHandler,
+	metadataManager chain.MetadataManager,
 	actionCodec *codec.TypeParser[chain.Action],
 	authCodec *codec.TypeParser[chain.Auth],
 	outputCodec *codec.TypeParser[codec.Typed],
@@ -46,7 +47,8 @@ func New(
 	return vm.New(
 		v,
 		genesisFactory,
-		stateManager,
+		balanceHandler,
+		metadataManager,
 		actionCodec,
 		authCodec,
 		outputCodec,

--- a/vm/resolutions.go
+++ b/vm/resolutions.go
@@ -383,8 +383,12 @@ func (vm *VM) Genesis() genesis.Genesis {
 	return vm.genesis
 }
 
-func (vm *VM) StateManager() chain.StateManager {
-	return vm.stateManager
+func (vm *VM) BalanceHandler() chain.BalanceHandler {
+	return vm.balanceHandler
+}
+
+func (vm *VM) MetadataManager() chain.MetadataManager {
+	return vm.metadataManager
 }
 
 func (vm *VM) RecordRootCalculated(t time.Duration) {
@@ -468,7 +472,7 @@ func (vm *VM) RecordClearedMempool() {
 }
 
 func (vm *VM) UnitPrices(context.Context) (fees.Dimensions, error) {
-	v, err := vm.stateDB.Get(chain.FeeKey(vm.StateManager().FeeKey()))
+	v, err := vm.stateDB.Get(chain.FeeKey(vm.MetadataManager().FeePrefix()))
 	if err != nil {
 		return fees.Dimensions{}, err
 	}


### PR DESCRIPTION
This PR decouples `StateManger` into `BalanceHandler` and `MetadataManager`. In particular, this PR makes explicit the difference between HyperSDK-specific state prefixes and VM-specific state prefixes. 

Summary of Changes:
- Remove `StateManager`
- Add the `metadata` package which gives VM a default `MetadataManager` which they can use
    - Provides a `HasConflictingPrefixes()` sanity function which checks for any prefix conflicts between the HyperSDK-specific state prefixes and the VM-specific prefixes
 - Updates `vm.New()` by having developers pass in both `BalanceHandler` and `MetadataManager` rather than `StateManager` 
 - Updates dependencies which previously used `StateManager` to use either `BalanceHandler` or `MetadataManager` 

This PR was originally #1615, but I decided to close it as the original design of that PR differs from this PR.