### PR TITLE
Refactor chain/vm: move execution off of StatefulBlock

### DIFF
--- a/chain/block.go
+++ b/chain/block.go
@@ -5,7 +5,6 @@ package chain
 
 import (
 	"context"
-	"encoding/binary"
 	"errors"
 	"fmt"
 	"time"
@@ -168,8 +167,9 @@ type StatefulBlock struct {
 	results    []*Result
 	feeManager *internalfees.Manager
 
-	vm   VM
-	view merkledb.View
+	vm       VM
+	executor *Executor
+	view     merkledb.View
 
 	sigJob workers.Job
 }
@@ -182,6 +182,7 @@ func NewBlock(vm VM, parent snowman.Block, tmstp int64) *StatefulBlock {
 			Hght:   parent.Height() + 1,
 		},
 		vm:       vm,
+		executor: NewExecutor(vm),
 		accepted: false,
 	}
 }
@@ -274,6 +275,7 @@ func ParseStatefulBlock(
 		bytes:          source,
 		accepted:       accepted,
 		vm:             vm,
+		executor:       NewExecutor(vm),
 		id:             utils.ToID(source),
 	}
 
@@ -377,36 +379,6 @@ func (b *StatefulBlock) Verify(ctx context.Context) error {
 	return nil
 }
 
-// verifyExpiryReplayProtection handles expiry replay protection
-//
-// Replay protection confirms a transaction has not been included within the
-// past validity window.
-// Before the node is ready (we have synced a validity window of blocks), this
-// function may return an error when other nodes see the block as valid.
-//
-// If a block is already accepted, its transactions have already been added
-// to the VM's seen emap and calling [IsRepeat] will return a non-zero value
-// when it should already be considered valid, so we skip this step here.
-func (b *StatefulBlock) verifyExpiryReplayProtection(ctx context.Context, rules Rules, vctx VerifyContext) error {
-	if b.accepted {
-		return nil
-	}
-
-	oldestAllowed := b.Tmstmp - rules.GetValidityWindow()
-	if oldestAllowed < 0 {
-		// Can occur if verifying genesis
-		oldestAllowed = 0
-	}
-	dup, err := vctx.IsRepeat(ctx, oldestAllowed, b.Txs, set.NewBits(), true)
-	if err != nil {
-		return err
-	}
-	if dup.Len() > 0 {
-		return fmt.Errorf("%w: duplicate in ancestry", ErrDuplicateTx)
-	}
-	return nil
-}
-
 // innerVerify executes the block
 //
 // Invariants:
@@ -419,169 +391,13 @@ func (b *StatefulBlock) verifyExpiryReplayProtection(ctx context.Context, rules 
 //  3. If the view of a block we are accepting is missing (finishing dynamic
 //     state sync)
 func (b *StatefulBlock) innerVerify(ctx context.Context) error {
-	var (
-		log = b.vm.Logger()
-		r   = b.vm.Rules(b.Tmstmp)
-	)
-
-	vctx, err := b.GetVerifyContext(ctx, b.Hght, b.Prnt)
+	results, feeManager, view, err := b.executor.Execute(ctx, b)
 	if err != nil {
-		return fmt.Errorf("%w: unable to get verify context", err)
-	}
-
-	// Perform basic correctness checks before doing any expensive work
-	if b.Timestamp().UnixMilli() > time.Now().Add(FutureBound).UnixMilli() {
-		return ErrTimestampTooLate
-	}
-
-	// Fetch view where we will apply block state transitions
-	//
-	// This call may result in our ancestry being verified.
-	parentView, err := vctx.View(ctx, true)
-	if err != nil {
-		return fmt.Errorf("%w: unable to load parent view", err)
-	}
-
-	// Fetch parent height key and ensure block height is valid
-	heightKey := HeightKey(b.vm.MetadataManager().HeightPrefix())
-	parentHeightRaw, err := parentView.GetValue(ctx, heightKey)
-	if err != nil {
-		return err
-	}
-	parentHeight, err := database.ParseUInt64(parentHeightRaw)
-	if err != nil {
-		return err
-	}
-	if b.Hght != parentHeight+1 {
-		return ErrInvalidBlockHeight
-	}
-
-	// Fetch parent timestamp and confirm block timestamp is valid
-	//
-	// Parent may not be available (if we preformed state sync), so we
-	// can't rely on being able to fetch it during verification.
-	timestampKey := TimestampKey(b.vm.MetadataManager().TimestampPrefix())
-	parentTimestampRaw, err := parentView.GetValue(ctx, timestampKey)
-	if err != nil {
-		return err
-	}
-	parentTimestampUint64, err := database.ParseUInt64(parentTimestampRaw)
-	if err != nil {
-		return err
-	}
-	parentTimestamp := int64(parentTimestampUint64)
-	if b.Tmstmp < parentTimestamp+r.GetMinBlockGap() {
-		return ErrTimestampTooEarly
-	}
-	if len(b.Txs) == 0 && b.Tmstmp < parentTimestamp+r.GetMinEmptyBlockGap() {
-		return ErrTimestampTooEarly
-	}
-
-	if err := b.verifyExpiryReplayProtection(ctx, r, vctx); err != nil {
-		return err
-	}
-
-	// Compute next unit prices to use
-	feeKey := FeeKey(b.vm.MetadataManager().FeePrefix())
-	feeRaw, err := parentView.GetValue(ctx, feeKey)
-	if err != nil {
-		return err
-	}
-	parentFeeManager := internalfees.NewManager(feeRaw)
-	feeManager, err := parentFeeManager.ComputeNext(b.Tmstmp, r)
-	if err != nil {
-		return err
-	}
-
-	// Process transactions
-	results, ts, err := b.Execute(ctx, b.vm.Tracer(), parentView, feeManager, r)
-	if err != nil {
-		log.Error("failed to execute block", zap.Error(err))
 		return err
 	}
 	b.results = results
 	b.feeManager = feeManager
-
-	// Update chain metadata
-	heightKeyStr := string(heightKey)
-	timestampKeyStr := string(timestampKey)
-	feeKeyStr := string(feeKey)
-
-	keys := make(state.Keys)
-	keys.Add(heightKeyStr, state.Write)
-	keys.Add(timestampKeyStr, state.Write)
-	keys.Add(feeKeyStr, state.Write)
-	tsv := ts.NewView(keys, map[string][]byte{
-		heightKeyStr:    parentHeightRaw,
-		timestampKeyStr: parentTimestampRaw,
-		feeKeyStr:       parentFeeManager.Bytes(),
-	})
-	if err := tsv.Insert(ctx, heightKey, binary.BigEndian.AppendUint64(nil, b.Hght)); err != nil {
-		return err
-	}
-	if err := tsv.Insert(ctx, timestampKey, binary.BigEndian.AppendUint64(nil, uint64(b.Tmstmp))); err != nil {
-		return err
-	}
-	if err := tsv.Insert(ctx, feeKey, feeManager.Bytes()); err != nil {
-		return err
-	}
-	tsv.Commit()
-
-	// Compare state root
-	//
-	// Because fee bytes are not recorded in state, it is sufficient to check the state root
-	// to verify all fee calculations were correct.
-	_, rspan := b.vm.Tracer().Start(ctx, "StatefulBlock.Verify.WaitRoot")
-	start := time.Now()
-	computedRoot, err := parentView.GetMerkleRoot(ctx)
-	rspan.End()
-	if err != nil {
-		return err
-	}
-	b.vm.RecordWaitRoot(time.Since(start))
-	if b.StateRoot != computedRoot {
-		return fmt.Errorf(
-			"%w: expected=%s found=%s",
-			ErrStateRootMismatch,
-			computedRoot,
-			b.StateRoot,
-		)
-	}
-
-	// Ensure signatures are verified
-	_, sspan := b.vm.Tracer().Start(ctx, "StatefulBlock.Verify.WaitSignatures")
-	start = time.Now()
-	err = b.sigJob.Wait()
-	sspan.End()
-	if err != nil {
-		return err
-	}
-	b.vm.RecordWaitSignatures(time.Since(start))
-
-	// Get view from [tstate] after processing all state transitions
-	b.vm.RecordStateChanges(ts.PendingChanges())
-	b.vm.RecordStateOperations(ts.OpIndex())
-	view, err := ts.ExportMerkleDBView(ctx, b.vm.Tracer(), parentView)
-	if err != nil {
-		return err
-	}
 	b.view = view
-
-	// Kickoff root generation
-	go func() {
-		start := time.Now()
-		root, err := view.GetMerkleRoot(ctx)
-		if err != nil {
-			log.Error("merkle root generation failed", zap.Error(err))
-			return
-		}
-		log.Info("merkle root generated",
-			zap.Uint64("height", b.Hght),
-			zap.Stringer("blkID", b.ID()),
-			zap.Stringer("root", root),
-		)
-		b.vm.RecordRootCalculated(time.Since(start))
-	}()
 	return nil
 }
 

--- a/chain/processor.go
+++ b/chain/processor.go
@@ -207,7 +207,7 @@ func (e *Executor) Execute(
 // If a block is already accepted, its transactions have already been added
 // to the VM's seen emap and calling [IsRepeat] will return a non-zero value
 // when it should already be considered valid, so we skip this step here.
-func (e *Executor) verifyExpiryReplayProtection(ctx context.Context, b *StatefulBlock, rules Rules, vctx VerifyContext) error {
+func (*Executor) verifyExpiryReplayProtection(ctx context.Context, b *StatefulBlock, rules Rules, vctx VerifyContext) error {
 	if b.accepted {
 		return nil
 	}

--- a/chain/processor.go
+++ b/chain/processor.go
@@ -5,9 +5,15 @@ package chain
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
+	"time"
 
+	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/trace"
+	"github.com/ava-labs/avalanchego/utils/set"
+	"github.com/ava-labs/avalanchego/x/merkledb"
+	"go.uber.org/zap"
 
 	"github.com/ava-labs/hypersdk/internal/executor"
 	"github.com/ava-labs/hypersdk/internal/fees"
@@ -16,6 +22,211 @@ import (
 	"github.com/ava-labs/hypersdk/state/tstate"
 )
 
+type Executor struct {
+	vm VM
+}
+
+func NewExecutor(vm VM) *Executor {
+	return &Executor{vm: vm}
+}
+
+func (e *Executor) Execute(
+	ctx context.Context,
+	b *StatefulBlock,
+) ([]*Result, *fees.Manager, merkledb.View, error) {
+	var (
+		log = e.vm.Logger()
+		r   = e.vm.Rules(b.Tmstmp)
+	)
+
+	vctx, err := b.GetVerifyContext(ctx, b.Hght, b.Prnt)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("%w: unable to get verify context", err)
+	}
+
+	// Perform basic correctness checks before doing any expensive work
+	if b.Timestamp().UnixMilli() > time.Now().Add(FutureBound).UnixMilli() {
+		return nil, nil, nil, ErrTimestampTooLate
+	}
+
+	// Fetch view where we will apply block state transitions
+	//
+	// This call may result in our ancestry being verified.
+	parentView, err := vctx.View(ctx, true)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("%w: unable to load parent view", err)
+	}
+
+	// Fetch parent height key and ensure block height is valid
+	heightKey := HeightKey(e.vm.MetadataManager().HeightPrefix())
+	parentHeightRaw, err := parentView.GetValue(ctx, heightKey)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	parentHeight, err := database.ParseUInt64(parentHeightRaw)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if b.Hght != parentHeight+1 {
+		return nil, nil, nil, ErrInvalidBlockHeight
+	}
+
+	// Fetch parent timestamp and confirm block timestamp is valid
+	//
+	// Parent may not be available (if we preformed state sync), so we
+	// can't rely on being able to fetch it during verification.
+	timestampKey := TimestampKey(e.vm.MetadataManager().TimestampPrefix())
+	parentTimestampRaw, err := parentView.GetValue(ctx, timestampKey)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	parentTimestampUint64, err := database.ParseUInt64(parentTimestampRaw)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	parentTimestamp := int64(parentTimestampUint64)
+	if b.Tmstmp < parentTimestamp+r.GetMinBlockGap() {
+		return nil, nil, nil, ErrTimestampTooEarly
+	}
+	if len(b.Txs) == 0 && b.Tmstmp < parentTimestamp+r.GetMinEmptyBlockGap() {
+		return nil, nil, nil, ErrTimestampTooEarly
+	}
+
+	if err := e.verifyExpiryReplayProtection(ctx, b, r, vctx); err != nil {
+		return nil, nil, nil, err
+	}
+
+	// Compute next unit prices to use
+	feeKey := FeeKey(e.vm.MetadataManager().FeePrefix())
+	feeRaw, err := parentView.GetValue(ctx, feeKey)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	parentFeeManager := fees.NewManager(feeRaw)
+	feeManager, err := parentFeeManager.ComputeNext(b.Tmstmp, r)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	// Process transactions
+	results, ts, err := e.ExecuteTxs(ctx, b, e.vm.Tracer(), parentView, feeManager, r)
+	if err != nil {
+		log.Error("failed to execute block", zap.Error(err))
+		return nil, nil, nil, err
+	}
+
+	// Update chain metadata
+	heightKeyStr := string(heightKey)
+	timestampKeyStr := string(timestampKey)
+	feeKeyStr := string(feeKey)
+
+	keys := make(state.Keys)
+	keys.Add(heightKeyStr, state.Write)
+	keys.Add(timestampKeyStr, state.Write)
+	keys.Add(feeKeyStr, state.Write)
+	tsv := ts.NewView(keys, map[string][]byte{
+		heightKeyStr:    parentHeightRaw,
+		timestampKeyStr: parentTimestampRaw,
+		feeKeyStr:       parentFeeManager.Bytes(),
+	})
+	if err := tsv.Insert(ctx, heightKey, binary.BigEndian.AppendUint64(nil, b.Hght)); err != nil {
+		return nil, nil, nil, err
+	}
+	if err := tsv.Insert(ctx, timestampKey, binary.BigEndian.AppendUint64(nil, uint64(b.Tmstmp))); err != nil {
+		return nil, nil, nil, err
+	}
+	if err := tsv.Insert(ctx, feeKey, feeManager.Bytes()); err != nil {
+		return nil, nil, nil, err
+	}
+	tsv.Commit()
+
+	// Compare state root
+	//
+	// Because fee bytes are not recorded in state, it is sufficient to check the state root
+	// to verify all fee calculations were correct.
+	_, rspan := e.vm.Tracer().Start(ctx, "StatefulBlock.Verify.WaitRoot")
+	start := time.Now()
+	computedRoot, err := parentView.GetMerkleRoot(ctx)
+	rspan.End()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	e.vm.RecordWaitRoot(time.Since(start))
+	if b.StateRoot != computedRoot {
+		return nil, nil, nil, fmt.Errorf(
+			"%w: expected=%s found=%s",
+			ErrStateRootMismatch,
+			computedRoot,
+			b.StateRoot,
+		)
+	}
+
+	// Ensure signatures are verified
+	_, sspan := e.vm.Tracer().Start(ctx, "StatefulBlock.Verify.WaitSignatures")
+	start = time.Now()
+	err = b.sigJob.Wait()
+	sspan.End()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	e.vm.RecordWaitSignatures(time.Since(start))
+
+	// Get view from [tstate] after processing all state transitions
+	e.vm.RecordStateChanges(ts.PendingChanges())
+	e.vm.RecordStateOperations(ts.OpIndex())
+	view, err := ts.ExportMerkleDBView(ctx, e.vm.Tracer(), parentView)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	// Kickoff root generation
+	go func() {
+		start := time.Now()
+		root, err := view.GetMerkleRoot(ctx)
+		if err != nil {
+			log.Error("merkle root generation failed", zap.Error(err))
+			return
+		}
+		log.Info("merkle root generated",
+			zap.Uint64("height", b.Hght),
+			zap.Stringer("blkID", b.ID()),
+			zap.Stringer("root", root),
+		)
+		e.vm.RecordRootCalculated(time.Since(start))
+	}()
+	return results, feeManager, view, nil
+}
+
+// verifyExpiryReplayProtection handles expiry replay protection
+//
+// Replay protection confirms a transaction has not been included within the
+// past validity window.
+// Before the node is ready (we have synced a validity window of blocks), this
+// function may return an error when other nodes see the block as valid.
+//
+// If a block is already accepted, its transactions have already been added
+// to the VM's seen emap and calling [IsRepeat] will return a non-zero value
+// when it should already be considered valid, so we skip this step here.
+func (e *Executor) verifyExpiryReplayProtection(ctx context.Context, b *StatefulBlock, rules Rules, vctx VerifyContext) error {
+	if b.accepted {
+		return nil
+	}
+
+	oldestAllowed := b.Tmstmp - rules.GetValidityWindow()
+	if oldestAllowed < 0 {
+		// Can occur if verifying genesis
+		oldestAllowed = 0
+	}
+	dup, err := vctx.IsRepeat(ctx, oldestAllowed, b.Txs, set.NewBits(), true)
+	if err != nil {
+		return err
+	}
+	if dup.Len() > 0 {
+		return fmt.Errorf("%w: duplicate in ancestry", ErrDuplicateTx)
+	}
+	return nil
+}
+
 type fetchData struct {
 	v      []byte
 	exists bool
@@ -23,8 +234,9 @@ type fetchData struct {
 	chunks uint16
 }
 
-func (b *StatefulBlock) Execute(
+func (e *Executor) ExecuteTxs(
 	ctx context.Context,
+	b *StatefulBlock,
 	tracer trace.Tracer, //nolint:interfacer
 	im state.Immutable,
 	feeManager *fees.Manager,
@@ -34,14 +246,14 @@ func (b *StatefulBlock) Execute(
 	defer span.End()
 
 	var (
-		bh     = b.vm.BalanceHandler()
+		bh     = e.vm.BalanceHandler()
 		numTxs = len(b.Txs)
 		t      = b.GetTimestamp()
 
-		f       = fetcher.New(im, numTxs, b.vm.GetStateFetchConcurrency())
-		e       = executor.New(numTxs, b.vm.GetTransactionExecutionCores(), MaxKeyDependencies, b.vm.GetExecutorVerifyRecorder())
-		ts      = tstate.New(numTxs * 2) // TODO: tune this heuristic
-		results = make([]*Result, numTxs)
+		f          = fetcher.New(im, numTxs, e.vm.GetStateFetchConcurrency())
+		txExecutor = executor.New(numTxs, e.vm.GetTransactionExecutionCores(), MaxKeyDependencies, e.vm.GetExecutorVerifyRecorder())
+		ts         = tstate.New(numTxs * 2) // TODO: tune this heuristic
+		results    = make([]*Result, numTxs)
 	)
 
 	// Fetch required keys and execute transactions
@@ -52,7 +264,7 @@ func (b *StatefulBlock) Execute(
 		stateKeys, err := tx.StateKeys(bh)
 		if err != nil {
 			f.Stop()
-			e.Stop()
+			txExecutor.Stop()
 			return nil, nil, err
 		}
 
@@ -60,12 +272,12 @@ func (b *StatefulBlock) Execute(
 		units, err := tx.Units(bh, r)
 		if err != nil {
 			f.Stop()
-			e.Stop()
+			txExecutor.Stop()
 			return nil, nil, err
 		}
 		if ok, d := feeManager.Consume(units, r.GetMaxBlockUnits()); !ok {
 			f.Stop()
-			e.Stop()
+			txExecutor.Stop()
 			return nil, nil, fmt.Errorf("%w: %d too large", ErrInvalidUnitsConsumed, d)
 		}
 
@@ -74,7 +286,7 @@ func (b *StatefulBlock) Execute(
 		if err := f.Fetch(ctx, txID, stateKeys); err != nil {
 			return nil, nil, err
 		}
-		e.Run(stateKeys, func() error {
+		txExecutor.Run(stateKeys, func() error {
 			// Wait for stateKeys to be read from disk
 			storage, err := f.Get(txID)
 			if err != nil {
@@ -106,7 +318,7 @@ func (b *StatefulBlock) Execute(
 	if err := f.Wait(); err != nil {
 		return nil, nil, err
 	}
-	if err := e.Wait(); err != nil {
+	if err := txExecutor.Wait(); err != nil {
 		return nil, nil, err
 	}
 


### PR DESCRIPTION
- move replay protection to its own function within block verification
- move `GetVerifyContext` into `innerVerify` (called in the identical way in three places)
- Move execution from `innerVerify` into `Executor`

This is a start in the direction of https://github.com/ava-labs/hypersdk/issues/1278#issuecomment-2449962374 to separate `StatefulBlock` from the `chain` package, so that it only deals with block parsing, building, and execution.