### PR TITLE
Add formatted errors for tx execution

### DIFF
--- a/chain/transaction.go
+++ b/chain/transaction.go
@@ -319,17 +319,17 @@ func (t *Transaction) Execute(
 	units, err := t.Units(bh, r)
 	if err != nil {
 		// Should never happen
-		return nil, err
+		return nil, fmt.Errorf("failed to calculate tx units: %w", err)
 	}
 	fee, err := feeManager.Fee(units)
 	if err != nil {
 		// Should never happen
-		return nil, err
+		return nil, fmt.Errorf("failed to calculate tx fee: %w", err)
 	}
 	if err := bh.Deduct(ctx, t.Auth.Sponsor(), ts, fee); err != nil {
 		// This should never fail for low balance (as we check [CanDeductFee]
 		// immediately before).
-		return nil, err
+		return nil, fmt.Errorf("failed to deduct tx fee: %w", err)
 	}
 
 	// We create a temp state checkpoint to ensure we don't commit failed actions to state.
@@ -355,7 +355,7 @@ func (t *Transaction) Execute(
 		} else {
 			encodedOutput, err = MarshalTyped(actionOutput)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("failed to marshal action output %T: %w", actionOutput, err)
 			}
 		}
 


### PR DESCRIPTION
This PR adds formatted errors for any error that can cause tx execution to return an execution error (excluding action execution errors which are valid to include within a block ie. normal revert handling).

Added this while debugging and find it extremely helpful.