### PR TITLE
Remove stateful block from dsmr and move execute into node

### DIFF
--- a/x/dsmr/block.go
+++ b/x/dsmr/block.go
@@ -4,9 +4,6 @@
 package dsmr
 
 import (
-	"context"
-	"time"
-
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/crypto/bls"
 	"github.com/ava-labs/avalanchego/utils/wrappers"
@@ -120,51 +117,4 @@ type Block struct {
 
 func (b Block) GetID() ids.ID {
 	return b.blkID
-}
-
-// TODO: implement snowman.Block interface and integrate assembler
-type StatefulBlock[T Tx, State any, B any, Result any] struct {
-	handler *BlockHandler[T, State, B, Result]
-	block   *Block
-}
-
-func (s *StatefulBlock[T, S, B, R]) ID() ids.ID {
-	return s.block.blkID
-}
-
-func (s *StatefulBlock[T, S, B, R]) Parent() ids.ID {
-	return s.block.ParentID
-}
-
-func (s *StatefulBlock[T, S, B, R]) Verify(ctx context.Context) error {
-	// TODO: Verify header fields
-	// TODO: de-duplicate chunk certificates (internal to block and across history)
-	for _, chunkCert := range s.block.ChunkCerts {
-		// TODO: verify chunks within a provided context
-		if err := chunkCert.Verify(ctx, struct{}{}); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (s *StatefulBlock[T, S, B, R]) Accept(ctx context.Context) error {
-	return s.handler.Accept(ctx, s.block)
-}
-
-func (*StatefulBlock[T, S, B, R]) Reject(context.Context) error {
-	return nil
-}
-
-func (s *StatefulBlock[T, S, B, R]) Bytes() []byte {
-	return s.block.blkBytes
-}
-
-func (s *StatefulBlock[T, S, B, R]) Height() uint64 {
-	return s.block.Height
-}
-
-func (s *StatefulBlock[T, S, B, R]) Timestamp() time.Time {
-	return time.Unix(0, s.block.Timestamp)
 }

--- a/x/dsmr/node.go
+++ b/x/dsmr/node.go
@@ -207,7 +207,7 @@ func (n *Node[T]) BuildBlock(parent Block, timestamp int64) (Block, error) {
 	return blk, nil
 }
 
-func (*Node[T]) Execute(ctx context.Context, parent Block, block Block) error {
+func (*Node[T]) Execute(ctx context.Context, _ Block, block Block) error {
 	// TODO: Verify header fields
 	// TODO: de-duplicate chunk certificates (internal to block and across history)
 	for _, chunkCert := range block.ChunkCerts {

--- a/x/dsmr/node.go
+++ b/x/dsmr/node.go
@@ -171,7 +171,7 @@ func (n *Node[T]) NewChunk(
 	return chunk, n.storage.AddLocalChunkWithCert(chunk, &chunkCert)
 }
 
-func (n *Node[T]) NewBlock(parent Block, timestamp int64) (Block, error) {
+func (n *Node[T]) BuildBlock(parent Block, timestamp int64) (Block, error) {
 	if timestamp <= parent.Timestamp {
 		return Block{}, ErrTimestampNotMonotonicallyIncreasing
 	}
@@ -205,6 +205,19 @@ func (n *Node[T]) NewBlock(parent Block, timestamp int64) (Block, error) {
 	blk.blkBytes = packer.Bytes
 	blk.blkID = utils.ToID(blk.blkBytes)
 	return blk, nil
+}
+
+func (n *Node[T]) Execute(ctx context.Context, parent Block, block Block) error {
+	// TODO: Verify header fields
+	// TODO: de-duplicate chunk certificates (internal to block and across history)
+	for _, chunkCert := range block.ChunkCerts {
+		// TODO: verify chunks within a provided context
+		if err := chunkCert.Verify(ctx, struct{}{}); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (n *Node[T]) Accept(ctx context.Context, block Block) error {

--- a/x/dsmr/node.go
+++ b/x/dsmr/node.go
@@ -207,7 +207,7 @@ func (n *Node[T]) BuildBlock(parent Block, timestamp int64) (Block, error) {
 	return blk, nil
 }
 
-func (n *Node[T]) Execute(ctx context.Context, parent Block, block Block) error {
+func (*Node[T]) Execute(ctx context.Context, parent Block, block Block) error {
 	// TODO: Verify header fields
 	// TODO: de-duplicate chunk certificates (internal to block and across history)
 	for _, chunkCert := range block.ChunkCerts {

--- a/x/dsmr/node.go
+++ b/x/dsmr/node.go
@@ -99,9 +99,9 @@ type Node[T Tx] struct {
 	storage                       *chunkStorage[T]
 }
 
-// NewChunk builds transactions into a Chunk
+// BuildChunk builds transactions into a Chunk
 // TODO handle frozen sponsor + validator assignments
-func (n *Node[T]) NewChunk(
+func (n *Node[T]) BuildChunk(
 	ctx context.Context,
 	txs []T,
 	expiry int64,

--- a/x/dsmr/node_test.go
+++ b/x/dsmr/node_test.go
@@ -191,7 +191,7 @@ func TestNode_GetChunk_AvailableChunk(t *testing.T) {
 	)
 	r.NoError(err)
 
-	blk, err := node.NewBlock(
+	blk, err := node.BuildBlock(
 		Block{
 			ParentID:  ids.GenerateTestID(),
 			Height:    0,
@@ -577,7 +577,7 @@ func TestNode_BuiltChunksAvailableOverGetChunk(t *testing.T) {
 				wantChunks = append(wantChunks, chunk)
 			}
 
-			block, err := node.NewBlock(
+			block, err := node.BuildBlock(
 				Block{
 					ParentID:  ids.GenerateTestID(),
 					Height:    0,
@@ -881,7 +881,7 @@ func TestNode_GetChunkSignature_DuplicateChunk(t *testing.T) {
 		codec.Address{123},
 	)
 	r.NoError(err)
-	blk, err := node.NewBlock(
+	blk, err := node.BuildBlock(
 		Block{
 			ParentID:  ids.GenerateTestID(),
 			Height:    0,
@@ -1002,7 +1002,7 @@ func TestGetChunkSignature_PersistAttestedBlocks(t *testing.T) {
 	// chunk cert
 	var blk Block
 	for {
-		blk, err = node1.NewBlock(
+		blk, err = node1.BuildBlock(
 			Block{
 				ParentID:  ids.Empty,
 				Height:    0,
@@ -1308,7 +1308,7 @@ func TestNode_NewBlock_IncludesChunkCerts(t *testing.T) {
 				wantChunks = append(wantChunks, chunk)
 			}
 
-			blk, err := node.NewBlock(tt.parent, tt.timestamp)
+			blk, err := node.BuildBlock(tt.parent, tt.timestamp)
 			r.ErrorIs(err, tt.wantErr)
 			if err != nil {
 				return
@@ -1383,7 +1383,7 @@ func TestAccept_RequestReferencedChunks(t *testing.T) {
 		codec.Address{123},
 	)
 	r.NoError(err)
-	blk, err := node1.NewBlock(Block{
+	blk, err := node1.BuildBlock(Block{
 		ParentID:  ids.GenerateTestID(),
 		Height:    0,
 		Timestamp: 0,

--- a/x/dsmr/node_test.go
+++ b/x/dsmr/node_test.go
@@ -30,7 +30,7 @@ var (
 )
 
 // Test that chunks can be built through Node.NewChunk
-func TestNode_NewChunk(t *testing.T) {
+func TestNode_BuildChunk(t *testing.T) {
 	tests := []struct {
 		name        string
 		txs         []tx
@@ -119,7 +119,7 @@ func TestNode_NewChunk(t *testing.T) {
 			)
 			r.NoError(err)
 
-			chunk, err := node.NewChunk(
+			chunk, err := node.BuildChunk(
 				context.Background(),
 				tt.txs,
 				tt.expiry,
@@ -183,7 +183,7 @@ func TestNode_GetChunk_AvailableChunk(t *testing.T) {
 	)
 	r.NoError(err)
 
-	chunk, err := node.NewChunk(
+	chunk, err := node.BuildChunk(
 		context.Background(),
 		[]tx{{ID: ids.GenerateTestID(), Expiry: 123}},
 		123,
@@ -273,7 +273,7 @@ func TestNode_GetChunk_PendingChunk(t *testing.T) {
 	)
 	r.NoError(err)
 
-	chunk, err := node.NewChunk(
+	chunk, err := node.BuildChunk(
 		context.Background(),
 		[]tx{{ID: ids.GenerateTestID(), Expiry: 123}},
 		123,
@@ -566,7 +566,7 @@ func TestNode_BuiltChunksAvailableOverGetChunk(t *testing.T) {
 			// Build some chunks
 			wantChunks := make([]Chunk[tx], 0)
 			for _, args := range tt.availableChunks {
-				chunk, err := node.NewChunk(
+				chunk, err := node.BuildChunk(
 					context.Background(),
 					args.txs,
 					args.expiry,
@@ -742,7 +742,7 @@ func TestNode_GetChunkSignature_SignValidChunk(t *testing.T) {
 				nil,
 			)
 			r.NoError(err)
-			chunk, err := node2.NewChunk(
+			chunk, err := node2.BuildChunk(
 				context.Background(),
 				[]tx{{ID: ids.Empty, Expiry: 123}},
 				123,
@@ -874,7 +874,7 @@ func TestNode_GetChunkSignature_DuplicateChunk(t *testing.T) {
 
 	// Accept a chunk
 	r.NoError(err)
-	chunk, err := node.NewChunk(
+	chunk, err := node.BuildChunk(
 		context.Background(),
 		[]tx{{ID: ids.Empty, Expiry: 123}},
 		123,
@@ -990,7 +990,7 @@ func TestGetChunkSignature_PersistAttestedBlocks(t *testing.T) {
 	)
 	r.NoError(err)
 
-	chunk, err := node2.NewChunk(
+	chunk, err := node2.BuildChunk(
 		context.Background(),
 		[]tx{{ID: ids.Empty, Expiry: 1}},
 		1,
@@ -1292,7 +1292,7 @@ func TestNode_NewBlock_IncludesChunkCerts(t *testing.T) {
 
 			wantChunks := make([]Chunk[tx], 0)
 			for _, chunk := range tt.chunks {
-				chunk, err := node.NewChunk(
+				chunk, err := node.BuildChunk(
 					context.Background(),
 					chunk.txs,
 					chunk.expiry,
@@ -1376,7 +1376,7 @@ func TestAccept_RequestReferencedChunks(t *testing.T) {
 	)
 	r.NoError(err)
 
-	chunk, err := node1.NewChunk(
+	chunk, err := node1.BuildChunk(
 		context.Background(),
 		[]tx{{ID: ids.GenerateTestID(), Expiry: 1}},
 		1,


### PR DESCRIPTION
This PR removes the `StatefulBlock` type from the DSMR package since DSMR will use `vm/block.go` to implement the `snowman.Block` interface and should implement the same functionality as the chain package.

This moves the `Verify` function from `StatefulBlock` into the node. Alternatively, block building could be defined separately (https://github.com/ava-labs/hypersdk/pull/1744#discussion_r1834630726).