### PR TITLE
Remove `createAccount` parameter

### DIFF
--- a/chain/dependencies.go
+++ b/chain/dependencies.go
@@ -171,7 +171,7 @@ type BalanceHandler interface {
 	Deduct(ctx context.Context, addr codec.Address, mu state.Mutable, amount uint64) error
 
 	// AddBalance adds [amount] to [addr].
-	AddBalance(ctx context.Context, addr codec.Address, mu state.Mutable, amount uint64, createAccount bool) error
+	AddBalance(ctx context.Context, addr codec.Address, mu state.Mutable, amount uint64) error
 
 	// GetBalance returns the balance of [addr].
 	// If [addr] does not exist, this should return 0 and no error.

--- a/examples/morpheusvm/actions/transfer.go
+++ b/examples/morpheusvm/actions/transfer.go
@@ -68,7 +68,7 @@ func (t *Transfer) Execute(
 	if err != nil {
 		return nil, err
 	}
-	receiverBalance, err := storage.AddBalance(ctx, mu, t.To, t.Value, true)
+	receiverBalance, err := storage.AddBalance(ctx, mu, t.To, t.Value)
 	if err != nil {
 		return nil, err
 	}

--- a/examples/morpheusvm/actions/transfer_test.go
+++ b/examples/morpheusvm/actions/transfer_test.go
@@ -55,7 +55,6 @@ func TestTransferAction(t *testing.T) {
 					s,
 					codec.EmptyAddress,
 					0,
-					true,
 				)
 				require.NoError(t, err)
 				return s

--- a/examples/morpheusvm/storage/state_manager.go
+++ b/examples/morpheusvm/storage/state_manager.go
@@ -52,9 +52,8 @@ func (*BalanceHandler) AddBalance(
 	addr codec.Address,
 	mu state.Mutable,
 	amount uint64,
-	createAccount bool,
 ) error {
-	_, err := AddBalance(ctx, mu, addr, amount, createAccount)
+	_, err := AddBalance(ctx, mu, addr, amount)
 	return err
 }
 

--- a/examples/morpheusvm/storage/storage.go
+++ b/examples/morpheusvm/storage/storage.go
@@ -115,16 +115,10 @@ func AddBalance(
 	mu state.Mutable,
 	addr codec.Address,
 	amount uint64,
-	create bool,
 ) (uint64, error) {
-	key, bal, exists, err := getBalance(ctx, mu, addr)
+	key, bal, _, err := getBalance(ctx, mu, addr)
 	if err != nil {
 		return 0, err
-	}
-	// Don't add balance if account doesn't exist. This
-	// can be useful when processing fee refunds.
-	if !exists && !create {
-		return 0, nil
 	}
 	nbal, err := smath.Add(bal, amount)
 	if err != nil {

--- a/genesis/genesis.go
+++ b/genesis/genesis.go
@@ -69,7 +69,7 @@ func (g *DefaultGenesis) InitializeState(ctx context.Context, tracer trace.Trace
 		if err != nil {
 			return err
 		}
-		if err := balanceHandler.AddBalance(ctx, alloc.Address, mu, alloc.Balance, true); err != nil {
+		if err := balanceHandler.AddBalance(ctx, alloc.Address, mu, alloc.Balance); err != nil {
 			return fmt.Errorf("%w: addr=%s, bal=%d", err, alloc.Address, alloc.Balance)
 		}
 	}


### PR DESCRIPTION
This PR removes the `createAccount` parameter from `AddBalance` in `BalanceHandler`. This PR also updates both the `DefaultGenesis` and MorpheusVM to reflect the change.