### PR TITLE
Default Contract Manager Implementation

### DIFF
--- a/x/contracts/runtime/call_context_test.go
+++ b/x/contracts/runtime/call_context_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/hypersdk/codec"
+	"github.com/ava-labs/hypersdk/x/contracts/test"
 )
 
 func TestCallContext(t *testing.T) {
@@ -22,11 +23,14 @@ func TestCallContext(t *testing.T) {
 	contractID := ids.GenerateTestID()
 	contractAccount := codec.CreateAddress(0, contractID)
 	stringedID := string(contractID[:])
+	contractManager := NewContractStateManager(test.NewTestDB())
+	err := contractManager.SetAccountContract(ctx, contractAccount, ContractID(stringedID))
+	require.NoError(err)
 	testStateManager := &TestStateManager{
-		ContractsMap: map[string][]byte{},
-		AccountMap:   map[codec.Address]string{contractAccount: stringedID},
+		ContractManager: contractManager,
 	}
-	err := testStateManager.CompileAndSetContract(ContractID(stringedID), "call_contract")
+
+	err = testStateManager.CompileAndSetContract(ContractID(stringedID), "call_contract")
 	require.NoError(err)
 
 	r := NewRuntime(
@@ -75,12 +79,13 @@ func TestCallContextPreventOverwrite(t *testing.T) {
 	contract1Address := codec.CreateAddress(1, contract1ID)
 	stringedID0 := string(contract0ID[:])
 
+	contractManager := NewContractStateManager(test.NewTestDB())
+	err := contractManager.SetAccountContract(ctx, contract0Address, ContractID(stringedID0))
+	require.NoError(err)
 	testStateManager := &TestStateManager{
-		ContractsMap: map[string][]byte{},
-		AccountMap:   map[codec.Address]string{contract0Address: stringedID0},
+		ContractManager: contractManager,
 	}
-
-	err := testStateManager.CompileAndSetContract(ContractID(stringedID0), "call_contract")
+	err = testStateManager.CompileAndSetContract(ContractID(stringedID0), "call_contract")
 	require.NoError(err)
 
 	r := NewRuntime(
@@ -94,10 +99,13 @@ func TestCallContextPreventOverwrite(t *testing.T) {
 		})
 
 	stringedID1 := string(contract1ID[:])
+	contractManager1 := NewContractStateManager(test.NewTestDB())
+	err = contractManager.SetAccountContract(ctx, contract1Address, ContractID(stringedID1))
+	require.NoError(err)
 	testStateManager1 := &TestStateManager{
-		ContractsMap: map[string][]byte{},
-		AccountMap:   map[codec.Address]string{contract1Address: stringedID1},
+		ContractManager: contractManager1,
 	}
+
 	err = testStateManager1.CompileAndSetContract(ContractID(stringedID1), "call_contract")
 	require.NoError(err)
 

--- a/x/contracts/runtime/call_context_test.go
+++ b/x/contracts/runtime/call_context_test.go
@@ -23,7 +23,7 @@ func TestCallContext(t *testing.T) {
 	contractID := ids.GenerateTestID()
 	contractAccount := codec.CreateAddress(0, contractID)
 	stringedID := string(contractID[:])
-	contractManager := NewContractStateManager(test.NewTestDB())
+	contractManager := NewContractStateManager(test.NewTestDB(), []byte{})
 	err := contractManager.SetAccountContract(ctx, contractAccount, ContractID(stringedID))
 	require.NoError(err)
 	testStateManager := &TestStateManager{
@@ -79,7 +79,7 @@ func TestCallContextPreventOverwrite(t *testing.T) {
 	contract1Address := codec.CreateAddress(1, contract1ID)
 	stringedID0 := string(contract0ID[:])
 
-	contractManager := NewContractStateManager(test.NewTestDB())
+	contractManager := NewContractStateManager(test.NewTestDB(), []byte{})
 	err := contractManager.SetAccountContract(ctx, contract0Address, ContractID(stringedID0))
 	require.NoError(err)
 	testStateManager := &TestStateManager{
@@ -99,7 +99,7 @@ func TestCallContextPreventOverwrite(t *testing.T) {
 		})
 
 	stringedID1 := string(contract1ID[:])
-	contractManager1 := NewContractStateManager(test.NewTestDB())
+	contractManager1 := NewContractStateManager(test.NewTestDB(), []byte{})
 	err = contractManager.SetAccountContract(ctx, contract1Address, ContractID(stringedID1))
 	require.NoError(err)
 	testStateManager1 := &TestStateManager{

--- a/x/contracts/runtime/manager.go
+++ b/x/contracts/runtime/manager.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package runtime
 
 import (
@@ -7,14 +10,15 @@ import (
 
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/ids"
+
 	"github.com/ava-labs/hypersdk/codec"
 	"github.com/ava-labs/hypersdk/state"
 )
 
 var (
-	_ ContractManager = &ContractStateManager{}
-	ErrUnknownAccount = errors.New("unknown account")
-	contractKeyBytes  = []byte("contract")
+	_                 ContractManager = &ContractStateManager{}
+	ErrUnknownAccount                 = errors.New("unknown account")
+	contractKeyBytes                  = []byte("contract")
 )
 
 const (
@@ -23,7 +27,6 @@ const (
 	accountPrefix      = 0x1
 	accountDataPrefix  = 0x0
 	accountStatePrefix = 0x1
-
 )
 
 // default implementation of the ContractManager interface
@@ -67,7 +70,6 @@ func (p *ContractStateManager) GetContractBytes(ctx context.Context, contractID 
 
 	return contractBytes, nil
 }
-
 
 func (p *ContractStateManager) NewAccountWithContract(ctx context.Context, contractID ContractID, accountCreationData []byte) (codec.Address, error) {
 	newID := sha256.Sum256(append(contractID, accountCreationData...))

--- a/x/contracts/runtime/manager.go
+++ b/x/contracts/runtime/manager.go
@@ -1,0 +1,18 @@
+package runtime
+
+import "github.com/ava-labs/hypersdk/state"
+
+// default implementation of the ContractManager interface
+type ContractStateManager struct {
+	// this state mutable should have its own prefix that doesn't conflict with other state
+	db state.Mutable
+}
+
+func NewContractStateManager(
+	db state.Mutable,
+) *ContractStateManager {
+	return &ContractStateManager{
+		db: db,
+	}
+}
+

--- a/x/contracts/runtime/manager.go
+++ b/x/contracts/runtime/manager.go
@@ -22,24 +22,30 @@ var (
 )
 
 const (
+	// Global directory of contractIDs to contractBytes
 	contractPrefix = 0x0
 
-	accountPrefix      = 0x1
-	accountDataPrefix  = 0x0
+	// Prefix for all contract state spaces
+	accountPrefix = 0x1
+	// Associated data for an account, such as the contractID
+	accountDataPrefix = 0x0
+	// State space associated with an account
 	accountStatePrefix = 0x1
 )
 
-// default implementation of the ContractManager interface
+// ContractStateManager is an out of the box implementation of the ContractManager interface.
+// The contract state manager is responsible for managing all state keys associated with contracts.
 type ContractStateManager struct {
-	// this state mutable should have its own prefix that doesn't conflict with other state
 	db state.Mutable
 }
 
+// NewContractStateManager returns a new ContractStateManager instance.
+// [prefix] must be unique to ensures the contract's state space
+// remains isolated from other state spaces in [db].
 func NewContractStateManager(
 	db state.Mutable,
 	prefix []byte,
 ) *ContractStateManager {
-	// set db to prefixed state space
 	prefixedState := newPrefixStateMutable(prefix, db)
 
 	return &ContractStateManager{
@@ -47,6 +53,7 @@ func NewContractStateManager(
 	}
 }
 
+// GetContractState returns a mutable state instance associated with [account].
 func (p *ContractStateManager) GetContractState(account codec.Address) state.Mutable {
 	return newAccountPrefixedMutable(account, p.db)
 }
@@ -160,6 +167,7 @@ func newAccountPrefixedMutable(account codec.Address, mutable state.Mutable) sta
 	return &prefixedStateMutable{inner: mutable, prefix: accountStateKey(account[:])}
 }
 
+// [accountPrefix] + [account] + [accountStatePrefix] = state space associated with a contract
 func accountStateKey(key []byte) (k []byte) {
 	k = make([]byte, 2+len(key))
 	k[0] = accountPrefix

--- a/x/contracts/runtime/manager.go
+++ b/x/contracts/runtime/manager.go
@@ -1,6 +1,30 @@
 package runtime
 
-import "github.com/ava-labs/hypersdk/state"
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+
+	"github.com/ava-labs/avalanchego/database"
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/hypersdk/codec"
+	"github.com/ava-labs/hypersdk/state"
+)
+
+var (
+	_ ContractManager = &ContractStateManager{}
+	ErrUnknownAccount = errors.New("unknown account")
+	contractKeyBytes  = []byte("contract")
+)
+
+const (
+	contractPrefix = 0x0
+
+	accountPrefix      = 0x1
+	accountDataPrefix  = 0x0
+	accountStatePrefix = 0x1
+
+)
 
 // default implementation of the ContractManager interface
 type ContractStateManager struct {
@@ -16,3 +40,111 @@ func NewContractStateManager(
 	}
 }
 
+func (p *ContractStateManager) GetContractState(account codec.Address) state.Mutable {
+	return newAccountPrefixedMutable(account, p.db)
+}
+
+// GetAccountContract grabs the associated id with [account]. The ID is the key mapping to the contractbytes
+// Errors if there is no found account or an error fetching
+func (p *ContractStateManager) GetAccountContract(ctx context.Context, account codec.Address) (ContractID, error) {
+	contractID, exists, err := p.getAccountContract(ctx, account)
+	if err != nil {
+		return ids.Empty[:], err
+	}
+	if !exists {
+		return ids.Empty[:], ErrUnknownAccount
+	}
+	return contractID[:], nil
+}
+
+// [contractID] -> [contractBytes]
+func (p *ContractStateManager) GetContractBytes(ctx context.Context, contractID ContractID) ([]byte, error) {
+	// TODO: take fee out of balance?
+	contractBytes, err := p.db.GetValue(ctx, contractKey(contractID))
+	if err != nil {
+		return []byte{}, ErrUnknownAccount
+	}
+
+	return contractBytes, nil
+}
+
+
+func (p *ContractStateManager) NewAccountWithContract(ctx context.Context, contractID ContractID, accountCreationData []byte) (codec.Address, error) {
+	newID := sha256.Sum256(append(contractID, accountCreationData...))
+	newAccount := codec.CreateAddress(0, newID)
+	return newAccount, p.SetAccountContract(ctx, newAccount, contractID)
+}
+
+func (p *ContractStateManager) SetAccountContract(ctx context.Context, account codec.Address, contractID ContractID) error {
+	return p.db.Insert(ctx, accountDataKey(account[:], contractKeyBytes), contractID)
+}
+
+func contractKey(key []byte) (k []byte) {
+	k = make([]byte, 0, 1+len(key))
+	k = append(k, contractPrefix)
+	k = append(k, key...)
+	return
+}
+
+// Creates a key an account balance key
+func accountDataKey(account []byte, key []byte) (k []byte) {
+	// accountPrefix + account + accountDataPrefix + key
+	k = make([]byte, 0, 2+len(account)+len(key))
+	k = append(k, accountPrefix)
+	k = append(k, account...)
+	k = append(k, accountDataPrefix)
+	k = append(k, key...)
+	return
+}
+
+func accountContractKey(account []byte) []byte {
+	return accountDataKey(account, contractKeyBytes)
+}
+
+func (p *ContractStateManager) getAccountContract(ctx context.Context, account codec.Address) (ids.ID, bool, error) {
+	v, err := p.db.GetValue(ctx, accountContractKey(account[:]))
+	if errors.Is(err, database.ErrNotFound) {
+		return ids.Empty, false, nil
+	}
+	if err != nil {
+		return ids.Empty, false, err
+	}
+	return ids.ID(v[:ids.IDLen]), true, nil
+}
+
+// prefixed state
+type prefixedStateMutable struct {
+	inner  state.Mutable
+	prefix []byte
+}
+
+func (s *prefixedStateMutable) prefixKey(key []byte) (k []byte) {
+	k = make([]byte, len(s.prefix)+len(key))
+	copy(k, s.prefix)
+	copy(k[len(s.prefix):], key)
+	return
+}
+
+func (s *prefixedStateMutable) GetValue(ctx context.Context, key []byte) (value []byte, err error) {
+	return s.inner.GetValue(ctx, s.prefixKey(key))
+}
+
+func (s *prefixedStateMutable) Insert(ctx context.Context, key []byte, value []byte) error {
+	return s.inner.Insert(ctx, s.prefixKey(key), value)
+}
+
+func (s *prefixedStateMutable) Remove(ctx context.Context, key []byte) error {
+	return s.inner.Remove(ctx, s.prefixKey(key))
+}
+
+func newAccountPrefixedMutable(account codec.Address, mutable state.Mutable) state.Mutable {
+	return &prefixedStateMutable{inner: mutable, prefix: accountStateKey(account[:])}
+}
+
+func accountStateKey(key []byte) (k []byte) {
+	k = make([]byte, 2+len(key))
+	k[0] = accountPrefix
+	copy(k[1:], key)
+	k[len(k)-1] = accountStatePrefix
+	return
+}

--- a/x/contracts/runtime/runtime.go
+++ b/x/contracts/runtime/runtime.go
@@ -50,6 +50,8 @@ type ContractManager interface {
 	NewAccountWithContract(ctx context.Context, contractID ContractID, accountCreationData []byte) (codec.Address, error)
 	// SetAccountContract associates the given contract ID with the given account.
 	SetAccountContract(ctx context.Context, account codec.Address, contractID ContractID) error
+	// SetContractBytes stores the compiled WASM bytes of the contract with the given ID.
+	SetContractBytes(ctx context.Context, contractID ContractID, contractBytes []byte) error
 }
 
 func NewRuntime(

--- a/x/contracts/runtime/util_test.go
+++ b/x/contracts/runtime/util_test.go
@@ -58,8 +58,7 @@ func (t TestStateManager) CompileAndSetContract(contractID ContractID, contractN
 	if err != nil {
 		return err
 	}
-	t.SetContractBytes(context.Background(), contractID, contractBytes)
-	return nil
+	return t.SetContractBytes(context.Background(), contractID, contractBytes)
 }
 
 func (t TestStateManager) NewAccountWithContract(_ context.Context, contractID ContractID, _ []byte) (codec.Address, error) {
@@ -205,7 +204,7 @@ func newTestRuntime(ctx context.Context) *testRuntime {
 			NewConfig(),
 			logging.NoLog{}).WithDefaults(CallInfo{Fuel: 1000000000}),
 		StateManager: TestStateManager{
-			ContractManager: NewContractStateManager(test.NewTestDB()),
+			ContractManager: NewContractStateManager(test.NewTestDB(), []byte{}),
 			Balances:        map[codec.Address]uint64{},
 		},
 	}

--- a/x/contracts/simulator/ffi/ffi.go
+++ b/x/contracts/simulator/ffi/ffi.go
@@ -87,14 +87,15 @@ func CreateContract(db *C.Mutable, path *C.char) C.CreateContractResponse {
 		}
 	}
 
-	contractID, err := generateRandomID()
+	id, err := generateRandomID()
 	if err != nil {
 		return C.CreateContractResponse{
 			error: C.CString(err.Error()),
 		}
 	}
 
-	err = contractManager.SetContractBytes(context.TODO(), runtime.ContractID(contractID[:]), contractBytes)
+	contractID := runtime.ContractID(id[:])
+	err = contractManager.SetContractBytes(context.TODO(), contractID, contractBytes)
 	if err != nil {
 		errmsg := "contract creation failed: " + err.Error()
 		return C.CreateContractResponse{

--- a/x/contracts/simulator/ffi/ffi.go
+++ b/x/contracts/simulator/ffi/ffi.go
@@ -94,7 +94,7 @@ func CreateContract(db *C.Mutable, path *C.char) C.CreateContractResponse {
 		}
 	}
 
-	err = contractManager.SetContract(context.TODO(), contractID, contractBytes)
+	err = contractManager.SetContractBytes(context.TODO(), runtime.ContractID(contractID[:]), contractBytes)
 	if err != nil {
 		errmsg := "contract creation failed: " + err.Error()
 		return C.CreateContractResponse{

--- a/x/contracts/simulator/state/manager.go
+++ b/x/contracts/simulator/state/manager.go
@@ -5,7 +5,6 @@ package state
 
 import (
 	"context"
-	"crypto/sha256"
 	"encoding/binary"
 	"errors"
 
@@ -13,7 +12,6 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 
 	"github.com/ava-labs/hypersdk/codec"
-	"github.com/ava-labs/hypersdk/crypto/ed25519"
 	"github.com/ava-labs/hypersdk/state"
 	"github.com/ava-labs/hypersdk/x/contracts/runtime"
 )
@@ -83,80 +81,9 @@ func (p *ContractStateManager) TransferBalance(ctx context.Context, from codec.A
 	return p.SetBalance(ctx, from, fromBalance-amount)
 }
 
-func (p *ContractStateManager) GetContractState(account codec.Address) state.Mutable {
-	return newAccountPrefixedMutable(account, p.db)
-}
-
-// GetAccountContract grabs the associated id with [account]. The ID is the key mapping to the contractbytes
-// Errors if there is no found account or an error fetching
-func (p *ContractStateManager) GetAccountContract(ctx context.Context, account codec.Address) (runtime.ContractID, error) {
-	contractID, exists, err := p.getAccountContract(ctx, account)
-	if err != nil {
-		return ids.Empty[:], err
-	}
-	if !exists {
-		return ids.Empty[:], ErrUnknownAccount
-	}
-	return contractID[:], nil
-}
-
-// [contractID] -> [contractBytes]
-func (p *ContractStateManager) GetContractBytes(ctx context.Context, contractID runtime.ContractID) ([]byte, error) {
-	// TODO: take fee out of balance?
-	contractBytes, err := p.db.GetValue(ctx, contractKey(contractID))
-	if err != nil {
-		return []byte{}, ErrUnknownAccount
-	}
-
-	return contractBytes, nil
-}
-
-func (p *ContractStateManager) NewAccountWithContract(ctx context.Context, contractID runtime.ContractID, accountCreationData []byte) (codec.Address, error) {
-	newID := sha256.Sum256(append(contractID, accountCreationData...))
-	newAccount := codec.CreateAddress(0, newID)
-	return newAccount, p.SetAccountContract(ctx, newAccount, contractID)
-}
-
-func (p *ContractStateManager) SetAccountContract(ctx context.Context, account codec.Address, contractID runtime.ContractID) error {
-	return p.db.Insert(ctx, accountDataKey(account[:], contractKeyBytes), contractID)
-}
-
 // Creates an account balance key
 func accountBalanceKey(account []byte) []byte {
 	return accountDataKey(account, balanceKeyBytes)
-}
-
-func accountContractKey(account []byte) []byte {
-	return accountDataKey(account, contractKeyBytes)
-}
-
-// Creates a key an account balance key
-func accountDataKey(account []byte, key []byte) (k []byte) {
-	// accountPrefix + account + accountDataPrefix + key
-	k = make([]byte, 0, 2+len(account)+len(key))
-	k = append(k, accountPrefix)
-	k = append(k, account...)
-	k = append(k, accountDataPrefix)
-	k = append(k, key...)
-	return
-}
-
-func contractKey(key []byte) (k []byte) {
-	k = make([]byte, 0, 1+len(key))
-	k = append(k, contractPrefix)
-	k = append(k, key...)
-	return
-}
-
-func (p *ContractStateManager) getAccountContract(ctx context.Context, account codec.Address) (ids.ID, bool, error) {
-	v, err := p.db.GetValue(ctx, accountContractKey(account[:]))
-	if errors.Is(err, database.ErrNotFound) {
-		return ids.Empty, false, nil
-	}
-	if err != nil {
-		return ids.Empty, false, err
-	}
-	return ids.ID(v[:ids.IDLen]), true, nil
 }
 
 // setContract stores [contract] at [contractID]
@@ -166,27 +93,4 @@ func (p *ContractStateManager) SetContract(
 	contract []byte,
 ) error {
 	return p.db.Insert(ctx, contractKey(contractID[:]), contract)
-}
-
-// gets the public key mapped to the given name.
-func GetPublicKey(ctx context.Context, db state.Immutable, name string) (ed25519.PublicKey, bool, error) {
-	k := make([]byte, 1+ed25519.PublicKeyLen)
-	k = append(k, addressStoragePrefix)
-	k = append(k, []byte(name)...)
-
-	v, err := db.GetValue(ctx, k)
-	if errors.Is(err, database.ErrNotFound) {
-		return ed25519.EmptyPublicKey, false, nil
-	}
-	if err != nil {
-		return ed25519.EmptyPublicKey, false, err
-	}
-	return ed25519.PublicKey(v), true, nil
-}
-
-func SetKey(ctx context.Context, db state.Mutable, privateKey ed25519.PrivateKey, name string) error {
-	k := make([]byte, 1+ed25519.PublicKeyLen)
-	k = append(k, addressStoragePrefix)
-	k = append(k, []byte(name)...)
-	return db.Insert(ctx, k, privateKey[:])
 }

--- a/x/contracts/simulator/state/manager.go
+++ b/x/contracts/simulator/state/manager.go
@@ -15,20 +15,20 @@ import (
 	"github.com/ava-labs/hypersdk/x/contracts/runtime"
 )
 
-var _ runtime.ContractStateManager = &ContractStateManager{}
+var _ runtime.StateManager = &ContractStateManager{}
 
 var (
-	balanceKeyBytes   = []byte("balance")
+	balanceKeyBytes       = []byte("balance")
 	contractManagerPrefix = []byte("contract")
 )
 
 const (
-	BalanceManagerPrefix  = 0x1
-	BalanceDataPrefix     = 0x0
+	BalanceManagerPrefix = 0x1
+	BalanceDataPrefix    = 0x0
 )
 
 type ContractStateManager struct {
-	db state.Mutable
+	db            state.Mutable
 	contractState *runtime.ContractStateManager
 }
 
@@ -40,7 +40,7 @@ func NewContractStateManager(db state.Mutable) *ContractStateManager {
 		),
 	)
 	return &ContractStateManager{
-		db: db,
+		db:            db,
 		contractState: contractManager,
 	}
 }
@@ -93,4 +93,27 @@ func accountBalanceKey(account []byte) (k []byte) {
 	return
 }
 
+// expose contract manager methods
+func (p *ContractStateManager) GetContractState(address codec.Address) state.Mutable {
+	return p.contractState.GetContractState(address)
+}
 
+func (p *ContractStateManager) GetAccountContract(ctx context.Context, account codec.Address) (runtime.ContractID, error) {
+	return p.contractState.GetAccountContract(ctx, account)
+}
+
+func (p *ContractStateManager) GetContractBytes(ctx context.Context, contractID runtime.ContractID) ([]byte, error) {
+	return p.contractState.GetContractBytes(ctx, contractID)
+}
+
+func (p *ContractStateManager) NewAccountWithContract(ctx context.Context, contractID runtime.ContractID, accountCreationData []byte) (codec.Address, error) {
+	return p.contractState.NewAccountWithContract(ctx, contractID, accountCreationData)
+}
+
+func (p *ContractStateManager) SetAccountContract(ctx context.Context, account codec.Address, contractID runtime.ContractID) error {
+	return p.contractState.SetAccountContract(ctx, account, contractID)
+}
+
+func (p *ContractStateManager) SetContractBytes(ctx context.Context, contractID runtime.ContractID, contractBytes []byte) error {
+	return p.contractState.SetContractBytes(ctx, contractID, contractBytes)
+}

--- a/x/contracts/simulator/state/manager.go
+++ b/x/contracts/simulator/state/manager.go
@@ -33,12 +33,7 @@ type ContractStateManager struct {
 }
 
 func NewContractStateManager(db state.Mutable) *ContractStateManager {
-	contractManager := runtime.NewContractStateManager(
-		runtime.NewPrefixStateMutable(
-			contractManagerPrefix,
-			db,
-		),
-	)
+	contractManager := runtime.NewContractStateManager(db, contractManagerPrefix)
 	return &ContractStateManager{
 		db:            db,
 		contractState: contractManager,

--- a/x/contracts/simulator/state/manager.go
+++ b/x/contracts/simulator/state/manager.go
@@ -24,7 +24,6 @@ var (
 
 const (
 	BalanceManagerPrefix = 0x1
-	BalanceDataPrefix    = 0x0
 )
 
 type ContractStateManager struct {

--- a/x/contracts/simulator/state/state.go
+++ b/x/contracts/simulator/state/state.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/ava-labs/avalanchego/database"
 
-	"github.com/ava-labs/hypersdk/codec"
 	"github.com/ava-labs/hypersdk/state"
 )
 
@@ -98,40 +97,4 @@ func (s *Mutable) Remove(_ context.Context, key []byte) error {
 	C.bridge_remove_callback(s.remove_callback, s.stateObj, keyStruct)
 
 	return nil
-}
-
-type prefixedStateMutable struct {
-	inner  state.Mutable
-	prefix []byte
-}
-
-func (s *prefixedStateMutable) prefixKey(key []byte) (k []byte) {
-	k = make([]byte, len(s.prefix)+len(key))
-	copy(k, s.prefix)
-	copy(k[len(s.prefix):], key)
-	return
-}
-
-func (s *prefixedStateMutable) GetValue(ctx context.Context, key []byte) (value []byte, err error) {
-	return s.inner.GetValue(ctx, s.prefixKey(key))
-}
-
-func (s *prefixedStateMutable) Insert(ctx context.Context, key []byte, value []byte) error {
-	return s.inner.Insert(ctx, s.prefixKey(key), value)
-}
-
-func (s *prefixedStateMutable) Remove(ctx context.Context, key []byte) error {
-	return s.inner.Remove(ctx, s.prefixKey(key))
-}
-
-func newAccountPrefixedMutable(account codec.Address, mutable state.Mutable) state.Mutable {
-	return &prefixedStateMutable{inner: mutable, prefix: accountStateKey(account[:])}
-}
-
-func accountStateKey(key []byte) (k []byte) {
-	k = make([]byte, 2+len(key))
-	k[0] = accountPrefix
-	copy(k[1:], key)
-	k[len(k)-1] = accountStatePrefix
-	return
 }

--- a/x/contracts/wasmlanche/src/simulator.rs
+++ b/x/contracts/wasmlanche/src/simulator.rs
@@ -266,16 +266,14 @@ mod tests {
 
     #[test]
     fn get_balance() {
-        let account_data_prefix = [0x00];
-        let account_prefix = [0x01];
+        let balance_manager_prefix = [0x01];
         let alice = Address::new([1; 33]);
         let mut state = SimpleState::new();
         let exptected_balance = 999u64;
 
-        let key = account_prefix
+        let key = balance_manager_prefix
             .into_iter()
             .chain(alice.as_ref().iter().copied())
-            .chain(account_data_prefix)
             .chain(b"balance".iter().copied())
             .collect();
 


### PR DESCRIPTION
This PR provides a default state layout for VMs that want to use contracts. VMs that use our out of the box implementation don't need to worry about managing and setting up their state keys(although they still can if they want).