### PR TITLE
Add back `actionID` to `StateKeys()`

### DIFF
--- a/api/jsonrpc/server.go
+++ b/api/jsonrpc/server.go
@@ -204,7 +204,7 @@ func (j *JSONRPCServer) ExecuteActions(
 
 	for actionIndex, action := range actions {
 		// Get expected state keys
-		stateKeysWithPermissions := action.StateKeys(args.Actor)
+		stateKeysWithPermissions := action.StateKeys(args.Actor, ids.Empty)
 
 		// flatten the map to a slice of keys
 		storageKeysToRead := make([][]byte, 0, len(stateKeysWithPermissions))

--- a/chain/dependencies.go
+++ b/chain/dependencies.go
@@ -208,7 +208,7 @@ type Action interface {
 	// key (formatted as a big-endian uint16). This is used to automatically calculate storage usage.
 	//
 	// If any key is removed and then re-created, this will count as a creation instead of a modification.
-	StateKeys(actor codec.Address) state.Keys
+	StateKeys(actor codec.Address, actionID ids.ID) state.Keys
 
 	// Execute actually runs the [Action]. Any state changes that the [Action] performs should
 	// be done here.

--- a/chain/transaction.go
+++ b/chain/transaction.go
@@ -169,8 +169,8 @@ func (t *Transaction) StateKeys(bh BalanceHandler) (state.Keys, error) {
 	stateKeys := make(state.Keys)
 
 	// Verify the formatting of state keys passed by the controller
-	for _, action := range t.Actions {
-		for k, v := range action.StateKeys(t.Auth.Actor()) {
+	for i, action := range t.Actions {
+		for k, v := range action.StateKeys(t.Auth.Actor(), CreateActionID(t.ID(), uint8(i))) {
 			if !stateKeys.Add(k, v) {
 				return nil, ErrInvalidKeyValue
 			}
@@ -524,7 +524,7 @@ func EstimateUnits(r Rules, actions Actions, authFactory AuthFactory) (fees.Dime
 		}
 
 		actor := authFactory.Address()
-		stateKeys := action.StateKeys(actor)
+		stateKeys := action.StateKeys(actor, ids.Empty)
 		actionStateKeysMaxChunks, ok := stateKeys.ChunkSizes()
 		if !ok {
 			return fees.Dimensions{}, ErrInvalidKeyValue

--- a/chain/transaction_test.go
+++ b/chain/transaction_test.go
@@ -32,7 +32,7 @@ func (*abstractMockAction) Execute(_ context.Context, _ chain.Rules, _ state.Mut
 	panic("unimplemented")
 }
 
-func (*abstractMockAction) StateKeys(_ codec.Address) state.Keys {
+func (*abstractMockAction) StateKeys(_ codec.Address, _ ids.ID) state.Keys {
 	panic("unimplemented")
 }
 

--- a/examples/morpheusvm/actions/transfer.go
+++ b/examples/morpheusvm/actions/transfer.go
@@ -43,7 +43,7 @@ func (*Transfer) GetTypeID() uint8 {
 	return mconsts.TransferID
 }
 
-func (t *Transfer) StateKeys(actor codec.Address) state.Keys {
+func (t *Transfer) StateKeys(actor codec.Address, _ ids.ID) state.Keys {
 	return state.Keys{
 		string(storage.BalanceKey(actor)): state.Read | state.Write,
 		string(storage.BalanceKey(t.To)):  state.All,

--- a/examples/vmwithcontracts/actions/call.go
+++ b/examples/vmwithcontracts/actions/call.go
@@ -55,7 +55,7 @@ func (*Call) GetTypeID() uint8 {
 	return mconsts.CallContractID
 }
 
-func (t *Call) StateKeys(_ codec.Address) state.Keys {
+func (t *Call) StateKeys(_ codec.Address, _ ids.ID) state.Keys {
 	result := state.Keys{}
 	for _, stateKeyPermission := range t.SpecifiedStateKeys {
 		result.Add(stateKeyPermission.Key, stateKeyPermission.Permission)

--- a/examples/vmwithcontracts/actions/deploy.go
+++ b/examples/vmwithcontracts/actions/deploy.go
@@ -33,7 +33,7 @@ func (*Deploy) GetTypeID() uint8 {
 	return mconsts.DeployID
 }
 
-func (d *Deploy) StateKeys(_ codec.Address) state.Keys {
+func (d *Deploy) StateKeys(_ codec.Address, _ ids.ID) state.Keys {
 	if d.address == codec.EmptyAddress {
 		d.address = storage.GetAddressForDeploy(0, d.CreationInfo)
 	}

--- a/examples/vmwithcontracts/actions/publish.go
+++ b/examples/vmwithcontracts/actions/publish.go
@@ -33,7 +33,7 @@ func (*Publish) GetTypeID() uint8 {
 	return mconsts.PublishID
 }
 
-func (t *Publish) StateKeys(_ codec.Address) state.Keys {
+func (t *Publish) StateKeys(_ codec.Address, _ ids.ID) state.Keys {
 	if t.id == nil {
 		hashedID := sha256.Sum256(t.ContractBytes)
 		t.id, _ = keys.Encode(storage.ContractsKey(hashedID[:]), len(t.ContractBytes))

--- a/examples/vmwithcontracts/actions/transfer.go
+++ b/examples/vmwithcontracts/actions/transfer.go
@@ -44,7 +44,7 @@ func (*Transfer) GetTypeID() uint8 {
 	return mconsts.TransferID
 }
 
-func (t *Transfer) StateKeys(actor codec.Address) state.Keys {
+func (t *Transfer) StateKeys(actor codec.Address, _ ids.ID) state.Keys {
 	return state.Keys{
 		string(storage.BalanceKey(actor)): state.Read | state.Write,
 		string(storage.BalanceKey(t.To)):  state.All,


### PR DESCRIPTION
As referenced in #1645, this PR adds back the `actionID` parameter back to `StateKeys()`.

Following the convention for when `actionID` previously existed, we call `CreateActionID()` whenever possible. If creating the action ID via `CreateActionID()` isn't possible, we pass in `ids.Empty{}`