### PR TITLE
Support targeted gossip

### DIFF
--- a/internal/gossiper/strategy.go
+++ b/internal/gossiper/strategy.go
@@ -1,0 +1,99 @@
+// Copyright (C) 2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package gossiper
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/snow/engine/common"
+	"github.com/ava-labs/avalanchego/utils/set"
+)
+
+type TargetStrategy[T any] interface {
+	Target(ctx context.Context, txs []T) ([]GossipContainer[T], error)
+}
+
+type TargetProposerConfig struct {
+	GossipProposerDiff  int
+	GossipProposerDepth int
+}
+
+func DefaultTargetProposerConfig() TargetProposerConfig {
+	return TargetProposerConfig{
+		GossipProposerDiff:  4,
+		GossipProposerDepth: 1,
+	}
+}
+
+type TargetProposers[T any] struct {
+	Validators ValidatorSet
+	Config     TargetProposerConfig
+}
+
+func (g *TargetProposers[T]) Target(ctx context.Context, txs []T) ([]GossipContainer[T], error) {
+	// Select next set of proposers and send gossip to them
+	proposers, err := g.Validators.Proposers(
+		ctx,
+		g.Config.GossipProposerDiff,
+		g.Config.GossipProposerDepth,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("%w: unable to fetch proposers", err)
+	}
+	if proposers.Len() == 0 {
+		return nil, errors.New("no proposers to gossip to")
+	}
+	recipients := set.NewSet[ids.NodeID](len(proposers))
+	for proposer := range proposers {
+		// Don't gossip to self
+		if proposer == g.Validators.NodeID() {
+			continue
+		}
+		recipients.Add(proposer)
+	}
+
+	return []GossipContainer[T]{
+		{
+			SendConfig: common.SendConfig{NodeIDs: recipients},
+			Txs:        txs,
+		},
+	}, nil
+}
+
+type TxAssigner[T any] interface {
+	AssignTxs(ctx context.Context, txs []T) (map[ids.NodeID][]T, error)
+}
+
+type TargetAssigner[T Tx] struct {
+	NodeID   ids.NodeID
+	Assigner TxAssigner[T]
+}
+
+func (t *TargetAssigner[T]) Target(ctx context.Context, txs []T) ([]GossipContainer[T], error) {
+	targetedGossip, err := t.Assigner.AssignTxs(ctx, txs)
+	if err != nil {
+		return nil, err
+	}
+
+	gossipContainers := make([]GossipContainer[T], 0, len(targetedGossip))
+
+	for targetedNodeID, txs := range targetedGossip {
+		if targetedNodeID == t.NodeID {
+			// Don't gossip to self
+			continue
+		}
+
+		// Send gossip to partitioned node
+		targetedVdrSet := set.NewSet[ids.NodeID](1)
+		targetedVdrSet.Add(targetedNodeID)
+		gossipContainers = append(gossipContainers, GossipContainer[T]{
+			SendConfig: common.SendConfig{NodeIDs: targetedVdrSet},
+			Txs:        txs,
+		})
+	}
+	return gossipContainers, nil
+}

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -549,7 +549,7 @@ func (vm *VM) applyOptions(o *Options) error {
 			return fmt.Errorf("failed to create manual gossiper: %w", err)
 		}
 	} else {
-		txGossiper, err := gossiper.NewProposer[*chain.Transaction](
+		txGossiper, err := gossiper.NewTarget[*chain.Transaction](
 			vm.tracer,
 			vm.snowCtx.Log,
 			gossipRegistry,
@@ -561,7 +561,11 @@ func (vm *VM) applyOptions(o *Options) error {
 			vm,
 			vm,
 			vm.config.TargetGossipDuration,
-			gossiper.DefaultProposerConfig(),
+			&gossiper.TargetProposers[*chain.Transaction]{
+				Validators: vm,
+				Config:     gossiper.DefaultTargetProposerConfig(),
+			},
+			gossiper.DefaultTargetConfig(),
 			vm.stop,
 		)
 		if err != nil {


### PR DESCRIPTION
This PR updates the proposer gossiper to take in a target strategy that determines where to gossip transactions. This moves the current proposer targeted logic into its own strategy and adds a new `TxAssigner` strategy that uses the following interface to assign transactions to specific nodeIDs:

```golang
type TxAssigner[T any] interface {
	AssignTxs(ctx context.Context, txs []T) (map[ids.NodeID][]T, error)
}
```

This PR + https://github.com/ava-labs/hypersdk/pull/1799 resolves https://github.com/ava-labs/hypersdk/issues/1775 to support gossiping transactions.