### PR TITLE
Set Packer Limit to MaxInt in ExecutedBlock Marshal

### DIFF
--- a/chain/executed_block.go
+++ b/chain/executed_block.go
@@ -34,7 +34,7 @@ func (e *ExecutedBlock) Marshal() ([]byte, error) {
 	}
 
 	size := codec.BytesLen(blockBytes) + codec.CummSize(e.Results) + fees.DimensionsLen
-	writer := codec.NewWriter(size, consts.NetworkSizeLimit)
+	writer := codec.NewWriter(size, consts.MaxInt)
 
 	writer.PackBytes(blockBytes)
 	resultBytes, err := MarshalResults(e.Results)


### PR DESCRIPTION
No need to set an upper bound here since we don't send these bytes over the p2p network.
