### PR TITLE
Remove HRP + Decimals dead code

### DIFF
--- a/codec/errors.go
+++ b/codec/errors.go
@@ -9,7 +9,6 @@ var (
 	ErrTooManyItems       = errors.New("too many items")
 	ErrDuplicateItem      = errors.New("duplicate item")
 	ErrFieldNotPopulated  = errors.New("field is not populated")
-	ErrIncorrectHRP       = errors.New("incorrect hrp")
 	ErrInsufficientLength = errors.New("insufficient length")
 	ErrInvalidSize        = errors.New("invalid size")
 )

--- a/docs/tutorials/morpheusvm/morpheusvm.md
+++ b/docs/tutorials/morpheusvm/morpheusvm.md
@@ -61,8 +61,7 @@ values:
 mkdir consts
 ```
 
-Inside `consts/`, we'll add a `consts.go` file to declare the name, HRP for Bech32 addresses,
-and the initial version of our VM:
+Inside `consts/`, we'll add a `consts.go` file to declare the name and the initial version of our VM:
 
 ```golang
 package consts
@@ -73,7 +72,6 @@ import (
 )
 
 const (
-	HRP  = "tutorial"
 	Name = "tutorialvm"
 )
 
@@ -126,7 +124,6 @@ mkdir actions
 
 In `actions/`, create `transfer.go`. This file will declare the struct and add a type assertion that it
 implements the `chain.Action` interface:
-
 
 ```golang
 package actions
@@ -637,7 +634,7 @@ func (*Transfer) GetTypeID() uint8 {
 We import the following into `transfer.go`:
 
 ```golang
-    mconsts "github.com/ava-labs/hypersdk/examples/tutorial/consts"  
+    mconsts "github.com/ava-labs/hypersdk/examples/tutorial/consts"
 ```
 
 ### `StateKeys()`
@@ -653,7 +650,6 @@ Beforehand, we need to import the `storage` package from earlier:
 ```golang
 	"github.com/ava-labs/hypersdk/examples/tutorial/storage"
 ```
-
 
 ```golang
 func (t *Transfer) StateKeys(actor codec.Address, _ ids.ID) state.Keys {
@@ -716,7 +712,7 @@ func (t *Transfer) Execute(
 
 The `ComputeUnits` function specifies how many units of computation are consumed
 by this action. The HyperSDK uses dynamic, multi-dimensional fees and specifies its
-own resource limits ie. units of compute, storage, and bandwidth. This means it's 
+own resource limits ie. units of compute, storage, and bandwidth. This means it's
 more important that `ComputeUnits` of different actions is proportional to the maximum,
 target, and the cost of other actions than it is to be exact. So, we'll simply return 1
 for `Transfer`.

--- a/examples/morpheusvm/consts/consts.go
+++ b/examples/morpheusvm/consts/consts.go
@@ -9,7 +9,6 @@ import (
 )
 
 const (
-	HRP      = "morpheus"
 	Name     = "morpheusvm"
 	Symbol   = "RED"
 	Decimals = 9

--- a/examples/morpheusvm/consts/consts.go
+++ b/examples/morpheusvm/consts/consts.go
@@ -9,9 +9,8 @@ import (
 )
 
 const (
-	Name     = "morpheusvm"
-	Symbol   = "RED"
-	Decimals = 9
+	Name   = "morpheusvm"
+	Symbol = "RED"
 )
 
 var ID ids.ID

--- a/x/contracts/vm/cmd/vmwithcontracts-cli/cmd/handler.go
+++ b/x/contracts/vm/cmd/vmwithcontracts-cli/cmd/handler.go
@@ -14,12 +14,12 @@ import (
 	"github.com/ava-labs/hypersdk/chain"
 	"github.com/ava-labs/hypersdk/cli"
 	"github.com/ava-labs/hypersdk/codec"
+	"github.com/ava-labs/hypersdk/consts"
 	"github.com/ava-labs/hypersdk/crypto/bls"
 	"github.com/ava-labs/hypersdk/crypto/ed25519"
 	"github.com/ava-labs/hypersdk/crypto/secp256r1"
 	"github.com/ava-labs/hypersdk/pubsub"
 	"github.com/ava-labs/hypersdk/utils"
-	"github.com/ava-labs/hypersdk/x/contracts/vm/consts"
 	"github.com/ava-labs/hypersdk/x/contracts/vm/vm"
 )
 

--- a/x/contracts/vm/cmd/vmwithcontracts-cli/cmd/handler.go
+++ b/x/contracts/vm/cmd/vmwithcontracts-cli/cmd/handler.go
@@ -14,13 +14,15 @@ import (
 	"github.com/ava-labs/hypersdk/chain"
 	"github.com/ava-labs/hypersdk/cli"
 	"github.com/ava-labs/hypersdk/codec"
-	"github.com/ava-labs/hypersdk/consts"
 	"github.com/ava-labs/hypersdk/crypto/bls"
 	"github.com/ava-labs/hypersdk/crypto/ed25519"
 	"github.com/ava-labs/hypersdk/crypto/secp256r1"
 	"github.com/ava-labs/hypersdk/pubsub"
 	"github.com/ava-labs/hypersdk/utils"
+	"github.com/ava-labs/hypersdk/x/contracts/vm/consts"
 	"github.com/ava-labs/hypersdk/x/contracts/vm/vm"
+
+	hconsts "github.com/ava-labs/hypersdk/consts"
 )
 
 var _ cli.Controller = (*Controller)(nil)
@@ -122,7 +124,7 @@ func (*Controller) Symbol() string {
 }
 
 func (*Controller) Decimals() uint8 {
-	return consts.Decimals
+	return hconsts.Decimals
 }
 
 func (*Controller) GetParser(uri string) (chain.Parser, error) {

--- a/x/contracts/vm/consts/consts.go
+++ b/x/contracts/vm/consts/consts.go
@@ -9,7 +9,6 @@ import (
 )
 
 const (
-	HRP      = "contracts"
 	Name     = "vmwithcontracts"
 	Symbol   = "RED"
 	Decimals = 9

--- a/x/contracts/vm/consts/consts.go
+++ b/x/contracts/vm/consts/consts.go
@@ -9,9 +9,8 @@ import (
 )
 
 const (
-	Name     = "vmwithcontracts"
-	Symbol   = "RED"
-	Decimals = 9
+	Name   = "vmwithcontracts"
+	Symbol = "RED"
 )
 
 var ID ids.ID


### PR DESCRIPTION
We are no longer using `HRP` prefixes since we moved away from Bech32 addresses

Also remove `Decimals` as that is a hypersdk const now