### PR TITLE
Add tx partitioner

### DIFF
--- a/examples/morpheusvm/go.sum
+++ b/examples/morpheusvm/go.sum
@@ -569,8 +569,8 @@ github.com/supranational/blst v0.3.11/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7/go.mod h1:q4W45IWZaF22tdD+VEXcAWRA037jwmWEB5VWYORlTpc=
 github.com/syndtr/goleveldb v1.0.1-0.20220614013038-64ee5596c38a h1:1ur3QoCqvE5fl+nylMaIr9PVV1w343YRDtsy+Rwu7XI=
 github.com/syndtr/goleveldb v1.0.1-0.20220614013038-64ee5596c38a/go.mod h1:RRCYJbIwD5jmqPI9XoAFR0OcDxqUctll6zUj/+B4S48=
-github.com/thepudds/fzgen v0.4.2 h1:HlEHl5hk2/cqEomf2uK5SA/FeJc12s/vIHmOG+FbACw=
-github.com/thepudds/fzgen v0.4.2/go.mod h1:kHCWdsv5tdnt32NIHYDdgq083m6bMtaY0M+ipiO9xWE=
+github.com/thepudds/fzgen v0.4.3 h1:srUP/34BulQaEwPP/uHZkdjUcUjIzL7Jkf4CBVryiP8=
+github.com/thepudds/fzgen v0.4.3/go.mod h1:BhhwtRhzgvLWAjjcHDJ9pEiLD2Z9hrVIFjBCHJ//zJ4=
 github.com/tklauser/go-sysconf v0.3.12 h1:0QaGUFOdQaIVdPgfITYzaTegZvdCjmYO52cSFAEVmqU=
 github.com/tklauser/go-sysconf v0.3.12/go.mod h1:Ho14jnntGE1fpdOqQEEaiKRpvIavV0hSfmBq8nJbHYI=
 github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+Fk=

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/spf13/cobra v1.5.0
 	github.com/spf13/viper v1.12.0
 	github.com/stretchr/testify v1.8.4
+	github.com/thepudds/fzgen v0.4.3
 	go.opentelemetry.io/otel v1.22.0
 	go.opentelemetry.io/otel/exporters/zipkin v1.11.2
 	go.opentelemetry.io/otel/sdk v1.22.0
@@ -119,6 +120,7 @@ require (
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
 	github.com/rs/cors v1.7.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/sanity-io/litter v1.5.1 // indirect
 	github.com/shirou/gopsutil v3.21.11+incompatible // indirect
 	github.com/spf13/afero v1.8.2 // indirect
 	github.com/spf13/cast v1.5.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,6 @@ require (
 	github.com/spf13/cobra v1.5.0
 	github.com/spf13/viper v1.12.0
 	github.com/stretchr/testify v1.8.4
-	github.com/thepudds/fzgen v0.4.3
 	go.opentelemetry.io/otel v1.22.0
 	go.opentelemetry.io/otel/exporters/zipkin v1.11.2
 	go.opentelemetry.io/otel/sdk v1.22.0
@@ -120,7 +119,6 @@ require (
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
 	github.com/rs/cors v1.7.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
-	github.com/sanity-io/litter v1.5.1 // indirect
 	github.com/shirou/gopsutil v3.21.11+incompatible // indirect
 	github.com/spf13/afero v1.8.2 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
@@ -130,6 +128,7 @@ require (
 	github.com/subosito/gotenv v1.3.0 // indirect
 	github.com/supranational/blst v0.3.11 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20220614013038-64ee5596c38a // indirect
+	github.com/thepudds/fzgen v0.4.3 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/tyler-smith/go-bip39 v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -146,6 +146,7 @@ github.com/crate-crypto/go-ipa v0.0.0-20231025140028-3c0104f4b233/go.mod h1:geZJ
 github.com/crate-crypto/go-kzg-4844 v0.7.0 h1:C0vgZRk4q4EZ/JgPfzuSoxdCq3C3mOZMBShovmncxvA=
 github.com/crate-crypto/go-kzg-4844 v0.7.0/go.mod h1:1kMhvPgI0Ky3yIa+9lFySEBUBXkYxeOi8ZF1sYioxhc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/davecgh/go-spew v0.0.0-20161028175848-04cdfd42973b/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -495,6 +496,7 @@ github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qRg=
+github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v1.16.0 h1:yk/hx9hDbrGHovbci4BY+pRMfSuuat626eFsHb7tmT8=
@@ -551,6 +553,7 @@ github.com/status-im/keycard-go v0.2.0 h1:QDLFswOQu1r5jsycloeQh3bVU8n/NatHHaZobt
 github.com/status-im/keycard-go v0.2.0/go.mod h1:wlp8ZLbsmrF6g6WjugPAx+IzoLrkdf9+mHxBEeo3Hbg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/testify v0.0.0-20161117074351-18a02ba4a312/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
@@ -569,8 +572,8 @@ github.com/supranational/blst v0.3.11/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7/go.mod h1:q4W45IWZaF22tdD+VEXcAWRA037jwmWEB5VWYORlTpc=
 github.com/syndtr/goleveldb v1.0.1-0.20220614013038-64ee5596c38a h1:1ur3QoCqvE5fl+nylMaIr9PVV1w343YRDtsy+Rwu7XI=
 github.com/syndtr/goleveldb v1.0.1-0.20220614013038-64ee5596c38a/go.mod h1:RRCYJbIwD5jmqPI9XoAFR0OcDxqUctll6zUj/+B4S48=
-github.com/thepudds/fzgen v0.4.2 h1:HlEHl5hk2/cqEomf2uK5SA/FeJc12s/vIHmOG+FbACw=
-github.com/thepudds/fzgen v0.4.2/go.mod h1:kHCWdsv5tdnt32NIHYDdgq083m6bMtaY0M+ipiO9xWE=
+github.com/thepudds/fzgen v0.4.3 h1:srUP/34BulQaEwPP/uHZkdjUcUjIzL7Jkf4CBVryiP8=
+github.com/thepudds/fzgen v0.4.3/go.mod h1:BhhwtRhzgvLWAjjcHDJ9pEiLD2Z9hrVIFjBCHJ//zJ4=
 github.com/tklauser/go-sysconf v0.3.12 h1:0QaGUFOdQaIVdPgfITYzaTegZvdCjmYO52cSFAEVmqU=
 github.com/tklauser/go-sysconf v0.3.12/go.mod h1:Ho14jnntGE1fpdOqQEEaiKRpvIavV0hSfmBq8nJbHYI=
 github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+Fk=

--- a/go.sum
+++ b/go.sum
@@ -146,7 +146,6 @@ github.com/crate-crypto/go-ipa v0.0.0-20231025140028-3c0104f4b233/go.mod h1:geZJ
 github.com/crate-crypto/go-kzg-4844 v0.7.0 h1:C0vgZRk4q4EZ/JgPfzuSoxdCq3C3mOZMBShovmncxvA=
 github.com/crate-crypto/go-kzg-4844 v0.7.0/go.mod h1:1kMhvPgI0Ky3yIa+9lFySEBUBXkYxeOi8ZF1sYioxhc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/davecgh/go-spew v0.0.0-20161028175848-04cdfd42973b/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -496,7 +495,6 @@ github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qRg=
-github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v1.16.0 h1:yk/hx9hDbrGHovbci4BY+pRMfSuuat626eFsHb7tmT8=
@@ -553,7 +551,6 @@ github.com/status-im/keycard-go v0.2.0 h1:QDLFswOQu1r5jsycloeQh3bVU8n/NatHHaZobt
 github.com/status-im/keycard-go v0.2.0/go.mod h1:wlp8ZLbsmrF6g6WjugPAx+IzoLrkdf9+mHxBEeo3Hbg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
-github.com/stretchr/testify v0.0.0-20161117074351-18a02ba4a312/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=

--- a/x/dsmr/block.go
+++ b/x/dsmr/block.go
@@ -22,6 +22,7 @@ const InitialChunkSize = 250 * 1024
 type Tx interface {
 	GetID() ids.ID
 	GetExpiry() int64
+	GetSponsor() codec.Address
 }
 
 type UnsignedChunk[T Tx] struct {

--- a/x/dsmr/node.go
+++ b/x/dsmr/node.go
@@ -32,6 +32,7 @@ var (
 
 type Validator struct {
 	NodeID ids.NodeID
+	Weight uint64
 }
 
 func New[T Tx](

--- a/x/dsmr/node_test.go
+++ b/x/dsmr/node_test.go
@@ -1479,8 +1479,9 @@ func getSignerBitSet(t *testing.T, pChain validators.State, nodeIDs ...ids.NodeI
 }
 
 type tx struct {
-	ID     ids.ID `serialize:"true"`
-	Expiry int64  `serialize:"true"`
+	ID      ids.ID        `serialize:"true"`
+	Expiry  int64         `serialize:"true"`
+	Sponsor codec.Address `serialize:"true"`
 }
 
 func (t tx) GetID() ids.ID {
@@ -1489,6 +1490,10 @@ func (t tx) GetID() ids.ID {
 
 func (t tx) GetExpiry() int64 {
 	return t.Expiry
+}
+
+func (t tx) GetSponsor() codec.Address {
+	return t.Sponsor
 }
 
 type failVerifier struct{}

--- a/x/dsmr/partition.go
+++ b/x/dsmr/partition.go
@@ -1,0 +1,194 @@
+// Copyright (C) 2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package dsmr
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/snow/validators"
+	"github.com/ava-labs/avalanchego/utils"
+	"github.com/ava-labs/hypersdk/codec"
+	"github.com/ava-labs/hypersdk/consts"
+	"github.com/ava-labs/hypersdk/internal/cache"
+)
+
+const partitionCacheSize = 100
+
+type weightedValidator struct {
+	weight uint64
+	nodeID ids.NodeID
+}
+
+type PrecalculatedPartition[T Tx] struct {
+	validators  []*weightedValidator
+	totalWeight uint64
+}
+
+func (w *weightedValidator) Compare(o *weightedValidator) int {
+	return bytes.Compare(w.nodeID[:], o.nodeID[:])
+}
+
+func CalculatePartition[T Tx](ctx context.Context, state validators.State, pChainHeight uint64, subnetID ids.ID) (*PrecalculatedPartition[T], error) {
+	vdrs, err := state.GetValidatorSet(ctx, pChainHeight, subnetID)
+	if err != nil {
+		return nil, err
+	}
+	weightedValidators := make([]*weightedValidator, 0, len(vdrs))
+	totalWeight := uint64(0)
+	for _, vdr := range vdrs {
+		weightedValidators = append(weightedValidators, &weightedValidator{
+			weight: vdr.Weight,
+			nodeID: vdr.NodeID,
+		})
+		totalWeight += vdr.Weight
+	}
+	utils.Sort(weightedValidators)
+
+	return &PrecalculatedPartition[T]{
+		validators:  weightedValidators,
+		totalWeight: totalWeight,
+	}, nil
+}
+
+func calculateSponsorWeightIndex(sponsor codec.Address, totalWeight uint64) uint64 {
+	return binary.BigEndian.Uint64(sponsor[len(sponsor)-consts.Uint64Len:]) % totalWeight
+}
+
+func (pp *PrecalculatedPartition[T]) AssignTx(tx T) (ids.NodeID, bool) {
+	sponsor := tx.GetSponsor()
+	sponsorWeightIndex := calculateSponsorWeightIndex(sponsor, pp.totalWeight)
+	weightIndex := uint64(0)
+	for _, vdr := range pp.validators {
+		weightIndex += vdr.weight
+		if weightIndex > sponsorWeightIndex {
+			return vdr.nodeID, true
+		}
+	}
+	// This should only happen if there are no validators
+	return ids.NodeID{}, false
+}
+
+type indexedTx[T Tx] struct {
+	index uint64
+	tx    T
+}
+
+func (i *indexedTx[T]) Compare(o *indexedTx[T]) int {
+	switch {
+	case i.index < o.index:
+		return -1
+	case i.index > o.index:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func (pp *PrecalculatedPartition[T]) calculateIndexedTxs(txs []T) []*indexedTx[T] {
+	indexedTxs := make([]*indexedTx[T], len(txs))
+	for i, tx := range txs {
+		sponsor := tx.GetSponsor()
+		sponsorWeightIndex := calculateSponsorWeightIndex(sponsor, pp.totalWeight)
+		indexedTxs[i] = &indexedTx[T]{
+			index: sponsorWeightIndex,
+			tx:    tx,
+		}
+	}
+	utils.Sort(indexedTxs)
+	return indexedTxs
+}
+
+func (pp *PrecalculatedPartition[T]) AssignTxs(txs []T) (map[ids.NodeID][]T, error) {
+	indexedTxs := pp.calculateIndexedTxs(txs)
+
+	assignments := make(map[ids.NodeID][]T)
+	weightIndex := uint64(0)
+	txIndex := 0
+	for _, vdr := range pp.validators {
+		weightIndex += vdr.weight
+		for txIndex < len(indexedTxs) && weightIndex > indexedTxs[txIndex].index {
+			assignments[vdr.nodeID] = append(assignments[vdr.nodeID], indexedTxs[txIndex].tx)
+			txIndex++
+		}
+		if txIndex >= len(indexedTxs) {
+			break
+		}
+	}
+	return assignments, nil
+}
+
+func (pp *PrecalculatedPartition[T]) FilterTxs(nodeID ids.NodeID, txs []T) ([]T, error) {
+	// Return early if there are no transactions to filter
+	if len(txs) == 0 {
+		return nil, nil
+	}
+
+	// Calculate the weight index boundaries for the provided nodeID
+	weightIndex := uint64(0)
+	startWeight := uint64(0)
+	endWeight := uint64(0)
+	for _, vdr := range pp.validators {
+		if vdr.nodeID == nodeID {
+			startWeight = weightIndex
+			endWeight = weightIndex + vdr.weight
+			break
+		}
+		weightIndex += vdr.weight
+	}
+
+	filteredTxs := make([]T, 0, len(txs)/2)
+	for _, tx := range txs {
+		txIndexWeight := calculateSponsorWeightIndex(tx.GetSponsor(), pp.totalWeight)
+		if endWeight > txIndexWeight && startWeight <= txIndexWeight {
+			filteredTxs = append(filteredTxs, tx)
+		}
+	}
+
+	return filteredTxs, nil
+}
+
+type Partition[T Tx] struct {
+	state    validators.State
+	subnetID ids.ID
+
+	partitions *cache.FIFO[uint64, *PrecalculatedPartition[T]]
+}
+
+func NewPartition[T Tx](state validators.State, subnetID ids.ID) (*Partition[T], error) {
+	partitionCache, err := cache.NewFIFO[uint64, *PrecalculatedPartition[T]](partitionCacheSize)
+	if err != nil {
+		return nil, err
+	}
+	return &Partition[T]{
+		state:      state,
+		subnetID:   subnetID,
+		partitions: partitionCache,
+	}, nil
+}
+
+func (p *Partition[T]) GetPartition(ctx context.Context, pChainHeight uint64) (*PrecalculatedPartition[T], error) {
+	partition, ok := p.partitions.Get(pChainHeight)
+	if ok {
+		return partition, nil
+	}
+
+	partition, err := CalculatePartition[T](ctx, p.state, pChainHeight, p.subnetID)
+	if err != nil {
+		return nil, err
+	}
+	p.partitions.Put(pChainHeight, partition)
+	return partition, nil
+}
+
+func (p *Partition[T]) GetCurrentPartition(ctx context.Context) (*PrecalculatedPartition[T], error) {
+	pChainHeight, err := p.state.GetCurrentHeight(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return p.GetPartition(ctx, pChainHeight)
+}

--- a/x/dsmr/partition.go
+++ b/x/dsmr/partition.go
@@ -5,20 +5,15 @@ package dsmr
 
 import (
 	"bytes"
-	"context"
 	"encoding/binary"
 	"sort"
 
 	"github.com/ava-labs/avalanchego/ids"
-	"github.com/ava-labs/avalanchego/snow/validators"
 	"github.com/ava-labs/avalanchego/utils"
 
 	"github.com/ava-labs/hypersdk/codec"
 	"github.com/ava-labs/hypersdk/consts"
-	"github.com/ava-labs/hypersdk/internal/cache"
 )
-
-const partitionCacheSize = 100
 
 type weightedValidator struct {
 	weight uint64
@@ -27,142 +22,47 @@ type weightedValidator struct {
 	accumulatedWeight uint64
 }
 
-type PrecalculatedPartition[T Tx] struct {
-	validators  []*weightedValidator
+type Partition[T Tx] struct {
+	validators  []weightedValidator
 	totalWeight uint64
 }
 
-func (w *weightedValidator) Compare(o *weightedValidator) int {
+func (w weightedValidator) Compare(o weightedValidator) int {
 	return bytes.Compare(w.nodeID[:], o.nodeID[:])
 }
 
-func getWeightedVdrsFromState(ctx context.Context, state validators.State, pChainHeight uint64, subnetID ids.ID) ([]*weightedValidator, error) {
-	vdrs, err := state.GetValidatorSet(ctx, pChainHeight, subnetID)
-	if err != nil {
-		return nil, err
-	}
-	weightedValidators := make([]*weightedValidator, 0, len(vdrs))
-	for _, vdr := range vdrs {
-		weightedValidators = append(weightedValidators, &weightedValidator{
+func NewPartition[T Tx](validators []Validator) *Partition[T] {
+	weightedVdrs := make([]weightedValidator, len(validators))
+	for i, vdr := range validators {
+		weightedVdrs[i] = weightedValidator{
 			weight: vdr.Weight,
 			nodeID: vdr.NodeID,
-		})
+		}
 	}
-	return weightedValidators, nil
-}
 
-func precomputePartition[T Tx](validators []*weightedValidator) *PrecalculatedPartition[T] {
-	utils.Sort(validators)
+	utils.Sort(weightedVdrs)
 	accumulatedWeight := uint64(0)
-	for _, weightedVdr := range validators {
+	for i, weightedVdr := range weightedVdrs {
 		accumulatedWeight += weightedVdr.weight
 		weightedVdr.accumulatedWeight = accumulatedWeight
+		weightedVdrs[i] = weightedVdr
 	}
-	return &PrecalculatedPartition[T]{
-		validators:  validators,
+	return &Partition[T]{
+		validators:  weightedVdrs,
 		totalWeight: accumulatedWeight,
 	}
-}
-
-func CalculatePartition[T Tx](ctx context.Context, state validators.State, pChainHeight uint64, subnetID ids.ID) (*PrecalculatedPartition[T], error) {
-	weightedValidators, err := getWeightedVdrsFromState(ctx, state, pChainHeight, subnetID)
-	if err != nil {
-		return nil, err
-	}
-
-	return precomputePartition[T](weightedValidators), nil
 }
 
 func calculateSponsorWeightIndex(sponsor codec.Address, totalWeight uint64) uint64 {
 	return binary.BigEndian.Uint64(sponsor[len(sponsor)-consts.Uint64Len:]) % totalWeight
 }
 
-func (pp *PrecalculatedPartition[T]) AssignTx(tx T) (ids.NodeID, bool) {
-	if pp.totalWeight == 0 || len(pp.validators) == 0 {
-		return ids.NodeID{}, false
-	}
-
+func (p *Partition[T]) AssignTx(tx T) (ids.NodeID, bool) {
 	sponsor := tx.GetSponsor()
-	sponsorWeightIndex := calculateSponsorWeightIndex(sponsor, pp.totalWeight)
-	nodeIDIndex := sort.Search(len(pp.validators), func(i int) bool {
-		return pp.validators[i].accumulatedWeight > sponsorWeightIndex
+	sponsorWeightIndex := calculateSponsorWeightIndex(sponsor, p.totalWeight)
+	nodeIDIndex := sort.Search(len(p.validators), func(i int) bool {
+		return p.validators[i].accumulatedWeight > sponsorWeightIndex
 	})
 
-	// Defensive: this should never happen
-	if nodeIDIndex >= len(pp.validators) {
-		return ids.NodeID{}, false
-	}
-	return pp.validators[nodeIDIndex].nodeID, true
-}
-
-type indexedTx[T Tx] struct {
-	index uint64
-	tx    T
-}
-
-func (i *indexedTx[T]) Compare(o *indexedTx[T]) int {
-	switch {
-	case i.index < o.index:
-		return -1
-	case i.index > o.index:
-		return 1
-	default:
-		return 0
-	}
-}
-
-func (pp *PrecalculatedPartition[T]) calculateIndexedTxs(txs []T) []*indexedTx[T] {
-	indexedTxs := make([]*indexedTx[T], len(txs))
-	for i, tx := range txs {
-		sponsor := tx.GetSponsor()
-		sponsorWeightIndex := calculateSponsorWeightIndex(sponsor, pp.totalWeight)
-		indexedTxs[i] = &indexedTx[T]{
-			index: sponsorWeightIndex,
-			tx:    tx,
-		}
-	}
-	utils.Sort(indexedTxs)
-	return indexedTxs
-}
-
-type Partition[T Tx] struct {
-	state    validators.State
-	subnetID ids.ID
-
-	partitions *cache.FIFO[uint64, *PrecalculatedPartition[T]]
-}
-
-func NewPartition[T Tx](state validators.State, subnetID ids.ID) (*Partition[T], error) {
-	partitionCache, err := cache.NewFIFO[uint64, *PrecalculatedPartition[T]](partitionCacheSize)
-	if err != nil {
-		return nil, err
-	}
-	return &Partition[T]{
-		state:      state,
-		subnetID:   subnetID,
-		partitions: partitionCache,
-	}, nil
-}
-
-func (p *Partition[T]) GetPartition(ctx context.Context, pChainHeight uint64) (*PrecalculatedPartition[T], error) {
-	partition, ok := p.partitions.Get(pChainHeight)
-	if ok {
-		return partition, nil
-	}
-
-	partition, err := CalculatePartition[T](ctx, p.state, pChainHeight, p.subnetID)
-	if err != nil {
-		return nil, err
-	}
-	p.partitions.Put(pChainHeight, partition)
-	return partition, nil
-}
-
-func (p *Partition[T]) GetCurrentPartition(ctx context.Context) (*PrecalculatedPartition[T], error) {
-	pChainHeight, err := p.state.GetCurrentHeight(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	return p.GetPartition(ctx, pChainHeight)
+	return p.validators[nodeIDIndex].nodeID, true
 }

--- a/x/dsmr/partition.go
+++ b/x/dsmr/partition.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow/validators"
 	"github.com/ava-labs/avalanchego/utils"
+
 	"github.com/ava-labs/hypersdk/codec"
 	"github.com/ava-labs/hypersdk/consts"
 	"github.com/ava-labs/hypersdk/internal/cache"

--- a/x/dsmr/partition_test.go
+++ b/x/dsmr/partition_test.go
@@ -10,10 +10,11 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/math"
-	"github.com/ava-labs/hypersdk/codec"
-	"github.com/ava-labs/hypersdk/consts"
 	"github.com/stretchr/testify/require"
 	"github.com/thepudds/fzgen/fuzzer"
+
+	"github.com/ava-labs/hypersdk/codec"
+	"github.com/ava-labs/hypersdk/consts"
 )
 
 // createTestPartition creates a precalculated partition with the provided weights
@@ -242,7 +243,7 @@ func FuzzFilterTxs(f *testing.F) {
 
 		nodeIDIndex := 0
 		fz.Fill(&nodeIDIndex)
-		nodeIDIndex = nodeIDIndex % len(partition.validators)
+		nodeIDIndex %= len(partition.validators)
 		nodeID := partition.validators[nodeIDIndex].nodeID
 
 		r := require.New(t)
@@ -254,9 +255,9 @@ func FuzzFilterTxs(f *testing.F) {
 		}
 
 		for _, tx := range txs {
-			nodeID, ok := partition.AssignTx(tx)
+			assignedNodeID, ok := partition.AssignTx(tx)
 			r.True(ok)
-			expectedIncluded := nodeID == nodeID
+			expectedIncluded := nodeID == assignedNodeID
 			_, included := filteredTxsSet[tx.ID]
 			r.Equal(expectedIncluded, included)
 		}

--- a/x/dsmr/partition_test.go
+++ b/x/dsmr/partition_test.go
@@ -241,9 +241,10 @@ func FuzzFilterTxs(f *testing.F) {
 			return
 		}
 
-		nodeIDIndex := 0
+		nodeIDIndex := uint32(0)
 		fz.Fill(&nodeIDIndex)
-		nodeIDIndex %= len(partition.validators)
+
+		nodeIDIndex %= uint32(len(partition.validators))
 		nodeID := partition.validators[nodeIDIndex].nodeID
 
 		r := require.New(t)

--- a/x/dsmr/partition_test.go
+++ b/x/dsmr/partition_test.go
@@ -27,18 +27,13 @@ func createTestPartition(weights []uint64) *PrecalculatedPartition[tx] {
 	utils.Sort(nodeIDs)
 
 	validators := make([]*weightedValidator, 0, len(weights))
-	totalWeight := uint64(0)
 	for i, weight := range weights {
 		validators = append(validators, &weightedValidator{
 			weight: weight,
 			nodeID: nodeIDs[i],
 		})
-		totalWeight += weight
 	}
-	return &PrecalculatedPartition[tx]{
-		validators:  validators,
-		totalWeight: totalWeight,
-	}
+	return precomputePartition[tx](validators)
 }
 
 func createTestPartitionTx(weight uint64) tx {

--- a/x/dsmr/partition_test.go
+++ b/x/dsmr/partition_test.go
@@ -1,0 +1,264 @@
+// Copyright (C) 2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package dsmr
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils"
+	"github.com/ava-labs/avalanchego/utils/math"
+	"github.com/ava-labs/hypersdk/codec"
+	"github.com/ava-labs/hypersdk/consts"
+	"github.com/stretchr/testify/require"
+	"github.com/thepudds/fzgen/fuzzer"
+)
+
+// createTestPartition creates a precalculated partition with the provided weights
+// and generates sorted nodeIDs to match the original ordering of weights
+func createTestPartition(weights []uint64) *PrecalculatedPartition[tx] {
+	nodeIDs := make([]ids.NodeID, 0, len(weights))
+	for i := 0; i < len(weights); i++ {
+		nodeIDs = append(nodeIDs, ids.GenerateTestNodeID())
+	}
+	utils.Sort(nodeIDs)
+
+	validators := make([]*weightedValidator, 0, len(weights))
+	totalWeight := uint64(0)
+	for i, weight := range weights {
+		validators = append(validators, &weightedValidator{
+			weight: weight,
+			nodeID: nodeIDs[i],
+		})
+		totalWeight += weight
+	}
+	return &PrecalculatedPartition[tx]{
+		validators:  validators,
+		totalWeight: totalWeight,
+	}
+}
+
+func createTestPartitionTx(weight uint64) tx {
+	sponsorAddrID := ids.GenerateTestID()
+	binary.BigEndian.PutUint64(
+		sponsorAddrID[len(sponsorAddrID)-consts.Uint64Len:],
+		weight,
+	)
+
+	sponsorAddr := codec.CreateAddress(0, sponsorAddrID)
+	return tx{
+		ID:      ids.GenerateTestID(),
+		Expiry:  100,
+		Sponsor: sponsorAddr,
+	}
+}
+
+func TestAssignTx(t *testing.T) {
+	for _, test := range []struct {
+		name          string
+		weights       []uint64
+		txWeight      uint64
+		expectedIndex int
+	}{
+		{
+			name: "zero weight",
+			weights: []uint64{
+				100,
+				100,
+			},
+			txWeight:      0,
+			expectedIndex: 0,
+		},
+		{
+			name: "total weight",
+			weights: []uint64{
+				100,
+				100,
+			},
+			txWeight:      200,
+			expectedIndex: 0,
+		},
+		{
+			name: "middle of first node",
+			weights: []uint64{
+				100,
+				100,
+			},
+			txWeight:      50,
+			expectedIndex: 0,
+		},
+		{
+			name: "middle of last node",
+			weights: []uint64{
+				100,
+				100,
+			},
+			txWeight:      150,
+			expectedIndex: 1,
+		},
+		{
+			name: "middle of interior node",
+			weights: []uint64{
+				100,
+				100,
+				100,
+			},
+			txWeight:      150,
+			expectedIndex: 1,
+		},
+		{
+			name: "upper boundary of interior node",
+			weights: []uint64{
+				100,
+				100,
+				100,
+			},
+			txWeight:      200,
+			expectedIndex: 2,
+		},
+		{
+			name: "lower boundary of interior node",
+			weights: []uint64{
+				100,
+				100,
+				100,
+			},
+			txWeight:      100,
+			expectedIndex: 1,
+		},
+		{
+			name: "upper boundary of first node",
+			weights: []uint64{
+				100,
+				100,
+				100,
+			},
+			txWeight:      100,
+			expectedIndex: 1,
+		},
+		{
+			name: "lower boundary of last node",
+			weights: []uint64{
+				100,
+				100,
+				100,
+			},
+			txWeight:      200,
+			expectedIndex: 2,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			r := require.New(t)
+			partition := createTestPartition(test.weights)
+
+			tx := createTestPartitionTx(test.txWeight)
+			nodeID, ok := partition.AssignTx(tx)
+			r.True(ok)
+			foundNodeIDIndex := -1
+			for i, vdr := range partition.validators {
+				if vdr.nodeID == nodeID {
+					foundNodeIDIndex = i
+					break
+				}
+			}
+			r.Equal(test.expectedIndex, foundNodeIDIndex)
+			r.Equal(partition.validators[test.expectedIndex].nodeID, nodeID)
+		})
+	}
+}
+
+func createFuzzPartitionAndTxs(fz *fuzzer.Fuzzer, numVdrs int, numTxs int) (*PrecalculatedPartition[tx], []tx, bool) {
+	vdrs := make([]uint64, 0, numVdrs)
+	for i := 0; i < numVdrs; i++ {
+		vdrWeight := uint64(0)
+		fz.Fill(&vdrWeight)
+		if vdrWeight == 0 {
+			vdrWeight = 1
+		}
+		vdrs = append(vdrs, vdrWeight)
+	}
+
+	sum := uint64(0)
+	for _, vdrWeight := range vdrs {
+		updatedSum, err := math.Add(sum, vdrWeight)
+		if err != nil {
+			return nil, nil, false
+		}
+		sum = updatedSum
+	}
+
+	txs := make([]tx, 0, numTxs)
+	for i := 0; i < numTxs; i++ {
+		txWeight := uint64(0)
+		fz.Fill(&txWeight)
+		txs = append(txs, createTestPartitionTx(txWeight))
+	}
+
+	return createTestPartition(vdrs), txs, true
+}
+
+func FuzzAssignTxs(f *testing.F) {
+	for i := 0; i < 100; i++ {
+		f.Add([]byte{byte(i)})
+	}
+	f.Fuzz(func(t *testing.T, data []byte) {
+		fz := fuzzer.NewFuzzer(data)
+		partition, txs, ok := createFuzzPartitionAndTxs(fz, 4, 4)
+		if !ok {
+			return
+		}
+
+		r := require.New(t)
+		assignedTxs, err := partition.AssignTxs(txs)
+		r.NoError(err)
+
+		expectedAssignments := make(map[ids.NodeID][]tx)
+		for _, tx := range txs {
+			nodeID, ok := partition.AssignTx(tx)
+			r.True(ok)
+			expectedAssignments[nodeID] = append(expectedAssignments[nodeID], tx)
+		}
+		r.Equal(len(expectedAssignments), len(assignedTxs))
+		for nodeID, txs := range assignedTxs {
+			expectedTxs, ok := expectedAssignments[nodeID]
+			r.True(ok)
+			r.ElementsMatch(expectedTxs, txs)
+		}
+	})
+}
+
+func FuzzFilterTxs(f *testing.F) {
+	for i := 0; i < 100; i++ {
+		f.Add([]byte{byte(i)})
+	}
+	f.Fuzz(func(t *testing.T, data []byte) {
+		fz := fuzzer.NewFuzzer(data)
+		partition, txs, ok := createFuzzPartitionAndTxs(fz, 4, 4)
+		if !ok {
+			return
+		}
+
+		nodeIDIndex := 0
+		fz.Fill(&nodeIDIndex)
+		nodeIDIndex = nodeIDIndex % len(partition.validators)
+		nodeID := partition.validators[nodeIDIndex].nodeID
+
+		r := require.New(t)
+		filteredTxs, err := partition.FilterTxs(nodeID, txs)
+		r.NoError(err)
+		filteredTxsSet := make(map[ids.ID]struct{})
+		for _, tx := range filteredTxs {
+			filteredTxsSet[tx.ID] = struct{}{}
+		}
+
+		for _, tx := range txs {
+			nodeID, ok := partition.AssignTx(tx)
+			r.True(ok)
+			expectedIncluded := nodeID == nodeID
+			_, included := filteredTxsSet[tx.ID]
+			r.Equal(expectedIncluded, included)
+		}
+	})
+}


### PR DESCRIPTION
This PR adds transaction partitioning based on the sponsor address into the DSMR package.

This will be used to partition transactions to be assigned to a specific node for chunk production/verification and targeted transaction gossip.