### PR TITLE
Create linker on runtime creation

### DIFF
--- a/x/contracts/runtime/runtime_test.go
+++ b/x/contracts/runtime/runtime_test.go
@@ -119,7 +119,7 @@ func BenchmarkRuntimeInstance(b *testing.B) {
 	require.NoError(err)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		inst, err := rt.callContext.r.getInstance(module, rt.callContext.r.hostImports)
+		inst, err := rt.callContext.r.getInstance(module)
 		require.NoError(err)
 		_ = inst
 
@@ -160,7 +160,7 @@ func BenchmarkRuntimeInstanceCall(b *testing.B) {
 
 	module, err := rt.callContext.r.getModule(ctx, newInfo, programID)
 	require.NoError(err)
-	inst, err := rt.callContext.r.getInstance(module, rt.callContext.r.hostImports)
+	inst, err := rt.callContext.r.getInstance(module)
 	require.NoError(err)
 	b.ResetTimer()
 	newInfo.inst = inst
@@ -176,7 +176,7 @@ func BenchmarkRuntimeInstanceCall(b *testing.B) {
 		// reset module
 		module, err = rt.callContext.r.getModule(ctx, newInfo, programID)
 		require.NoError(err)
-		inst, err = rt.callContext.r.getInstance(module, rt.callContext.r.hostImports)
+		inst, err = rt.callContext.r.getInstance(module)
 		require.NoError(err)
 		newInfo.inst = inst
 		b.StartTimer()

--- a/x/contracts/runtime/util_test.go
+++ b/x/contracts/runtime/util_test.go
@@ -198,11 +198,13 @@ func (t *testRuntime) CallContract(contract codec.Address, function string, para
 }
 
 func newTestRuntime(ctx context.Context) *testRuntime {
+	callContext := NewRuntime(
+		NewConfig(),
+		logging.NoLog{}).WithDefaults(CallInfo{Fuel: 1000000000})
+
 	return &testRuntime{
-		Context: ctx,
-		callContext: NewRuntime(
-			NewConfig(),
-			logging.NoLog{}).WithDefaults(CallInfo{Fuel: 1000000000}),
+		Context:     ctx,
+		callContext: callContext,
 		StateManager: TestStateManager{
 			ContractManager: NewContractStateManager(test.NewTestDB(), []byte{}),
 			Balances:        map[codec.Address]uint64{},


### PR DESCRIPTION
I'm not sure why we were lazy-loading/creating the linker in the first place. This is something that should remain static for the lifetime of the runtime

