### PR TITLE
Replace manual byte manipulation with using rand

### DIFF
--- a/state/tstate/recorder_test.go
+++ b/state/tstate/recorder_test.go
@@ -5,13 +5,11 @@ package tstate
 import (
 	"context"
 	"crypto/sha256"
-	"encoding/binary"
+	"math/rand"
 	"testing"
 
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/stretchr/testify/require"
-
-	"github.com/ava-labs/hypersdk/keys"
 )
 
 const (
@@ -26,28 +24,25 @@ const (
 
 func FuzzRecorderPermissionValidator(f *testing.F) {
 	for i := 0; i < 100; i++ {
-		shaBytes := sha256.Sum256([]byte{byte(i), byte(i >> 8)})
-		bytes := shaBytes[:]
-
-		f.Add(bytes[0], // opCount
-			binary.BigEndian.Uint64(bytes[1:9]), // keyPrefix
-			bytes[10:])                          // randBytes
+		f.Add(byte(i), int64(i))
 	}
+
 	f.Fuzz(
 		RecorderPermissionValidatorFuzzer,
 	)
 }
 
-func createKeys(prefix uint64) [][]byte {
-	var keylist [][]byte
-	bytesPrefix := binary.AppendUvarint([]byte{}, prefix)
-	for i := 0; i < 512; i++ {
-		shaBytes := sha256.Sum256(append(bytesPrefix, []byte{byte(i), byte(i >> 8)}...))
-		randNewKey := make([]byte, 30, 32)
-		copy(randNewKey, shaBytes[:])
-		keylist = append(keylist, keys.EncodeChunks(randNewKey, 1))
+func createKeys(numKeys int, keySize int, rand *rand.Rand) [][]byte {
+	keys := make([][]byte, numKeys)
+	for i := 0; i < numKeys; i++ {
+		randKey := make([]byte, keySize)
+		_, err := rand.Read(randKey)
+		if err != nil {
+			panic(err)
+		}
+		keys[i] = randKey
 	}
-	return keylist
+	return keys
 }
 
 func createKeysValues(keys [][]byte) map[string][]byte {
@@ -79,27 +74,23 @@ func removeSliceElement[K any](slice []K, idx int) []K {
 	return slice[:len(slice)-1]
 }
 
-func RecorderPermissionValidatorFuzzer(t *testing.T, operationCount byte, keysPrefix uint64, randBytes []byte) {
+func RecorderPermissionValidatorFuzzer(t *testing.T, operationCount byte, source int64) {
 	require := require.New(t)
+	r := rand.New(rand.NewSource(source)) //nolint:gosec
 	// create a set of keys which would be used for testing.
 	// half of these keys would "exists", where the other won't.
-	existingKeys := createKeys(keysPrefix)
-	nonExistingKeys := createKeys(keysPrefix + 1)
+	existingKeys := createKeys(512, 32, r)
+	nonExistingKeys := createKeys(512, 32, r)
 	existingKeyValue := createKeysValues(existingKeys)
 
 	// create a long living recorder.
 	recorder := NewRecorder(immutableScopeStorage(existingKeyValue).duplicate())
 
 	for opIdx := byte(0); opIdx < operationCount; opIdx++ {
-		updatedSeed := sha256.Sum256(append(binary.AppendUvarint([]byte{}, uint64(opIdx)), randBytes...))
-		randBytes = updatedSeed[:]
-
-		opType := binary.BigEndian.Uint64(randBytes) & fuzzerOpCount
-		keyIdx := binary.BigEndian.Uint16(randBytes[8:])
+		opType := r.Intn(fuzzerOpCount)
 		switch opType {
 		case fuzzerOpInsertExistingKey: // insert existing key
-			keyIdx %= uint16(len(existingKeys))
-			key := existingKeys[keyIdx]
+			key := existingKeys[r.Intn(len(existingKeys))]
 			require.NoError(recorder.Insert(context.Background(), key, []byte{1, 2, 3}))
 
 			// validate operation agaist TStateView
@@ -108,9 +99,9 @@ func RecorderPermissionValidatorFuzzer(t *testing.T, operationCount byte, keysPr
 
 			existingKeyValue[string(key)] = []byte{1, 2, 3}
 		case fuzzerOpInsertNonExistingKey: // insert non existing key
-			keyIdx %= uint16(len(nonExistingKeys))
+			keyIdx := r.Intn(len(nonExistingKeys))
 			key := nonExistingKeys[keyIdx]
-			nonExistingKeys = removeSliceElement(nonExistingKeys, int(keyIdx))
+			nonExistingKeys = removeSliceElement(nonExistingKeys, keyIdx)
 
 			require.NoError(recorder.Insert(context.Background(), key, []byte{1, 2, 3, 4}))
 
@@ -122,7 +113,7 @@ func RecorderPermissionValidatorFuzzer(t *testing.T, operationCount byte, keysPr
 			existingKeys = append(existingKeys, key)
 			existingKeyValue[string(key)] = []byte{1, 2, 3, 4}
 		case fuzzerOpRemoveExistingKey: // remove existing key
-			keyIdx %= uint16(len(existingKeys))
+			keyIdx := r.Intn(len(existingKeys))
 			require.NoError(recorder.Remove(context.Background(), existingKeys[keyIdx]))
 
 			// validate operation agaist TStateView
@@ -133,14 +124,14 @@ func RecorderPermissionValidatorFuzzer(t *testing.T, operationCount byte, keysPr
 			delete(existingKeyValue, string(existingKeys[keyIdx]))
 			existingKeys = append(existingKeys[:keyIdx], existingKeys[keyIdx+1:]...)
 		case fuzzerOpRemoveNonExistingKey: // remove a non existing key
-			keyIdx %= uint16(len(nonExistingKeys))
+			keyIdx := r.Intn(len(nonExistingKeys))
 			require.NoError(recorder.Remove(context.Background(), nonExistingKeys[keyIdx]))
 
 			// validate operation agaist TStateView
 			stateKeys := recorder.GetStateKeys()
 			require.NoError(New(0).NewView(stateKeys, immutableScopeStorage(existingKeyValue).duplicate()).Remove(context.Background(), nonExistingKeys[keyIdx]))
 		case fuzzerOpGetExistingKey: // get value of existing key
-			keyIdx %= uint16(len(existingKeys))
+			keyIdx := r.Intn(len(existingKeys))
 			recorderValue, err := recorder.GetValue(context.Background(), existingKeys[keyIdx])
 			require.NoError(err)
 
@@ -152,7 +143,7 @@ func RecorderPermissionValidatorFuzzer(t *testing.T, operationCount byte, keysPr
 			// both the recorder and the stateview should return the same value.
 			require.Equal(recorderValue, stateValue)
 		case fuzzerOpGetNonExistingKey: // get value of non existing key
-			keyIdx %= uint16(len(nonExistingKeys))
+			keyIdx := r.Intn(len(nonExistingKeys))
 			val, err := recorder.GetValue(context.Background(), nonExistingKeys[keyIdx])
 			require.ErrorIs(err, database.ErrNotFound, "element was found with a value of %v, while it was supposed to be missing", val)
 


### PR DESCRIPTION
This PR replaces manual byte manipulations to get the fuzz tests random inputs with using a single `rand.Rand` type generated from a source to generate all of the random inputs.

We could further improve how we seed the fuzzer by using a library to more intelligently fill the inputs like https://github.com/thepudds/fzgen, but I don't think that's necessary for the recorder fuzz tests.