### PR TITLE
Remove pebble avametrics

### DIFF
--- a/api/indexer/indexer.go
+++ b/api/indexer/indexer.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/wrappers"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/ava-labs/hypersdk/chain"
 	"github.com/ava-labs/hypersdk/codec"
@@ -45,11 +46,11 @@ func NewIndexer(path string, parser chain.Parser, blockWindow uint64) (*Indexer,
 	if blockWindow > maxBlockWindow {
 		return nil, fmt.Errorf("block window %d exceeds maximum %d", blockWindow, maxBlockWindow)
 	}
-	txDB, _, err := pebble.New(filepath.Join(path, "tx"), pebble.NewDefaultConfig())
+	txDB, err := pebble.New(filepath.Join(path, "tx"), pebble.NewDefaultConfig(), prometheus.NewRegistry())
 	if err != nil {
 		return nil, err
 	}
-	blockDB, _, err := pebble.New(filepath.Join(path, "block"), pebble.NewDefaultConfig())
+	blockDB, err := pebble.New(filepath.Join(path, "block"), pebble.NewDefaultConfig(), prometheus.NewRegistry())
 	if err != nil {
 		return nil, err
 	}

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -5,6 +5,7 @@ package cli
 
 import (
 	"github.com/ava-labs/avalanchego/database"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/ava-labs/hypersdk/chain"
 	"github.com/ava-labs/hypersdk/codec"
@@ -26,7 +27,7 @@ type Handler struct {
 }
 
 func New(c Controller) (*Handler, error) {
-	db, _, err := pebble.New(c.DatabasePath(), pebble.NewDefaultConfig())
+	db, err := pebble.New(c.DatabasePath(), pebble.NewDefaultConfig(), prometheus.NewRegistry())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pebble/metrics.go
+++ b/internal/pebble/metrics.go
@@ -33,15 +33,14 @@ type metrics struct {
 	obsoleteWALCount   prometheus.Gauge
 }
 
-func newMetrics() (*prometheus.Registry, *metrics, error) {
-	r := prometheus.NewRegistry()
+func newMetrics(r prometheus.Registerer) (*metrics, error) {
 	writeStall, err := metric.NewAverager(
 		"pebble_write_stall",
 		"time spent waiting for disk write",
 		r,
 	)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	getLatency, err := metric.NewAverager(
 		"pebble_read_latency",
@@ -49,7 +48,7 @@ func newMetrics() (*prometheus.Registry, *metrics, error) {
 		r,
 	)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	m := &metrics{
 		writeStall: writeStall,
@@ -118,7 +117,7 @@ func newMetrics() (*prometheus.Registry, *metrics, error) {
 		r.Register(m.obsoleteWALSize),
 		r.Register(m.obsoleteWALCount),
 	)
-	return r, m, errs.Err
+	return m, errs.Err
 }
 
 func (db *Database) onCompactionBegin(info pebble.CompactionInfo) {

--- a/internal/pebble/pebble.go
+++ b/internal/pebble/pebble.go
@@ -133,7 +133,8 @@ func (db *Database) Has(key []byte) (bool, error) {
 func (db *Database) Get(key []byte) ([]byte, error) {
 	start := time.Now()
 	data, closer, err := db.db.Get(key)
-	db.metrics.getLatency.Observe(float64(time.Since(start)))
+	db.metrics.getCount.Inc()
+	db.metrics.getSum.Add(float64(time.Since(start)))
 	if err != nil {
 		return nil, updateError(err)
 	}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -4,26 +4,22 @@
 package storage
 
 import (
-	"github.com/ava-labs/avalanchego/api/metrics"
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/database/corruptabledb"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/ava-labs/hypersdk/internal/pebble"
 	"github.com/ava-labs/hypersdk/utils"
 )
 
-func New(cfg pebble.Config, chainDataDir string, namespace string, gatherer metrics.MultiGatherer) (database.Database, error) {
+func New(cfg pebble.Config, chainDataDir string, namespace string, registerer prometheus.Registerer) (database.Database, error) {
 	path, err := utils.InitSubDirectory(chainDataDir, namespace)
 	if err != nil {
 		return nil, err
 	}
 
-	db, registry, err := pebble.New(path, cfg)
+	db, err := pebble.New(path, cfg, registerer)
 	if err != nil {
-		return nil, err
-	}
-
-	if err := gatherer.Register(namespace, registry); err != nil {
 		return nil, err
 	}
 

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -223,8 +223,8 @@ func (vm *VM) Initialize(
 	}
 
 	rawStateDBRegistry := prometheus.NewRegistry()
-	if err := vm.snowCtx.Metrics.Register("rawstatedb", blockDBRegistry); err != nil {
-		return fmt.Errorf("failed to register blockdb metrics: %w", err)
+	if err := vm.snowCtx.Metrics.Register("rawstatedb", rawStateDBRegistry); err != nil {
+		return fmt.Errorf("failed to register rawstatedb metrics: %w", err)
 	}
 	vm.rawStateDB, err = storage.New(pebbleConfig, vm.snowCtx.ChainDataDir, stateDB, rawStateDBRegistry)
 	if err != nil {

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -212,13 +212,21 @@ func (vm *VM) Initialize(
 		return fmt.Errorf("failed to initialize p2p: %w", err)
 	}
 
+	blockDBRegistry := prometheus.NewRegistry()
+	if err := vm.snowCtx.Metrics.Register("blockdb", blockDBRegistry); err != nil {
+		return fmt.Errorf("failed to register blockdb metrics: %w", err)
+	}
 	pebbleConfig := pebble.NewDefaultConfig()
-	vm.vmDB, err = storage.New(pebbleConfig, vm.snowCtx.ChainDataDir, blockDB, vm.snowCtx.Metrics)
+	vm.vmDB, err = storage.New(pebbleConfig, vm.snowCtx.ChainDataDir, blockDB, blockDBRegistry)
 	if err != nil {
 		return err
 	}
 
-	vm.rawStateDB, err = storage.New(pebbleConfig, vm.snowCtx.ChainDataDir, stateDB, vm.snowCtx.Metrics)
+	rawStateDBRegistry := prometheus.NewRegistry()
+	if err := vm.snowCtx.Metrics.Register("rawstatedb", blockDBRegistry); err != nil {
+		return fmt.Errorf("failed to register blockdb metrics: %w", err)
+	}
+	vm.rawStateDB, err = storage.New(pebbleConfig, vm.snowCtx.ChainDataDir, stateDB, rawStateDBRegistry)
 	if err != nil {
 		return err
 	}

--- a/x/dsmr/storage_test.go
+++ b/x/dsmr/storage_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/set"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/hypersdk/codec"
@@ -75,7 +76,7 @@ func createTestStorage(t *testing.T, numValidChunks, numInvalidChunks int) (
 
 	tempDir := t.TempDir()
 
-	db, _, err := pebble.New(tempDir, pebble.NewDefaultConfig())
+	db, err := pebble.New(tempDir, pebble.NewDefaultConfig(), prometheus.NewRegistry())
 	require.NoError(err)
 	validChunkIDs := make([]ids.ID, 0, numValidChunks)
 	for _, chunk := range validChunks {
@@ -91,7 +92,7 @@ func createTestStorage(t *testing.T, numValidChunks, numInvalidChunks int) (
 
 	restart := func() *chunkStorage[tx] {
 		require.NoError(db.Close())
-		db, _, err = pebble.New(tempDir, pebble.NewDefaultConfig())
+		db, err = pebble.New(tempDir, pebble.NewDefaultConfig(), prometheus.NewRegistry())
 		require.NoError(err)
 
 		storage, err := newChunkStorage[tx](


### PR DESCRIPTION
This PR removes the usage of the AvalancheGo multigatherer and `metric.Averager` from pebble