### PR TITLE
Enforce Contract in `AddBalance`

### DIFF
--- a/chain/dependencies.go
+++ b/chain/dependencies.go
@@ -171,7 +171,7 @@ type BalanceHandler interface {
 	Deduct(ctx context.Context, addr codec.Address, mu state.Mutable, amount uint64) error
 
 	// AddBalance adds [amount] to [addr].
-	// If [addr] doesn not exist and [createAccount] is false, this should return an error.
+	// If [addr] does not exist and [createAccount] is false, this should return an error.
 	AddBalance(ctx context.Context, addr codec.Address, mu state.Mutable, amount uint64, createAccount bool) error
 
 	// GetBalance returns the balance of [addr].

--- a/chain/dependencies.go
+++ b/chain/dependencies.go
@@ -171,6 +171,7 @@ type BalanceHandler interface {
 	Deduct(ctx context.Context, addr codec.Address, mu state.Mutable, amount uint64) error
 
 	// AddBalance adds [amount] to [addr].
+	// If [addr] doesn not exist and [createAccount] is false, this should return an error.
 	AddBalance(ctx context.Context, addr codec.Address, mu state.Mutable, amount uint64, createAccount bool) error
 
 	// GetBalance returns the balance of [addr].

--- a/examples/morpheusvm/storage/storage.go
+++ b/examples/morpheusvm/storage/storage.go
@@ -124,7 +124,7 @@ func AddBalance(
 	// Don't add balance if account doesn't exist. This
 	// can be useful when processing fee refunds.
 	if !exists && !create {
-		return 0, nil
+		return 0, ErrInvalidAddress
 	}
 	nbal, err := smath.Add(bal, amount)
 	if err != nil {


### PR DESCRIPTION
This PR updates `AddBalance()` in MorpheusVM so that, if an account doesn't exist and if it wasn't given permission to create an account, that it returns an error. This PR also updates the documentation of `AddBalance()` to make it explicit that if the account doesn't exist and `createAccount = false`, it should return an error.