### PR TITLE
Fix two builder regressions

### DIFF
--- a/vm/vm.go
+++ b/vm/vm.go
@@ -324,7 +324,7 @@ func (vm *VM) Initialize(
 	}
 	err = vm.applyOptions(options)
 	if err != nil {
-		return fmt.Errorf("failed to apply options : %v", err)
+		return fmt.Errorf("failed to apply options : %w", err)
 	}
 
 	vm.chainTimeValidityWindow = chain.NewTimeValidityWindow(vm.snowCtx.Log, vm.tracer, vm)


### PR DESCRIPTION
## What ?

This PR addresses two regressions introduced in PR 1767.

1. The `Manual` builder specified in the options wouldn't work. This is because the `applyOptions` is implemented as 
```golang
func (vm *VM) applyOptions(o *Options) {
	vm.blockSubscriptionFactories = o.blockSubscriptionFactories
	vm.vmAPIHandlerFactories = o.vmAPIHandlerFactories
	if o.builder {
		vm.builder = builder.NewManual(vm.toEngine, vm.snowCtx.Log)
	}
	if o.gossiper {
		vm.gossiper = gossiper.NewManual(vm)
	}
}
```
which relies on `vm.toEngine` to be initialized. But it wasn't ( by the time `applyOptions` was called ).
Fix : move the initialization of the `vm.toEngine` to the beginning of the `Initialize` function.

2. The builder `builder.NewTime` always override the manual one. This happened due to moving the `builder.NewTime` call from line 264 to line 335 so that the mempool would be initialized.
As a side observation, the creation of a Manual or NewTime is expected to be mutually exclusive. The previous code didn't really taken that into account.
Fix : Let the `applyOptions` create the builder as needed. If no builder was created, a new one would be created.






 