### PR TITLE
Don't benchmark serializing parameters

### DIFF
--- a/x/contracts/runtime/import_balance_test.go
+++ b/x/contracts/runtime/import_balance_test.go
@@ -33,7 +33,7 @@ func TestImportBalanceSendBalanceToAnotherContract(t *testing.T) {
 	stateManager.Balances[newInstanceAddress] = 0
 
 	// contract 2 starts with 0 balance
-	result, err := r.CallContract(newInstanceAddress, "balance")
+	result, err := r.CallContract(newInstanceAddress, "balance", nil)
 	require.NoError(err)
 	require.Equal(uint64(0), into[uint64](result))
 

--- a/x/contracts/runtime/import_contract_test.go
+++ b/x/contracts/runtime/import_contract_test.go
@@ -36,7 +36,7 @@ func BenchmarkDeployContract(b *testing.B) {
 		newAccount := into[codec.Address](result)
 
 		b.StopTimer()
-		result, err = runtime.CallContract(newAccount, "simple_call")
+		result, err = runtime.CallContract(newAccount, "simple_call", nil)
 		require.NoError(err)
 		require.Equal(uint64(0), into[uint64](result))
 		b.StartTimer()
@@ -63,7 +63,7 @@ func TestImportContractDeployContract(t *testing.T) {
 
 	newAccount := into[codec.Address](result)
 
-	result, err = runtime.CallContract(newAccount, "simple_call")
+	result, err = runtime.CallContract(newAccount, "simple_call", nil)
 	require.NoError(err)
 	require.Equal(uint64(0), into[uint64](result))
 }

--- a/x/contracts/runtime/util_test.go
+++ b/x/contracts/runtime/util_test.go
@@ -186,14 +186,14 @@ func (t *testRuntime) AddContract(contractID ContractID, account codec.Address, 
 	return t.StateManager.(TestStateManager).SetAccountContract(t.Context, account, contractID)
 }
 
-func (t *testRuntime) CallContract(contract codec.Address, function string, params ...interface{}) ([]byte, error) {
+func (t *testRuntime) CallContract(contract codec.Address, function string, params []byte) ([]byte, error) {
 	return t.callContext.CallContract(
 		t.Context,
 		&CallInfo{
 			Contract:     contract,
 			State:        t.StateManager,
 			FunctionName: function,
-			Params:       test.SerializeParams(params...),
+			Params:       params,
 		})
 }
 
@@ -235,10 +235,15 @@ type testContract struct {
 }
 
 func (t *testContract) Call(function string, params ...interface{}) ([]byte, error) {
+	args := test.SerializeParams(params...)
+	return t.CallWithSerializedParams(function, args)
+}
+
+func (t *testContract) CallWithSerializedParams(function string, params []byte) ([]byte, error) {
 	return t.Runtime.CallContract(
 		t.Address,
 		function,
-		params...)
+		params)
 }
 
 func (t *testContract) WithStateManager(manager StateManager) *testContract {


### PR DESCRIPTION
This doesn't have a meaningful effect on the results, but param serialization likely won't be part of the execution of a transaction so we shouldn't benchmark it

