### PR TITLE
Add `balance` cmd to CLI

### DIFF
--- a/cmd/hypersdk-cli/README.md
+++ b/cmd/hypersdk-cli/README.md
@@ -126,6 +126,18 @@ For interactive input:
 hypersdk-cli tx Transfer
 ```
 
+### balance
+
+Query the balance of an address
+
+```bash
+hypersdk-cli balance --sender 0x00c4cb545f748a28770042f893784ce85b107389004d6a0e0d6d7518eeae1292d9
+```
+
+If `--sender` isn't provided, the address associated with the private key in
+`~/.hypersdk-cli/config.yaml` is queried.
+
+
 ## Notes
 
 - Only flat actions are supported. Arrays, slices, embedded structs, maps, and struct fields are not supported.
@@ -134,7 +146,6 @@ hypersdk-cli tx Transfer
 
 ## Known Issues
 
-- The `balance` command is not currently implemented due to the lack of a standardized balance RPC method at the HyperSDK level.
 - The `maxFee` for transactions is currently hardcoded to 1,000,000.
 - The `key set` and `endpoint set` commands use a nested command structure which adds unnecessary complexity for a small CLI tool. A flatter command structure would be more appropriate.
 - Currency values are represented as uint64 without decimal point support in the ABI. The CLI cannot automatically parse decimal inputs (e.g. "12.0") since there is no currency type annotation. Users must enter the raw uint64 value including all decimal places (e.g. "12000000000" for 12 coins with 9 decimal places).

--- a/cmd/hypersdk-cli/balance.go
+++ b/cmd/hypersdk-cli/balance.go
@@ -1,0 +1,88 @@
+// Copyright (C) 2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/ava-labs/hypersdk/api/jsonrpc"
+	"github.com/ava-labs/hypersdk/auth"
+	"github.com/ava-labs/hypersdk/codec"
+)
+
+var balanceCmd = &cobra.Command{
+	Use:   "balance [address]",
+	Short: "Get the balance of an address",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// 1. figure out sender address
+		addressStr, err := cmd.Flags().GetString("sender")
+		if err != nil {
+			return fmt.Errorf("failed to get sender: %w", err)
+		}
+
+		var address codec.Address
+
+		if addressStr != "" {
+			address, err = codec.StringToAddress(addressStr)
+			if err != nil {
+				return fmt.Errorf("failed to convert sender to address: %w", err)
+			}
+		} else {
+			// ok, infer user's address from the private key
+			keyString, err := getConfigValue(cmd, "key", true)
+			if err != nil {
+				return fmt.Errorf("failed to get key from config: %w", err)
+			}
+			key, err := privateKeyFromString(keyString)
+			if err != nil {
+				return fmt.Errorf("failed to decode key: %w", err)
+			}
+			address = auth.NewED25519Address(key.PublicKey())
+		}
+
+		// 2. create client
+		endpoint, err := getConfigValue(cmd, "endpoint", true)
+		if err != nil {
+			return fmt.Errorf("failed to get endpoint: %w", err)
+		}
+		client := jsonrpc.NewJSONRPCClient(endpoint)
+
+		// 3. get balance
+		balance, err := client.GetBalance(context.Background(), address)
+		errorString := ""
+		if err != nil {
+			errorString = err.Error()
+		}
+
+		return printValue(cmd, balanceResponse{
+			Balance: balance,
+			Error:   errorString,
+		})
+	},
+}
+
+type balanceResponse struct {
+	Balance uint64 `json:"balance"`
+	Error   string `json:"error"`
+}
+
+func (b balanceResponse) String() string {
+	var result strings.Builder
+	if b.Error != "" {
+		result.WriteString(fmt.Sprintf("❌ Error: %s\n", b.Error))
+	} else {
+		result.WriteString(fmt.Sprintf("✅ Balance: %d\n", b.Balance))
+	}
+
+	return result.String()
+}
+
+func init() {
+	balanceCmd.Flags().String("sender", "", "Address being queried in hex")
+	rootCmd.AddCommand(balanceCmd)
+}

--- a/cmd/hypersdk-cli/balance.go
+++ b/cmd/hypersdk-cli/balance.go
@@ -18,7 +18,7 @@ import (
 var balanceCmd = &cobra.Command{
 	Use:   "balance [address]",
 	Short: "Get the balance of an address",
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		// 1. figure out sender address
 		addressStr, err := cmd.Flags().GetString("sender")
 		if err != nil {
@@ -60,21 +60,21 @@ var balanceCmd = &cobra.Command{
 		}
 
 		return printValue(cmd, balanceResponse{
-			Balance: balance,
-			Error:   errorString,
+			Balance:      balance,
+			BalanceError: errorString,
 		})
 	},
 }
 
 type balanceResponse struct {
-	Balance uint64 `json:"balance"`
-	Error   string `json:"error"`
+	Balance      uint64 `json:"balance"`
+	BalanceError string `json:"error"`
 }
 
 func (b balanceResponse) String() string {
 	var result strings.Builder
-	if b.Error != "" {
-		result.WriteString(fmt.Sprintf("❌ Error: %s\n", b.Error))
+	if b.BalanceError != "" {
+		result.WriteString(fmt.Sprintf("❌ Error: %s\n", b.BalanceError))
 	} else {
 		result.WriteString(fmt.Sprintf("✅ Balance: %d\n", b.Balance))
 	}


### PR DESCRIPTION
This PR adds the `balance` cmd to `hypersdk-cli`.

This PR also updates the `README` of the CLI to account for the `balance` cmd.