### PR TITLE
extend the timeout for transfer test

### DIFF
--- a/examples/morpheusvm/tests/transfer.go
+++ b/examples/morpheusvm/tests/transfer.go
@@ -42,7 +42,7 @@ var _ = registry.Register(TestsRegistry, "Transfer Transaction", func(t ginkgo.F
 	)
 	require.NoError(err)
 
-	timeoutCtx, timeoutCtxFnc := context.WithDeadline(context.Background(), time.Now().Add(2*time.Second))
+	timeoutCtx, timeoutCtxFnc := context.WithDeadline(context.Background(), time.Now().Add(30*time.Second))
 	defer timeoutCtxFnc()
 
 	require.NoError(tn.ConfirmTxs(timeoutCtx, []*chain.Transaction{tx}))


### PR DESCRIPTION
## What ? 

extend the timeout for transfer test so that it would work in CI e2e tests.

## Why ? 

It seems that CI have a lower performance compared to local run, resulting in a longer time for transaction to settle.