### PR TITLE
Remove errors from stateless block return types

### DIFF
--- a/chain/block.go
+++ b/chain/block.go
@@ -286,27 +286,6 @@ func ParseStatefulBlock(
 	return b, b.populateTxs(ctx)
 }
 
-// [initializeBuilt] is invoked after a block is built
-func (b *StatefulBlock) initializeBuilt(
-	ctx context.Context,
-	view merkledb.View,
-	results []*Result,
-	feeManager *internalfees.Manager,
-) error {
-	_, span := b.vm.Tracer().Start(ctx, "StatefulBlock.initializeBuilt")
-	defer span.End()
-
-	b.view = view
-	b.t = time.UnixMilli(b.StatelessBlock.Tmstmp)
-	b.results = results
-	b.feeManager = feeManager
-	b.txsSet = set.NewSet[ids.ID](len(b.Txs))
-	for _, tx := range b.Txs {
-		b.txsSet.Add(tx.ID())
-	}
-	return nil
-}
-
 // implements "snowman.Block.choices.Decidable"
 func (b *StatefulBlock) ID() ids.ID { return b.id }
 

--- a/chain/chaintest/block.go
+++ b/chain/chaintest/block.go
@@ -21,15 +21,16 @@ func GenerateEmptyExecutedBlocks(
 ) []*chain.ExecutedBlock {
 	executedBlocks := make([]*chain.ExecutedBlock, numBlocks)
 	for i := range executedBlocks {
-		statelessBlock := &chain.StatelessBlock{
-			Prnt:   parentID,
-			Tmstmp: parentTimestamp + timestampOffset*int64(i),
-			Hght:   parentHeight + 1 + uint64(i),
-			Txs:    []*chain.Transaction{},
-		}
-		blkID, err := statelessBlock.ID()
+		statelessBlock, err := chain.NewStatelessBlock(
+			parentID,
+			parentTimestamp+timestampOffset*int64(i),
+			parentHeight+1+uint64(i),
+			nil,
+			ids.Empty,
+		)
 		require.NoError(err)
-		parentID = blkID
+		require.NoError(err)
+		parentID = statelessBlock.ID()
 
 		blk, err := chain.NewExecutedBlock(
 			statelessBlock,

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -374,10 +374,13 @@ func (vm *VM) Initialize(
 		snowCtx.Log.Info("genesis state created", zap.Stringer("root", root))
 
 		// Create genesis block
+		statelessGenesisBlock, err := chain.NewGenesisBlock(root)
+		if err != nil {
+			return err
+		}
 		genesisBlk, err := chain.ParseStatefulBlock(
 			ctx,
-			chain.NewGenesisBlock(root),
-			nil,
+			statelessGenesisBlock,
 			true,
 			vm,
 		)

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -26,11 +26,16 @@ func TestBlockCache(t *testing.T) {
 	require := require.New(t)
 
 	// create a block with "Unknown" status
+	block, err := chain.NewStatelessBlock(
+		ids.GenerateTestID(),
+		0,
+		10_000,
+		nil,
+		ids.Empty,
+	)
+	require.NoError(err)
 	blk := &chain.StatefulBlock{
-		StatelessBlock: &chain.StatelessBlock{
-			Prnt: ids.GenerateTestID(),
-			Hght: 10000,
-		},
+		StatelessBlock: block,
 	}
 	blkID := blk.ID()
 


### PR DESCRIPTION
This PR updates `StatelessBlock` to remove error from the return type of `ID()` and `Marshal` in favor of initializing the `id` and `bytes` when constructing the block in the first place.