### PR TITLE
support context for the builder

### DIFF
--- a/internal/builder/time.go
+++ b/internal/builder/time.go
@@ -44,14 +44,14 @@ type Time struct {
 }
 
 func NewTime(engineCh chan<- common.Message, logger logging.Logger, mempool Mempool, getPreferredTimestampAndBlockGap GetPreferredTimestampAndBlockGap) *Time {
-	cancelCtx, CancelCtxFunc := context.WithCancel(context.Background())
+	cancelCtx, cancelCtxFunc := context.WithCancel(context.Background())
 	b := &Time{
 		engineCh:                         engineCh,
 		logger:                           logger,
 		mempool:                          mempool,
 		getPreferredTimestampAndBlockGap: getPreferredTimestampAndBlockGap,
 		doneBuild:                        make(chan struct{}),
-		cancelCtxFunc:                    CancelCtxFunc,
+		cancelCtxFunc:                    cancelCtxFunc,
 	}
 	b.timer = timer.NewTimer(func() {
 		b.handleTimerNotify(cancelCtx)

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -529,8 +529,8 @@ func (vm *VM) applyOptions(o *Options) error {
 	if o.builder {
 		vm.builder = builder.NewManual(vm.toEngine, vm.snowCtx.Log)
 	} else {
-		vm.builder = builder.NewTime(vm.toEngine, vm.snowCtx.Log, vm.mempool, func(t int64) (int64, int64, error) {
-			blk, err := vm.GetStatefulBlock(context.TODO(), vm.preferred)
+		vm.builder = builder.NewTime(vm.toEngine, vm.snowCtx.Log, vm.mempool, func(ctx context.Context, t int64) (int64, int64, error) {
+			blk, err := vm.GetStatefulBlock(ctx, vm.preferred)
 			if err != nil {
 				return 0, 0, err
 			}


### PR DESCRIPTION
## What ?

Three context related issues:
* The builder wasn't passing the current context to the `GetPreferredTimestampAndBlockGap`, allowing it to be canceled externally.
* The `b.mempool.Len` was receiving a `TODO` context, which would be used by the tracer. It would make it more meaningful to pass a real context.
* The periodic block building wouldn't have a real context, but only a `TODO` context. This PR add a real context to the block building, and support canceling the build as needed.