### PR TITLE
Handle nil state keys in unmarshal JSON

### DIFF
--- a/state/keys.go
+++ b/state/keys.go
@@ -80,6 +80,10 @@ func (k Keys) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON unmarshals readable JSON.
 func (k *Keys) UnmarshalJSON(b []byte) error {
+	// Initialize map if nil
+	if *k == nil {
+		*k = make(Keys)
+	}
 	var keysJSON keysJSON
 	if err := json.Unmarshal(b, &keysJSON); err != nil {
 		return err

--- a/state/keys_test.go
+++ b/state/keys_test.go
@@ -243,3 +243,16 @@ func TestPermissionStringer(t *testing.T) {
 	require.Equal("none", None.String())
 	require.Equal("09", Permissions(9).String())
 }
+
+func TestUnmarshalIntoNilKeys(t *testing.T) {
+	require := require.New(t)
+
+	keys := Keys{}
+	require.True(keys.Add("key1", Read))
+	bytes, err := keys.MarshalJSON()
+	require.NoError(err)
+
+	var unmarshalledKeys Keys
+	require.NoError(unmarshalledKeys.UnmarshalJSON(bytes))
+	require.Len(unmarshalledKeys, 1)
+}


### PR DESCRIPTION
This PR initializes `state.Keys` if it was not already initialized when unmarshalling JSON.

Fixes https://github.com/ava-labs/hypersdk/issues/1788