### PR TITLE
Force test-context to be initialized with an actor

### DIFF
--- a/x/contracts/examples/counter-external/src/lib.rs
+++ b/x/contracts/examples/counter-external/src/lib.rs
@@ -35,9 +35,8 @@ mod tests {
 
     #[test]
     fn get_value_exists() {
-        let mut ctx = Context::new();
-        let external = Address::new([0; 33]);
-        let of = Address::new([1; 33]);
+        let [external, of] = [0, 1].map(|i| Address::new([i; 33]));
+        let mut ctx = Context::with_actor(external);
 
         // mock `get_value` external contract call to return `value`
         let value = 5_u64;

--- a/x/contracts/examples/multisig/src/lib.rs
+++ b/x/contracts/examples/multisig/src/lib.rs
@@ -283,8 +283,7 @@ mod tests {
 
         let voters = Voters::Addresses(HashSet::from([bob]));
         let quorum = NonZeroU32::new(1).unwrap();
-        let mut ctx = Context::new();
-        ctx.set_actor(bob);
+        let mut ctx = Context::with_actor(bob);
 
         propose(&mut ctx, proposal, voters, quorum);
     }
@@ -301,8 +300,7 @@ mod tests {
             args: Default::default(),
         };
 
-        let mut ctx = Context::new();
-        ctx.set_actor(bob);
+        let mut ctx = Context::with_actor(bob);
 
         propose(&mut ctx, proposal, voters, quorum);
     }
@@ -330,8 +328,7 @@ mod tests {
             args: vec![],
         };
 
-        let mut ctx = Context::new();
-        ctx.set_actor(bob);
+        let mut ctx = Context::with_actor(bob);
 
         let id = propose(&mut ctx, proposal, voters, NonZeroU32::new(quorum).unwrap());
 
@@ -357,8 +354,7 @@ mod tests {
             args: vec![],
         };
 
-        let ctx = &mut Context::new();
-        ctx.set_actor(bob);
+        let ctx = &mut Context::with_actor(bob);
 
         let id = propose(ctx, proposal, voters, quorum);
 
@@ -381,8 +377,7 @@ mod tests {
             args: args.to_vec(),
         };
 
-        let mut ctx = Context::new();
-        ctx.set_actor(bob);
+        let mut ctx = Context::with_actor(bob);
 
         let id = propose(&mut ctx, proposal, voters, quorum);
 
@@ -414,8 +409,7 @@ mod tests {
             args: args.to_vec(),
         };
 
-        let mut ctx = Context::new();
-        ctx.set_actor(bob);
+        let mut ctx = Context::with_actor(bob);
 
         let id = propose(&mut ctx, proposal, voters, quorum);
         let result = "hello world";
@@ -450,8 +444,7 @@ mod tests {
             args: args.to_vec(),
         };
 
-        let mut ctx = Context::new();
-        ctx.set_actor(bob);
+        let mut ctx = Context::with_actor(bob);
 
         let id = propose(&mut ctx, proposal, voters, quorum);
         ctx.set_actor(charlie);
@@ -477,8 +470,7 @@ mod tests {
             args: args.to_vec(),
         };
 
-        let mut ctx = Context::new();
-        ctx.set_actor(bob);
+        let mut ctx = Context::with_actor(bob);
 
         let id = propose(&mut ctx, proposal, voters, quorum);
 

--- a/x/contracts/wasmlanche/src/context.rs
+++ b/x/contracts/wasmlanche/src/context.rs
@@ -264,10 +264,10 @@ impl Context {
 #[cfg(feature = "test")]
 impl Context {
     #[must_use]
-    pub fn new() -> Self {
+    pub fn with_actor(actor: Address) -> Self {
         Self {
             contract_address: Address::default(),
-            actor: Address::default(),
+            actor,
             height: 0,
             timestamp: 0,
             action_id: Id::default(),
@@ -397,12 +397,5 @@ mod external {
             self.context
                 .call_contract(contract_address, function_name, args, max_units, value)
         }
-    }
-}
-
-#[cfg(feature = "test")]
-impl Default for Context {
-    fn default() -> Self {
-        Self::new()
     }
 }

--- a/x/contracts/wasmlanche/tests/test-crate/src/lib.rs
+++ b/x/contracts/wasmlanche/tests/test-crate/src/lib.rs
@@ -70,8 +70,8 @@ mod tests {
 
     #[test]
     fn test_balance() {
-        let mut context = Context::new();
         let address = Address::default();
+        let mut context = Context::with_actor(address);
         let amount: u64 = 100;
 
         // set the balance


### PR DESCRIPTION
It's easy enough to initialize a context with the 0 address if one wants, but it should always be explicit who the actor is.

