### PR TITLE
Move runtime tests into contracts-ci

### DIFF
--- a/.github/workflows/contracts-ci.yml
+++ b/.github/workflows/contracts-ci.yml
@@ -1,7 +1,7 @@
 # Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 # See the file LICENSE for licensing terms.
 
-name: Rust CI
+name: Contracts CI
 
 on:
   push:
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  fmt:
+  cargo-fmt:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -46,7 +46,7 @@ jobs:
           taplo fmt
           git diff --color=always
 
-  docs:
+  cargo-doc:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -61,7 +61,7 @@ jobs:
       - name: Run doc tests
         run: RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --document-private-items --all
 
-  clippy:
+  cargo-clippy:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -76,7 +76,7 @@ jobs:
         shell: bash
         run: cargo clippy --all --all-features --tests --benches --examples -- -D warnings
 
-  unit-tests:
+  cargo-test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -116,3 +116,35 @@ jobs:
       - name: Run cross tests
         run: |
           cross -v test -p wasmlanche --target=wasm32-unknown-emscripten
+
+  go-test:
+    runs-on: ubuntu-20.04-32
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: ./.github/actions/install-go
+      - name: Install Rust
+        uses: ./.github/actions/install-rust
+        with:
+          targets: wasm32-unknown-unknown
+          cache: false
+      - name: Run unit tests
+        shell: bash
+        run: go test -v -race ./x/contracts/...
+
+  go-bench:
+    runs-on: ubuntu-20.04-32
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: ./.github/actions/install-go
+      - name: Install Rust
+        uses: ./.github/actions/install-rust
+        with:
+          targets: wasm32-unknown-unknown
+          cache: false
+      - name: Run unit tests
+        shell: bash
+        run: go test -v -benchmem -run=^$ -bench=. -benchtime=1x ./x/contracts/...

--- a/.github/workflows/hypersdk-ci.yml
+++ b/.github/workflows/hypersdk-ci.yml
@@ -51,11 +51,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up Go
         uses: ./.github/actions/install-go
-      - name: Install Rust
-        uses: ./.github/actions/install-rust
-        with:
-          targets: wasm32-unknown-unknown
-          cache: false
       - name: Run unit tests
         shell: bash
         run: scripts/tests.unit.sh
@@ -68,11 +63,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up Go
         uses: ./.github/actions/install-go
-      - name: Install Rust
-        uses: ./.github/actions/install-rust
-        with:
-          targets: wasm32-unknown-unknown
-          cache: false
       - name: Run unit tests
         shell: bash
         run: scripts/tests.benchmark.sh
@@ -188,90 +178,3 @@ jobs:
         with:
           vm-name: morpheusvm
           github-token: ${{ secrets.GITHUB_TOKEN }}
-
-  # VMWithContracts
-  vmwithcontracts-lint:
-    needs: [hypersdk-tests]
-    if: ${{ needs.hypersdk-tests.outputs.only_contracts_changed != 'true' }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Set up Go
-        uses: ./.github/actions/install-go
-        with:
-          cache-dependency-path: |
-            go.sum
-            examples/vmwithcontracts/go.sum
-      - name: Run static analysis tests
-        working-directory: ./examples/vmwithcontracts
-        shell: bash
-        run: scripts/lint.sh
-      - name: Build vm, cli
-        working-directory: ./examples/vmwithcontracts
-        shell: bash
-        run:
-          scripts/build.sh
-
-          #   vmwithcontracts-unit-tests:
-          #     needs: [ hypersdk-tests ]
-          #     if: ${{ needs.hypersdk-tests.outputs.only_contracts_changed != 'true' }}
-          #     runs-on: ubuntu-20.04-32
-          #     timeout-minutes: 10
-          #     steps:
-          #       - name: Checkout
-          #         uses: actions/checkout@v4
-          #       - name: Set up Go
-          #         uses: ./.github/actions/install-go
-          #         with:
-          #           cache-dependency-path: |
-          #             go.sum
-          #             examples/vmwithcontracts/go.sum
-          #       - name: Run unit tests
-          #         working-directory: ./examples/vmwithcontracts
-          #         shell: bash
-          #         run: scripts/tests.unit.sh
-          #       - name: Run integration tests
-          #         working-directory: ./examples/vmwithcontracts
-          #         shell: bash
-          #         run: scripts/tests.integration.sh
-          #
-          #   vmwithcontracts-e2e-tests:
-          #     needs: [ vmwithcontracts-lint, vmwithcontracts-unit-tests ]
-          #     runs-on: ubuntu-20.04-32
-          #     timeout-minutes: 25
-          #     steps:
-          #       - name: Checkout
-          #         uses: actions/checkout@v4
-          #       - name: Set up Go
-          #         uses: ./.github/actions/install-go
-          #         with:
-          #           cache-dependency-path: |
-          #             go.sum
-          #             examples/vmwithcontracts/go.sum
-          #       - name: Run e2e tests
-          #         working-directory: ./examples/vmwithcontracts
-          #         shell: bash
-          #         run: scripts/run.sh
-          #         env:
-          #           MODE: 'test'
-          #       - name: Upload tmpnet network dir
-          #         uses: ava-labs/avalanchego/.github/actions/upload-tmpnet-artifact@v1-actions
-          #         if: always()
-          #         with:
-          #           name: vmwithcontracts-e2e-tmpnet-data
-          #
-          #   vmwithcontracts-release:
-          #     needs: [ vmwithcontracts-e2e-tests ]
-          #     # We build with 20.04 to maintain max compatibility: https://github.com/golang/go/issues/57328
-          #     runs-on: ubuntu-20.04-32
-          #     permissions:
-          #       contents: write
-          #     steps:
-          #       - name: Checkout
-          #         uses: actions/checkout@v4
-          #       - uses: ./.github/actions/vm-release
-          #         with:
-          #           vm-name: vmwithcontracts
-          #           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/tests.benchmark.sh
+++ b/scripts/tests.benchmark.sh
@@ -18,6 +18,6 @@ subdir=${1:-.}
 file_args=()
 while IFS= read -r line; do
     file_args+=("$line")
-done < <(find "$subdir" -type f -name "*.go" | grep -v "./examples/" | xargs -n1 dirname | sort -u)
+done < <(find "$subdir" -type f -name "*.go" | grep -v "./examples/" | grep -v "./x" | xargs -n1 dirname | sort -u)
 
 go test -benchmem -run=^$ -timeout="10m" -bench=. -benchtime=1x "${file_args[@]}"

--- a/scripts/tests.unit.sh
+++ b/scripts/tests.unit.sh
@@ -18,6 +18,6 @@ subdir=${1:-.}
 file_args=()
 while IFS= read -r line; do
     file_args+=("$line")
-done < <(find "$subdir" -type f -name "*.go" | grep -v "./examples/" | xargs -n1 dirname | sort -u)
+done < <(find "$subdir" -type f -name "*.go" | grep -v "./examples/" | grep -v "./x" | xargs -n1 dirname | sort -u)
 
 go test -race -timeout="6m" -coverprofile="coverage.out" -covermode="atomic" "${file_args[@]}"


### PR DESCRIPTION
This will isolate contracts-related Go tests

