### PR TITLE
Refactor api vm options

### DIFF
--- a/api/dependencies.go
+++ b/api/dependencies.go
@@ -19,7 +19,7 @@ import (
 )
 
 type VM interface {
-	GetDataDir() string
+	GetDataDir(namespace string) string
 	GetGenesisBytes() []byte
 	Genesis() genesis.Genesis
 	ChainID() ids.ID

--- a/api/indexer/option.go
+++ b/api/indexer/option.go
@@ -7,7 +7,6 @@ import (
 	"github.com/ava-labs/hypersdk/api"
 	"github.com/ava-labs/hypersdk/chain"
 	"github.com/ava-labs/hypersdk/event"
-	"github.com/ava-labs/hypersdk/vm"
 )
 
 const (
@@ -29,13 +28,13 @@ func NewDefaultConfig() Config {
 	}
 }
 
-func With() vm.Option {
-	return vm.NewOption(Namespace, NewDefaultConfig(), OptionFunc)
+func With() api.Option {
+	return api.NewOption(Namespace, NewDefaultConfig(), OptionFunc)
 }
 
-func OptionFunc(v api.VM, config Config) (vm.Opt, error) {
+func OptionFunc(v api.VM, config Config) (api.Opt, error) {
 	if !config.Enabled {
-		return vm.NewOpt(), nil
+		return api.NewOpt(), nil
 	}
 	indexer, err := NewIndexer(v.GetDataDir(Namespace), v, config.BlockWindow)
 	if err != nil {
@@ -52,9 +51,9 @@ func OptionFunc(v api.VM, config Config) (vm.Opt, error) {
 		indexer: indexer,
 	}
 
-	return vm.NewOpt(
-		vm.WithBlockSubscriptions(subscriptionFactory),
-		vm.WithVMAPIs(apiFactory),
+	return api.NewOpt(
+		api.WithBlockSubscriptions(subscriptionFactory),
+		api.WithVMAPIs(apiFactory),
 	), nil
 }
 

--- a/api/indexer/option.go
+++ b/api/indexer/option.go
@@ -4,8 +4,6 @@
 package indexer
 
 import (
-	"path/filepath"
-
 	"github.com/ava-labs/hypersdk/api"
 	"github.com/ava-labs/hypersdk/chain"
 	"github.com/ava-labs/hypersdk/event"
@@ -39,8 +37,7 @@ func OptionFunc(v api.VM, config Config) (vm.Opt, error) {
 	if !config.Enabled {
 		return vm.NewOpt(), nil
 	}
-	indexerPath := filepath.Join(v.GetDataDir(), Namespace)
-	indexer, err := NewIndexer(indexerPath, v, config.BlockWindow)
+	indexer, err := NewIndexer(v.GetDataDir(Namespace), v, config.BlockWindow)
 	if err != nil {
 		return nil, err
 	}

--- a/api/jsonrpc/option.go
+++ b/api/jsonrpc/option.go
@@ -5,7 +5,6 @@ package jsonrpc
 
 import (
 	"github.com/ava-labs/hypersdk/api"
-	"github.com/ava-labs/hypersdk/vm"
 )
 
 const Namespace = "core"
@@ -20,11 +19,11 @@ func NewDefaultConfig() Config {
 	}
 }
 
-func With() vm.Option {
-	return vm.NewOption(Namespace, NewDefaultConfig(), func(_ api.VM, config Config) (vm.Opt, error) {
+func With() api.Option {
+	return api.NewOption(Namespace, NewDefaultConfig(), func(_ api.VM, config Config) (api.Opt, error) {
 		if !config.Enabled {
-			return vm.NewOpt(), nil
+			return api.NewOpt(), nil
 		}
-		return vm.WithVMAPIs(JSONRPCServerFactory{}), nil
+		return api.WithVMAPIs(JSONRPCServerFactory{}), nil
 	})
 }

--- a/api/option.go
+++ b/api/option.go
@@ -1,38 +1,37 @@
 // Copyright (C) 2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-package vm
+package api
 
 import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/ava-labs/hypersdk/api"
 	"github.com/ava-labs/hypersdk/chain"
 	"github.com/ava-labs/hypersdk/event"
 )
 
 type Options struct {
-	builder                        bool
-	gossiper                       bool
-	blockSubscriptionFactories     []event.SubscriptionFactory[*chain.ExecutedBlock]
-	vmAPIHandlerFactories          []api.HandlerFactory[api.VM]
-	txRemovedSubscriptionFactories []event.SubscriptionFactory[TxRemovedEvent]
+	Builder                        bool
+	Gossiper                       bool
+	BlockSubscriptionFactories     []event.SubscriptionFactory[*chain.ExecutedBlock]
+	VMAPIHandlerFactories          []HandlerFactory[VM]
+	TxRemovedSubscriptionFactories []event.SubscriptionFactory[TxRemovedEvent]
 }
 
-type optionFunc func(vm api.VM, configBytes []byte) (Opt, error)
+type optionFunc func(vm VM, configBytes []byte) (Opt, error)
 
-type OptionFunc[T any] func(vm api.VM, config T) (Opt, error)
+type OptionFunc[T any] func(vm VM, config T) (Opt, error)
 
 type Option struct {
 	Namespace  string
-	optionFunc optionFunc
+	OptionFunc optionFunc
 }
 
 func newOptionWithBytes(namespace string, optionFunc optionFunc) Option {
 	return Option{
 		Namespace:  namespace,
-		optionFunc: optionFunc,
+		OptionFunc: optionFunc,
 	}
 }
 
@@ -42,7 +41,7 @@ func newOptionWithBytes(namespace string, optionFunc optionFunc) Option {
 // 3) An option function that takes the VM and resulting config value as arguments
 func NewOption[T any](namespace string, defaultConfig T, optionFunc OptionFunc[T]) Option {
 	config := defaultConfig
-	configOptionFunc := func(vm api.VM, configBytes []byte) (Opt, error) {
+	configOptionFunc := func(vm VM, configBytes []byte) (Opt, error) {
 		if len(configBytes) > 0 {
 			if err := json.Unmarshal(configBytes, &config); err != nil {
 				return nil, fmt.Errorf("failed to unmarshal %q config %q: %w", namespace, string(configBytes), err)
@@ -56,13 +55,13 @@ func NewOption[T any](namespace string, defaultConfig T, optionFunc OptionFunc[T
 
 func WithBuilder() Opt {
 	return newFuncOption(func(o *Options) {
-		o.builder = true
+		o.Builder = true
 	})
 }
 
 func WithGossiper() Opt {
 	return newFuncOption(func(o *Options) {
-		o.gossiper = true
+		o.Gossiper = true
 	})
 }
 
@@ -70,10 +69,10 @@ func WithManual() Option {
 	return NewOption[struct{}](
 		"manual",
 		struct{}{},
-		func(_ api.VM, _ struct{}) (Opt, error) {
+		func(_ VM, _ struct{}) (Opt, error) {
 			return newFuncOption(func(o *Options) {
-				WithBuilder().apply(o)
-				WithGossiper().apply(o)
+				WithBuilder().Apply(o)
+				WithGossiper().Apply(o)
 			}), nil
 		},
 	)
@@ -81,31 +80,31 @@ func WithManual() Option {
 
 func WithBlockSubscriptions(subscriptions ...event.SubscriptionFactory[*chain.ExecutedBlock]) Opt {
 	return newFuncOption(func(o *Options) {
-		o.blockSubscriptionFactories = append(o.blockSubscriptionFactories, subscriptions...)
+		o.BlockSubscriptionFactories = append(o.BlockSubscriptionFactories, subscriptions...)
 	})
 }
 
-func WithVMAPIs(apiHandlerFactories ...api.HandlerFactory[api.VM]) Opt {
+func WithVMAPIs(apiHandlerFactories ...HandlerFactory[VM]) Opt {
 	return newFuncOption(func(o *Options) {
-		o.vmAPIHandlerFactories = append(o.vmAPIHandlerFactories, apiHandlerFactories...)
+		o.VMAPIHandlerFactories = append(o.VMAPIHandlerFactories, apiHandlerFactories...)
 	})
 }
 
 func WithTxRemovedSubscriptions(subscriptions ...event.SubscriptionFactory[TxRemovedEvent]) Opt {
 	return newFuncOption(func(o *Options) {
-		o.txRemovedSubscriptionFactories = append(o.txRemovedSubscriptionFactories, subscriptions...)
+		o.TxRemovedSubscriptionFactories = append(o.TxRemovedSubscriptionFactories, subscriptions...)
 	})
 }
 
 type Opt interface {
-	apply(*Options)
+	Apply(*Options)
 }
 
 // NewOpt mixes a list of Opt in a new one Opt.
 func NewOpt(opts ...Opt) Opt {
 	return newFuncOption(func(o *Options) {
 		for _, opt := range opts {
-			opt.apply(o)
+			opt.Apply(o)
 		}
 	})
 }
@@ -114,7 +113,7 @@ type funcOption struct {
 	f func(*Options)
 }
 
-func (fdo *funcOption) apply(do *Options) {
+func (fdo *funcOption) Apply(do *Options) {
 	fdo.f(do)
 }
 

--- a/api/option.go
+++ b/api/option.go
@@ -53,13 +53,13 @@ func NewOption[T any](namespace string, defaultConfig T, optionFunc OptionFunc[T
 	return newOptionWithBytes(namespace, configOptionFunc)
 }
 
-func WithBuilder() Opt {
+func withBuilder() Opt {
 	return newFuncOption(func(o *Options) {
 		o.Builder = true
 	})
 }
 
-func WithGossiper() Opt {
+func withGossiper() Opt {
 	return newFuncOption(func(o *Options) {
 		o.Gossiper = true
 	})
@@ -71,8 +71,8 @@ func WithManual() Option {
 		struct{}{},
 		func(_ VM, _ struct{}) (Opt, error) {
 			return newFuncOption(func(o *Options) {
-				WithBuilder().Apply(o)
-				WithGossiper().Apply(o)
+				withBuilder().Apply(o)
+				withGossiper().Apply(o)
 			}), nil
 		},
 	)

--- a/api/state/option.go
+++ b/api/state/option.go
@@ -5,7 +5,6 @@ package state
 
 import (
 	"github.com/ava-labs/hypersdk/api"
-	"github.com/ava-labs/hypersdk/vm"
 )
 
 const Namespace = "corestate"
@@ -20,11 +19,11 @@ func NewDefaultConfig() Config {
 	}
 }
 
-func With() vm.Option {
-	return vm.NewOption(Namespace, NewDefaultConfig(), func(_ api.VM, config Config) (vm.Opt, error) {
+func With() api.Option {
+	return api.NewOption(Namespace, NewDefaultConfig(), func(_ api.VM, config Config) (api.Opt, error) {
 		if !config.Enabled {
-			return vm.NewOpt(), nil
+			return api.NewOpt(), nil
 		}
-		return vm.WithVMAPIs(JSONRPCStateServerFactory{}), nil
+		return api.WithVMAPIs(JSONRPCStateServerFactory{}), nil
 	})
 }

--- a/api/utils.go
+++ b/api/utils.go
@@ -6,6 +6,7 @@ package api
 import (
 	"net/http"
 
+	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/json"
 	"github.com/gorilla/rpc/v2"
 )
@@ -18,4 +19,9 @@ func NewJSONRPCHandler(
 	server.RegisterCodec(json.NewCodec(), "application/json")
 	server.RegisterCodec(json.NewCodec(), "application/json;charset=UTF-8")
 	return server, server.RegisterService(service, name)
+}
+
+type TxRemovedEvent struct {
+	TxID ids.ID
+	Err  error
 }

--- a/api/ws/server.go
+++ b/api/ws/server.go
@@ -20,7 +20,6 @@ import (
 	"github.com/ava-labs/hypersdk/event"
 	"github.com/ava-labs/hypersdk/internal/emap"
 	"github.com/ava-labs/hypersdk/pubsub"
-	"github.com/ava-labs/hypersdk/vm"
 )
 
 const (
@@ -46,13 +45,13 @@ func NewDefaultConfig() Config {
 	}
 }
 
-func With() vm.Option {
-	return vm.NewOption(Namespace, NewDefaultConfig(), OptionFunc)
+func With() api.Option {
+	return api.NewOption(Namespace, NewDefaultConfig(), OptionFunc)
 }
 
-func OptionFunc(v api.VM, config Config) (vm.Opt, error) {
+func OptionFunc(v api.VM, config Config) (api.Opt, error) {
 	if !config.Enabled {
-		return vm.NewOpt(), nil
+		return api.NewOpt(), nil
 	}
 
 	actionCodec, authCodec := v.ActionCodec(), v.AuthCodec()
@@ -66,8 +65,8 @@ func OptionFunc(v api.VM, config Config) (vm.Opt, error) {
 	)
 
 	webSocketFactory := NewWebSocketServerFactory(handler)
-	txRemovedSubscription := event.SubscriptionFuncFactory[vm.TxRemovedEvent]{
-		AcceptF: func(event vm.TxRemovedEvent) error {
+	txRemovedSubscription := event.SubscriptionFuncFactory[api.TxRemovedEvent]{
+		AcceptF: func(event api.TxRemovedEvent) error {
 			return server.RemoveTx(event.TxID, event.Err)
 		},
 	}
@@ -78,10 +77,10 @@ func OptionFunc(v api.VM, config Config) (vm.Opt, error) {
 		},
 	}
 
-	return vm.NewOpt(
-		vm.WithBlockSubscriptions(blockSubscription),
-		vm.WithTxRemovedSubscriptions(txRemovedSubscription),
-		vm.WithVMAPIs(webSocketFactory),
+	return api.NewOpt(
+		api.WithBlockSubscriptions(blockSubscription),
+		api.WithTxRemovedSubscriptions(txRemovedSubscription),
+		api.WithVMAPIs(webSocketFactory),
 	), nil
 }
 

--- a/docs/tutorials/morpheusvm/options.md
+++ b/docs/tutorials/morpheusvm/options.md
@@ -322,12 +322,12 @@ VM or not. Finally, we implement a `NewDefaultConfig()` function which returns a
 default config. We now implement the option itself:
 
 ```golang
-func With() vm.Option {
-	return vm.NewOption(Namespace, NewDefaultConfig(), func(v *vm.VM, config Config) error {
+func With() api.Option {
+	return api.NewOption(Namespace, NewDefaultConfig(), func(v *api.VM, config Config) error {
 		if !config.Enabled {
 			return nil
 		}
-		vm.WithVMAPIs(jsonRPCServerFactory{})(v)
+		api.WithVMAPIs(jsonRPCServerFactory{})(v)
 		return nil
 	})
 }

--- a/examples/morpheusvm/vm/option.go
+++ b/examples/morpheusvm/vm/option.go
@@ -5,7 +5,6 @@ package vm
 
 import (
 	"github.com/ava-labs/hypersdk/api"
-	"github.com/ava-labs/hypersdk/vm"
 )
 
 const Namespace = "controller"
@@ -20,11 +19,11 @@ func NewDefaultConfig() Config {
 	}
 }
 
-func With() vm.Option {
-	return vm.NewOption(Namespace, NewDefaultConfig(), func(v api.VM, config Config) (vm.Opt, error) {
+func With() api.Option {
+	return api.NewOption(Namespace, NewDefaultConfig(), func(v api.VM, config Config) (api.Opt, error) {
 		if !config.Enabled {
-			return vm.NewOpt(), nil
+			return api.NewOpt(), nil
 		}
-		return vm.WithVMAPIs(jsonRPCServerFactory{}), nil
+		return api.WithVMAPIs(jsonRPCServerFactory{}), nil
 	})
 }

--- a/examples/morpheusvm/vm/vm.go
+++ b/examples/morpheusvm/vm/vm.go
@@ -6,6 +6,7 @@ package vm
 import (
 	"github.com/ava-labs/avalanchego/utils/wrappers"
 
+	"github.com/ava-labs/hypersdk/api"
 	"github.com/ava-labs/hypersdk/auth"
 	"github.com/ava-labs/hypersdk/chain"
 	"github.com/ava-labs/hypersdk/codec"
@@ -56,7 +57,7 @@ func init() {
 }
 
 // NewWithOptions returns a VM with the specified options
-func New(options ...vm.Option) (*vm.VM, error) {
+func New(options ...api.Option) (*vm.VM, error) {
 	options = append(options, With()) // Add MorpheusVM API
 	return defaultvm.New(
 		consts.Version,

--- a/extension/externalsubscriber/option.go
+++ b/extension/externalsubscriber/option.go
@@ -9,7 +9,6 @@ import (
 	"github.com/ava-labs/hypersdk/api"
 	"github.com/ava-labs/hypersdk/chain"
 	"github.com/ava-labs/hypersdk/event"
-	"github.com/ava-labs/hypersdk/vm"
 )
 
 const (
@@ -25,13 +24,13 @@ func NewDefaultConfig() Config {
 	return Config{}
 }
 
-func With() vm.Option {
-	return vm.NewOption(Namespace, NewDefaultConfig(), OptionFunc)
+func With() api.Option {
+	return api.NewOption(Namespace, NewDefaultConfig(), OptionFunc)
 }
 
-func OptionFunc(v api.VM, config Config) (vm.Opt, error) {
+func OptionFunc(v api.VM, config Config) (api.Opt, error) {
 	if !config.Enabled {
-		return vm.NewOpt(), nil
+		return api.NewOpt(), nil
 	}
 	server, err := NewExternalSubscriberClient(
 		context.TODO(),
@@ -49,5 +48,5 @@ func OptionFunc(v api.VM, config Config) (vm.Opt, error) {
 		},
 	}
 
-	return vm.WithBlockSubscriptions(blockSubscription), nil
+	return api.WithBlockSubscriptions(blockSubscription), nil
 }

--- a/tests/integration/integration.go
+++ b/tests/integration/integration.go
@@ -27,6 +27,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/ava-labs/hypersdk/abi"
+	"github.com/ava-labs/hypersdk/api"
 	"github.com/ava-labs/hypersdk/api/jsonrpc"
 	"github.com/ava-labs/hypersdk/api/ws"
 	"github.com/ava-labs/hypersdk/chain"
@@ -65,7 +66,7 @@ var (
 	networkID uint32
 
 	// Injected values populated by Setup
-	createVM      func(...vm.Option) (*vm.VM, error)
+	createVM      func(...api.Option) (*vm.VM, error)
 	networkConfig workload.TestNetworkConfiguration
 	vmID          ids.ID
 
@@ -99,7 +100,7 @@ func init() {
 }
 
 func Setup(
-	newVM func(...vm.Option) (*vm.VM, error),
+	newVM func(...api.Option) (*vm.VM, error),
 	networkConfigImpl workload.TestNetworkConfiguration,
 	id ids.ID,
 	generator workload.TxGenerator,
@@ -210,7 +211,7 @@ func setInstances() {
 		db := memdb.New()
 
 		v, err := createVM(
-			vm.WithManual(),
+			api.WithManual(),
 		)
 		require.NoError(err)
 		require.NoError(v.Initialize(

--- a/vm/defaultvm/vm.go
+++ b/vm/defaultvm/vm.go
@@ -6,6 +6,7 @@ package defaultvm
 import (
 	"github.com/ava-labs/avalanchego/version"
 
+	"github.com/ava-labs/hypersdk/api"
 	"github.com/ava-labs/hypersdk/api/indexer"
 	"github.com/ava-labs/hypersdk/api/jsonrpc"
 	"github.com/ava-labs/hypersdk/api/ws"
@@ -21,8 +22,8 @@ import (
 // DefaultOptions provides the default set of options to include
 // when constructing a new VM including the indexer, websocket,
 // JSONRPC, and external subscriber options.
-func NewDefaultOptions() []vm.Option {
-	return []vm.Option{
+func NewDefaultOptions() []api.Option {
+	return []api.Option{
 		indexer.With(),
 		ws.With(),
 		jsonrpc.With(),
@@ -41,7 +42,7 @@ func New(
 	authCodec *codec.TypeParser[chain.Auth],
 	outputCodec *codec.TypeParser[codec.Typed],
 	authEngine map[uint8]vm.AuthEngine,
-	options ...vm.Option,
+	options ...api.Option,
 ) (*vm.VM, error) {
 	options = append(options, NewDefaultOptions()...)
 	return vm.New(

--- a/vm/dependencies.go
+++ b/vm/dependencies.go
@@ -4,17 +4,10 @@
 package vm
 
 import (
-	"github.com/ava-labs/avalanchego/ids"
-
 	"github.com/ava-labs/hypersdk/chain"
 )
 
 type AuthEngine interface {
 	GetBatchVerifier(cores int, count int) chain.AuthBatchVerifier
 	Cache(auth chain.Auth)
-}
-
-type TxRemovedEvent struct {
-	TxID ids.ID
-	Err  error
 }

--- a/vm/resolutions.go
+++ b/vm/resolutions.go
@@ -5,6 +5,7 @@ package vm
 
 import (
 	"context"
+	"path/filepath"
 	"time"
 
 	"github.com/ava-labs/avalanchego/ids"
@@ -495,8 +496,8 @@ func (vm *VM) GetExecutorVerifyRecorder() executor.Metrics {
 	return vm.metrics.executorVerifyRecorder
 }
 
-func (vm *VM) GetDataDir() string {
-	return vm.DataDir
+func (vm *VM) GetDataDir(namespace string) string {
+	return filepath.Join(vm.DataDir, namespace)
 }
 
 func (vm *VM) GetGenesisBytes() []byte {

--- a/x/contracts/vm/vm/option.go
+++ b/x/contracts/vm/vm/option.go
@@ -5,7 +5,6 @@ package vm
 
 import (
 	"github.com/ava-labs/hypersdk/api"
-	"github.com/ava-labs/hypersdk/vm"
 	"github.com/ava-labs/hypersdk/x/contracts/runtime"
 )
 
@@ -21,18 +20,18 @@ func NewDefaultConfig() Config {
 	}
 }
 
-func With() vm.Option {
-	return vm.NewOption(Namespace, NewDefaultConfig(), func(_ api.VM, config Config) (vm.Opt, error) {
+func With() api.Option {
+	return api.NewOption(Namespace, NewDefaultConfig(), func(_ api.VM, config Config) (api.Opt, error) {
 		if !config.Enabled {
-			return vm.NewOpt(), nil
+			return api.NewOpt(), nil
 		}
-		return vm.WithVMAPIs(jsonRPCServerFactory{}), nil
+		return api.WithVMAPIs(jsonRPCServerFactory{}), nil
 	})
 }
 
-func WithRuntime() vm.Option {
-	return vm.NewOption(Namespace+"runtime", *runtime.NewConfig(), func(v api.VM, cfg runtime.Config) (vm.Opt, error) {
+func WithRuntime() api.Option {
+	return api.NewOption(Namespace+"runtime", *runtime.NewConfig(), func(v api.VM, cfg runtime.Config) (api.Opt, error) {
 		wasmRuntime = runtime.NewRuntime(&cfg, v.Logger())
-		return vm.NewOpt(), nil
+		return api.NewOpt(), nil
 	})
 }


### PR DESCRIPTION
This PR is due on these comments:
https://github.com/ava-labs/hypersdk/pull/1710#discussion_r1829382123
https://github.com/ava-labs/hypersdk/pull/1710#discussion_r1829391502

This exports the options into api package.
There is 0 remaining import of `vm` package in to `api` package and sub-packages.
It is not the `vm` package that use `api` as a dependency.