### PR TITLE
Ensure Blocks Don't Overpack With Txs

### DIFF
--- a/chain/builder.go
+++ b/chain/builder.go
@@ -181,10 +181,11 @@ func (c *Builder) BuildBlock(ctx context.Context, parentView state.View, parent 
 		e := executor.New(streamBatch, c.config.TransactionExecutionCores, MaxKeyDependencies, c.metrics.executorBuildRecorder)
 		pending := make(map[ids.ID]*Transaction, streamBatch)
 		var pendingLock sync.Mutex
-		totalTxSize := 0
+		totalTxsSize := 0
 		for li, ltx := range txs {
 			txsAttempted++
-			if totalTxSize += ltx.Size(); totalTxSize > c.config.TargetTxsSize {
+			totalTxsSize += ltx.Size()
+			if totalTxsSize > c.config.TargetTxsSize {
 				c.log.Debug("Transactions in block exceeded allotted limit ", zap.Int("size", ltx.Size()))
 				restorable = append(restorable, txs[li:]...)
 				break

--- a/chain/builder.go
+++ b/chain/builder.go
@@ -19,6 +19,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.uber.org/zap"
 
+	"github.com/ava-labs/hypersdk/consts"
 	"github.com/ava-labs/hypersdk/internal/executor"
 	"github.com/ava-labs/hypersdk/internal/fees"
 	"github.com/ava-labs/hypersdk/keys"
@@ -181,8 +182,15 @@ func (c *Builder) BuildBlock(ctx context.Context, parentView state.View, parent 
 		e := executor.New(streamBatch, c.config.TransactionExecutionCores, MaxKeyDependencies, c.metrics.executorBuildRecorder)
 		pending := make(map[ids.ID]*Transaction, streamBatch)
 		var pendingLock sync.Mutex
+		totalTxSize := 0
 		for li, ltx := range txs {
 			txsAttempted++
+			if totalTxSize += ltx.Size(); totalTxSize > consts.MaxTotalTxSizePerBlock {
+				c.log.Debug("Transactions in exceeded block limit ", zap.Int("size", ltx.Size()))
+				restorable = append(restorable, txs[li:]...)
+				break
+			}
+
 			i := li
 			tx := ltx
 

--- a/chain/builder.go
+++ b/chain/builder.go
@@ -19,7 +19,6 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.uber.org/zap"
 
-	"github.com/ava-labs/hypersdk/consts"
 	"github.com/ava-labs/hypersdk/internal/executor"
 	"github.com/ava-labs/hypersdk/internal/fees"
 	"github.com/ava-labs/hypersdk/keys"
@@ -185,7 +184,7 @@ func (c *Builder) BuildBlock(ctx context.Context, parentView state.View, parent 
 		totalTxSize := 0
 		for li, ltx := range txs {
 			txsAttempted++
-			if totalTxSize += ltx.Size(); totalTxSize > consts.MaxTotalTxSizePerBlock {
+			if totalTxSize += ltx.Size(); totalTxSize > c.config.TargetTxsSize {
 				c.log.Debug("Transactions in block exceeded allotted limit ", zap.Int("size", ltx.Size()))
 				restorable = append(restorable, txs[li:]...)
 				break

--- a/chain/builder.go
+++ b/chain/builder.go
@@ -186,7 +186,7 @@ func (c *Builder) BuildBlock(ctx context.Context, parentView state.View, parent 
 		for li, ltx := range txs {
 			txsAttempted++
 			if totalTxSize += ltx.Size(); totalTxSize > consts.MaxTotalTxSizePerBlock {
-				c.log.Debug("Transactions in exceeded block limit ", zap.Int("size", ltx.Size()))
+				c.log.Debug("Transactions in block exceeded allotted limit ", zap.Int("size", ltx.Size()))
 				restorable = append(restorable, txs[li:]...)
 				break
 			}

--- a/chain/config.go
+++ b/chain/config.go
@@ -3,12 +3,18 @@
 
 package chain
 
-import "time"
+import (
+	"time"
+
+	"github.com/ava-labs/avalanchego/utils/units"
+)
 
 type Config struct {
 	TargetBuildDuration       time.Duration `json:"targetBuildDuration"`
 	TransactionExecutionCores int           `json:"transactionExecutionCores"`
 	StateFetchConcurrency     int           `json:"stateFetchConcurrency"`
+	// We leave room for other block data to be included alongside the transactions
+	TargetTxsSize int `json:"targetTxsSize"`
 }
 
 func NewDefaultConfig() Config {
@@ -16,5 +22,6 @@ func NewDefaultConfig() Config {
 		TargetBuildDuration:       100 * time.Millisecond,
 		TransactionExecutionCores: 1,
 		StateFetchConcurrency:     1,
+		TargetTxsSize:             1.5 * units.MiB,
 	}
 }

--- a/consts/consts.go
+++ b/consts/consts.go
@@ -20,7 +20,8 @@ const (
 	// 2 MiB - ProposerVM header - Protobuf encoding overhead (we assume this is
 	// no more than 50 KiB of overhead but is likely much less)
 	NetworkSizeLimit = 2_044_723 // 1.95 MiB
-
+	// We leave a little bit of room for the block header and other block data.
+	MaxTotalTxSizePerBlock = 1_572_864 // 1.5 MiB
 	// FIXME: should use the standard math.MaxUint8, etc.
 	MaxUint8              = ^uint8(0)
 	MaxUint16             = ^uint16(0)

--- a/consts/consts.go
+++ b/consts/consts.go
@@ -20,8 +20,9 @@ const (
 	// 2 MiB - ProposerVM header - Protobuf encoding overhead (we assume this is
 	// no more than 50 KiB of overhead but is likely much less)
 	NetworkSizeLimit = 2_044_723 // 1.95 MiB
-	// We leave a little bit of room for the block header and other block data.
+	// We leave room for other block data to be included alongside the transactions
 	MaxTotalTxSizePerBlock = 1_572_864 // 1.5 MiB
+
 	// FIXME: should use the standard math.MaxUint8, etc.
 	MaxUint8              = ^uint8(0)
 	MaxUint16             = ^uint16(0)

--- a/consts/consts.go
+++ b/consts/consts.go
@@ -20,8 +20,6 @@ const (
 	// 2 MiB - ProposerVM header - Protobuf encoding overhead (we assume this is
 	// no more than 50 KiB of overhead but is likely much less)
 	NetworkSizeLimit = 2_044_723 // 1.95 MiB
-	// We leave room for other block data to be included alongside the transactions
-	MaxTotalTxSizePerBlock = 1_572_864 // 1.5 MiB
 
 	// FIXME: should use the standard math.MaxUint8, etc.
 	MaxUint8              = ^uint8(0)

--- a/vm/config.go
+++ b/vm/config.go
@@ -34,7 +34,6 @@ type Config struct {
 	AcceptedBlockWindow              int                        `json:"acceptedBlockWindow"`
 	AcceptedBlockWindowCache         int                        `json:"acceptedBlockWindowCache"`
 	ContinuousProfilerConfig         profiler.Config            `json:"continuousProfilerConfig"`
-	TargetBuildDuration              time.Duration              `json:"targetBuildDuration"`
 	ProcessingBuildSkip              int                        `json:"processingBuildSkip"`
 	TargetGossipDuration             time.Duration              `json:"targetGossipDuration"`
 	BlockCompactionFrequency         int                        `json:"blockCompactionFrequency"`
@@ -63,7 +62,6 @@ func NewConfig() Config {
 		AcceptedBlockWindow:              50_000, // ~3.5hr with 250ms block time (100GB at 2MB)
 		AcceptedBlockWindowCache:         128,    // 256MB at 2MB blocks
 		ContinuousProfilerConfig:         profiler.Config{Enabled: false},
-		TargetBuildDuration:              100 * time.Millisecond,
 		ProcessingBuildSkip:              16,
 		TargetGossipDuration:             20 * time.Millisecond,
 		BlockCompactionFrequency:         32, // 64 MB of deletion if 2 MB blocks

--- a/vm/resolutions.go
+++ b/vm/resolutions.go
@@ -396,10 +396,6 @@ func (vm *VM) RecordBuildCapped() {
 	vm.metrics.buildCapped.Inc()
 }
 
-func (vm *VM) GetTargetBuildDuration() time.Duration {
-	return vm.config.TargetBuildDuration
-}
-
 func (vm *VM) GetTargetGossipDuration() time.Duration {
 	return vm.config.TargetGossipDuration
 }


### PR DESCRIPTION
The maximum block size that can be sent over the network is `2MiB`.

This PR adds a check to the block builder ensuring the total size of all txs included in a block is less than `1.5MiB`. This extra `.5MiB` of wiggle room allows enough space for the other fields in the blocks to be safely included without exceeding the `2MiB` limit. 