### PR TITLE
Add block assembler + executor

### DIFF
--- a/chain/assembler.go
+++ b/chain/assembler.go
@@ -1,0 +1,74 @@
+// Copyright (C) 2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package chain
+
+import (
+	"context"
+	"time"
+
+	"github.com/ava-labs/hypersdk/utils"
+)
+
+type Assembler struct {
+	vm VM
+}
+
+func (a *Assembler) AssembleBlock(
+	ctx context.Context,
+	parent *StatefulBlock,
+	timestamp int64,
+	blockHeight uint64,
+	txs []*Transaction,
+) (*StatefulBlock, error) {
+	ctx, span := a.vm.Tracer().Start(ctx, "chain.AssembleBlock")
+	defer span.End()
+
+	parentView, err := parent.View(ctx, true)
+	if err != nil {
+		return nil, err
+	}
+	parentStateRoot, err := parentView.GetMerkleRoot(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	blk := &StatelessBlock{
+		Prnt:      parent.ID(),
+		Tmstmp:    timestamp,
+		Hght:      blockHeight,
+		Txs:       txs,
+		StateRoot: parentStateRoot,
+	}
+	for _, tx := range txs {
+		blk.authCounts[tx.Auth.GetTypeID()]++
+	}
+
+	blkBytes, err := blk.Marshal()
+	if err != nil {
+		return nil, err
+	}
+	b := &StatefulBlock{
+		StatelessBlock: blk,
+		t:              time.UnixMilli(blk.Tmstmp),
+		bytes:          blkBytes,
+		accepted:       false,
+		vm:             a.vm,
+		id:             utils.ToID(blkBytes),
+	}
+	return b, b.populateTxs(ctx) // TODO: simplify since txs are guaranteed to already be de-duplicated here
+}
+
+func (a *Assembler) ExecuteBlock(
+	ctx context.Context,
+	b *StatefulBlock,
+) (*ExecutedBlock, error) {
+	ctx, span := a.vm.Tracer().Start(ctx, "chain.ExecuteBlock")
+	defer span.End()
+
+	if err := b.Verify(ctx); err != nil {
+		return nil, err
+	}
+
+	return NewExecutedBlockFromStateful(b), nil
+}

--- a/dsmr/README.md
+++ b/dsmr/README.md
@@ -51,7 +51,7 @@ TODO
 
 - fetch and store any chunks that are not stored locally
 - Filter duplicate transactions
-- define block assembler interface to assemble an executable block
+- define block assembler interface to assemble, execute, and accept a block
 
 ```golang
 type Assembler[T Tx, Block any, Result any] interface {

--- a/dsmr/README.md
+++ b/dsmr/README.md
@@ -54,12 +54,9 @@ TODO
 - define block assembler interface to assemble an executable block
 
 ```golang
-type Assembler[T Tx] interface {
-    AssembleBlock(parentID ids.ID, timestamp uint64, blockHeight uint64, txs []T) (Block, error)
-}
-
-type Executor[Block any, Result any] interface {
-    ExecuteBlock(b Block) (Result, error)
+type Assembler[T Tx, Block any, Result any] interface {
+	AssembleBlock(parentBlock Block, timestamp uint64, blockHeight uint64, txs []T) (Block, error)
+	ExecuteBlock(b Block) (Result, error)
 }
 ```
 

--- a/dsmr/block.go
+++ b/dsmr/block.go
@@ -134,6 +134,7 @@ func (s *StatefulBlock[T, B, R]) ID() ids.ID {
 func (s *StatefulBlock[T, B, R]) Parent() ids.ID {
 	return s.block.ParentID
 }
+
 func (s *StatefulBlock[T, B, R]) Verify(ctx context.Context) error {
 	// TODO: Verify header fields
 	// TODO: de-duplicate chunk certificates (internal to block and across history)

--- a/dsmr/dependencies.go
+++ b/dsmr/dependencies.go
@@ -3,12 +3,71 @@
 
 package dsmr
 
-import "context"
+import (
+	"context"
 
-// TODO delete this file
-// TODO: implement VM
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/set"
+)
+
+// TODO replace VM with usage of Assembler
 type VM[VerificationContext any] interface {
 	Verify(context.Context, *ExecutionBlock[VerificationContext]) error
 	Accept(context.Context, *ExecutionBlock[VerificationContext]) error
 	Reject(context.Context, *ExecutionBlock[VerificationContext]) error
+}
+
+// Note: Assembler breaks assembling and executing a block into two steps
+// but these will be called one after the other.
+type Assembler[T Tx, Block any, Result any] interface {
+	AssembleBlock(ctx context.Context, parentBlock Block, timestamp int64, blockHeight uint64, txs []T) (Block, error)
+	ExecuteBlock(ctx context.Context, b Block) (Result, error)
+}
+
+type ChunkGatherer[T Tx] interface {
+	// CollectChunks gathers the corresponding chunks and writes any chunks to
+	// storage that were not already persisted.
+	CollectChunks(chunkCerts []*ChunkCertificate) ([]*Chunk[T], error)
+}
+
+type BlockHandler[T Tx, Block any, Result any] struct {
+	lastAcceptedBlock Block
+	chunkGatherer     ChunkGatherer[T]
+	Assembler         Assembler[T, Block, Result]
+}
+
+func (b *BlockHandler[T, B, R]) Accept(ctx context.Context, block Block) error {
+	// Collect and store chunks in the accepted block
+	chunks, err := b.chunkGatherer.CollectChunks(block.Chunks)
+	if err != nil {
+		return err
+	}
+
+	// Collect and de-duplicate txs
+	numTxs := 0
+	for _, chunk := range chunks {
+		numTxs += len(chunk.Txs)
+	}
+
+	txs := make([]T, 0, numTxs)
+	txSet := set.Set[ids.ID]{}
+	for _, chunk := range chunks {
+		for _, tx := range chunk.Txs {
+			txID := tx.GetID()
+			if txSet.Contains(txID) {
+				continue
+			}
+			txSet.Add(txID)
+			txs = append(txs, tx)
+
+		}
+	}
+
+	assembledBlk, err := b.Assembler.AssembleBlock(ctx, b.lastAcceptedBlock, block.Timestamp, block.Height+1, txs)
+	if err != nil {
+		return err
+	}
+	b.lastAcceptedBlock = assembledBlk
+	_, err = b.Assembler.ExecuteBlock(ctx, assembledBlk)
+	return err
 }


### PR DESCRIPTION
WIP: add block assembler + executor to DSMR and add implementation of it for the chain package.

This structure should help us refactor the interaction between the `chain/` and `vm/` packages so that:
- `chain` provides a default implementation of transaction/block types that can be used with DSMR
- `vm` uses DSMR package to fulfill `chain.VM` and `snowman.Block` interfaces from AvalancheGo
- `vm` handles writing blocks to disk and notifies subscribers of accepted blocks
- we can separate out state sync from the `vm` package