### PR TITLE
Rename emap interface method names

### DIFF
--- a/api/indexer/indexer.go
+++ b/api/indexer/indexer.go
@@ -169,7 +169,7 @@ func (i *Indexer) storeTransactions(blk *chain.ExecutedBlock) error {
 		result := blk.Results[j]
 		if err := i.storeTransaction(
 			batch,
-			tx.ID(),
+			tx.GetID(),
 			blk.Block.Tmstmp,
 			result.Success,
 			result.Units,

--- a/api/jsonrpc/server.go
+++ b/api/jsonrpc/server.go
@@ -105,7 +105,7 @@ func (j *JSONRPCServer) SubmitTx(
 	if !rtx.Empty() {
 		return errTransactionExtraBytes
 	}
-	txID := tx.ID()
+	txID := tx.GetID()
 	reply.TxID = txID
 	return j.vm.Submit(ctx, []*chain.Transaction{tx})[0]
 }

--- a/api/ws/server.go
+++ b/api/ws/server.go
@@ -143,7 +143,7 @@ func (w *WebSocketServer) AddTxListener(tx *chain.Transaction, c *pubsub.Connect
 	defer w.txL.Unlock()
 
 	// TODO: limit max number of tx listeners a single connection can create
-	txID := tx.ID()
+	txID := tx.GetID()
 	connections, ok := w.txListeners[txID]
 	if !ok {
 		connections = pubsub.NewConnections()
@@ -197,7 +197,7 @@ func (w *WebSocketServer) AcceptBlock(b *chain.ExecutedBlock) error {
 	defer w.txL.Unlock()
 	results := b.Results
 	for i, tx := range b.Block.Txs {
-		txID := tx.ID()
+		txID := tx.GetID()
 		listeners, ok := w.txListeners[txID]
 		if !ok {
 			continue
@@ -251,7 +251,7 @@ func (w *WebSocketServer) MessageCallback() pubsub.Callback {
 			w.AddTxListener(tx, c)
 
 			// Submit will remove from [txListeners] if it is not added
-			txID := tx.ID()
+			txID := tx.GetID()
 			if err := w.vm.Submit(ctx, []*chain.Transaction{tx})[0]; err != nil {
 				w.logger.Error("failed to submit tx",
 					zap.Stringer("txID", txID),

--- a/chain/builder.go
+++ b/chain/builder.go
@@ -221,7 +221,7 @@ func (c *Builder) BuildBlock(ctx context.Context, parentView state.View, parent 
 			// We track pending transactions because an error may cause us
 			// not to execute restorable transactions.
 			pendingLock.Lock()
-			pending[tx.ID()] = tx
+			pending[tx.GetID()] = tx
 			pendingLock.Unlock()
 			e.Run(stateKeys, func() error {
 				// We use defer here instead of covering all returns because it is
@@ -229,7 +229,7 @@ func (c *Builder) BuildBlock(ctx context.Context, parentView state.View, parent 
 				var restore bool
 				defer func() {
 					pendingLock.Lock()
-					delete(pending, tx.ID())
+					delete(pending, tx.GetID())
 					pendingLock.Unlock()
 
 					if !restore {

--- a/chain/processor.go
+++ b/chain/processor.go
@@ -39,10 +39,10 @@ func NewExecutionBlock(block *StatelessBlock) (*ExecutionBlock, error) {
 	authCounts := make(map[uint8]int)
 	txsSet := set.NewSet[ids.ID](len(block.Txs))
 	for _, tx := range block.Txs {
-		if txsSet.Contains(tx.ID()) {
+		if txsSet.Contains(tx.GetID()) {
 			return nil, ErrDuplicateTx
 		}
-		txsSet.Add(tx.ID())
+		txsSet.Add(tx.GetID())
 		authCounts[tx.Auth.GetTypeID()]++
 	}
 
@@ -336,7 +336,7 @@ func (p *Processor) executeTxs(
 		}
 
 		// Prefetch state keys from disk
-		txID := tx.ID()
+		txID := tx.GetID()
 		if err := f.Fetch(ctx, txID, stateKeys); err != nil {
 			return nil, nil, err
 		}

--- a/chain/transaction.go
+++ b/chain/transaction.go
@@ -100,7 +100,7 @@ func SignRawActionBytesTx(
 	return p.Bytes(), p.Err()
 }
 
-func (t *TransactionData) Expiry() int64 { return t.Base.Timestamp }
+func (t *TransactionData) GetExpiry() int64 { return t.Base.Timestamp }
 
 func (t *TransactionData) MaxFee() uint64 { return t.Base.MaxFee }
 
@@ -184,7 +184,7 @@ func (t *Transaction) Bytes() []byte { return t.bytes }
 
 func (t *Transaction) Size() int { return t.size }
 
-func (t *Transaction) ID() ids.ID { return t.id }
+func (t *Transaction) GetID() ids.ID { return t.id }
 
 func (t *Transaction) StateKeys(bh BalanceHandler) (state.Keys, error) {
 	if t.stateKeys != nil {
@@ -194,7 +194,7 @@ func (t *Transaction) StateKeys(bh BalanceHandler) (state.Keys, error) {
 
 	// Verify the formatting of state keys passed by the controller
 	for i, action := range t.Actions {
-		for k, v := range action.StateKeys(t.Auth.Actor(), CreateActionID(t.ID(), uint8(i))) {
+		for k, v := range action.StateKeys(t.Auth.Actor(), CreateActionID(t.GetID(), uint8(i))) {
 			if !stateKeys.Add(k, v) {
 				return nil, ErrInvalidKeyValue
 			}
@@ -341,7 +341,7 @@ func (t *Transaction) Execute(
 		actionOutputs = [][]byte{}
 	)
 	for i, action := range t.Actions {
-		actionOutput, err := action.Execute(ctx, r, ts, timestamp, t.Auth.Actor(), CreateActionID(t.ID(), uint8(i)))
+		actionOutput, err := action.Execute(ctx, r, ts, timestamp, t.Auth.Actor(), CreateActionID(t.GetID(), uint8(i)))
 		if err != nil {
 			ts.Rollback(ctx, actionStart)
 			return &Result{false, utils.ErrBytes(err), actionOutputs, units, fee}, nil
@@ -407,7 +407,7 @@ func (t *Transaction) MarshalJSON() ([]byte, error) {
 	}
 
 	return json.Marshal(txJSON{
-		ID:      t.ID(),
+		ID:      t.GetID(),
 		Actions: actionsPacker.Bytes(),
 		Auth:    authPacker.Bytes(),
 		Base:    t.Base,

--- a/chain/transaction_test.go
+++ b/chain/transaction_test.go
@@ -190,7 +190,7 @@ func TestMarshalUnmarshal(t *testing.T) {
 	writerPacker := codec.NewWriter(0, consts.NetworkSizeLimit)
 	err = signedTx.Marshal(writerPacker)
 	require.NoError(err)
-	require.Equal(signedTx.ID(), utils.ToID(writerPacker.Bytes()))
+	require.Equal(signedTx.GetID(), utils.ToID(writerPacker.Bytes()))
 	require.Equal(signedTx.Bytes(), writerPacker.Bytes())
 
 	unsignedTxBytes, err := signedTx.UnsignedBytes()

--- a/docs/tutorials/morpheusvm/4_testing.md
+++ b/docs/tutorials/morpheusvm/4_testing.md
@@ -154,7 +154,7 @@ func (g *TxGenerator) GenerateTx(ctx context.Context, uri string) (*chain.Transa
 	}
 
 	return tx, func(ctx context.Context, require *require.Assertions, uri string) {
-		confirmTx(ctx, require, uri, tx.ID(), toAddress, 1)
+		confirmTx(ctx, require, uri, tx.GetID(), toAddress, 1)
 	}, nil
 }
 ```

--- a/examples/morpheusvm/cmd/morpheus-cli/cmd/resolutions.go
+++ b/examples/morpheusvm/cmd/morpheus-cli/cmd/resolutions.go
@@ -44,20 +44,20 @@ func sendAndWait(
 		if txErr != nil {
 			return false, ids.Empty, txErr
 		}
-		if txID == tx.ID() {
+		if txID == tx.GetID() {
 			result = txResult
 			break
 		}
-		utils.Outf("{{yellow}}skipping unexpected transaction:{{/}} %s\n", tx.ID())
+		utils.Outf("{{yellow}}skipping unexpected transaction:{{/}} %s\n", tx.GetID())
 	}
 	if printStatus {
 		status := "❌"
 		if result.Success {
 			status = "✅"
 		}
-		utils.Outf("%s {{yellow}}txID:{{/}} %s\n", status, tx.ID())
+		utils.Outf("%s {{yellow}}txID:{{/}} %s\n", status, tx.GetID())
 	}
-	return result.Success, tx.ID(), nil
+	return result.Success, tx.GetID(), nil
 }
 
 func handleTx(tx *chain.Transaction, result *chain.Result) {
@@ -66,7 +66,7 @@ func handleTx(tx *chain.Transaction, result *chain.Result) {
 		utils.Outf(
 			"%s {{yellow}}%s{{/}} {{yellow}}actor:{{/}} %s {{yellow}}error:{{/}} [%s] {{yellow}}fee (max %.2f%%):{{/}} %s %s {{yellow}}consumed:{{/}} [%s]\n",
 			"❌",
-			tx.ID(),
+			tx.GetID(),
 			actor,
 			result.Error,
 			float64(result.Fee)/float64(tx.Base.MaxFee)*100,
@@ -86,7 +86,7 @@ func handleTx(tx *chain.Transaction, result *chain.Result) {
 		utils.Outf(
 			"%s {{yellow}}%s{{/}} {{yellow}}actor:{{/}} %s {{yellow}}summary (%s):{{/}} [%s] {{yellow}}fee (max %.2f%%):{{/}} %s %s {{yellow}}consumed:{{/}} [%s]\n",
 			"✅",
-			tx.ID(),
+			tx.GetID(),
 			actor,
 			reflect.TypeOf(action),
 			summaryStr,

--- a/examples/morpheusvm/tests/workload/generator.go
+++ b/examples/morpheusvm/tests/workload/generator.go
@@ -65,7 +65,7 @@ func (g *TxGenerator) GenerateTx(ctx context.Context, uri string) (*chain.Transa
 	}
 
 	return tx, func(ctx context.Context, require *require.Assertions, uri string) {
-		confirmTx(ctx, require, uri, tx.ID(), toAddress, 1)
+		confirmTx(ctx, require, uri, tx.GetID(), toAddress, 1)
 	}, nil
 }
 

--- a/internal/eheap/eheap.go
+++ b/internal/eheap/eheap.go
@@ -11,8 +11,8 @@ import (
 
 // Item is the interface that any item put in the heap must adheare to.
 type Item interface {
-	ID() ids.ID
-	Expiry() int64
+	GetID() ids.ID
+	GetExpiry() int64
 }
 
 // ExpiryHeap keeps a min heap of [Items] sorted by [Expiry].
@@ -35,11 +35,11 @@ func New[T Item](items int) *ExpiryHeap[T] {
 
 // Add pushes [item] to eh.
 func (eh *ExpiryHeap[T]) Add(item T) {
-	itemID := item.ID()
+	itemID := item.GetID()
 	poolLen := eh.minHeap.Len()
 	eh.minHeap.Push(&heap.Entry[T, int64]{
 		ID:    itemID,
-		Val:   item.Expiry(),
+		Val:   item.GetExpiry(),
 		Item:  item,
 		Index: poolLen,
 	})
@@ -66,7 +66,7 @@ func (eh *ExpiryHeap[T]) SetMin(val int64) []T {
 		if !ok {
 			break
 		}
-		if min.Expiry() < val {
+		if min.GetExpiry() < val {
 			eh.PopMin() // Assumes that there is not concurrent access to [ExpiryHeap]
 			removed = append(removed, min)
 			continue
@@ -92,7 +92,7 @@ func (eh *ExpiryHeap[T]) PopMin() (T, bool) {
 		return *new(T), false
 	}
 	item := first.Item
-	eh.Remove(item.ID())
+	eh.Remove(item.GetID())
 	return item, true
 }
 

--- a/internal/eheap/eheap_test.go
+++ b/internal/eheap/eheap_test.go
@@ -18,7 +18,7 @@ type TestItem struct {
 	timestamp int64
 }
 
-func (mti *TestItem) ID() ids.ID {
+func (mti *TestItem) GetID() ids.ID {
 	return mti.id
 }
 
@@ -26,7 +26,7 @@ func (mti *TestItem) Sponsor() string {
 	return mti.sponsor
 }
 
-func (mti *TestItem) Expiry() int64 {
+func (mti *TestItem) GetExpiry() int64 {
 	return mti.timestamp
 }
 
@@ -53,7 +53,7 @@ func TestExpiryHeapAdd(t *testing.T) {
 	item := GenerateTestItem("sponsor", 1)
 	eheap.Add(item)
 	require.Equal(1, eheap.minHeap.Len(), "MinHeap not pushed correctly")
-	require.True(eheap.minHeap.Has(item.ID()), "MinHeap does not have ID")
+	require.True(eheap.minHeap.Has(item.GetID()), "MinHeap does not have ID")
 }
 
 func TestExpiryHeapRemove(t *testing.T) {
@@ -64,11 +64,11 @@ func TestExpiryHeapRemove(t *testing.T) {
 	// Add first
 	eheap.Add(item)
 	require.Equal(1, eheap.minHeap.Len(), "MinHeap not pushed correctly")
-	require.True(eheap.minHeap.Has(item.ID()), "MinHeap does not have ID")
+	require.True(eheap.minHeap.Has(item.GetID()), "MinHeap does not have ID")
 	// Remove
-	eheap.Remove(item.ID())
+	eheap.Remove(item.GetID())
 	require.Zero(eheap.minHeap.Len(), "MinHeap not removed")
-	require.False(eheap.minHeap.Has(item.ID()), "MinHeap still has ID")
+	require.False(eheap.minHeap.Has(item.GetID()), "MinHeap still has ID")
 }
 
 func TestExpiryHeapRemoveEmpty(t *testing.T) {
@@ -78,7 +78,7 @@ func TestExpiryHeapRemoveEmpty(t *testing.T) {
 	eheap := New[*TestItem](0)
 	item := GenerateTestItem("sponsor", 1)
 	// Require this returns
-	eheap.Remove(item.ID())
+	eheap.Remove(item.GetID())
 	require.True(true, "not true")
 }
 
@@ -89,7 +89,7 @@ func TestSetMin(t *testing.T) {
 	for i := int64(0); i <= 9; i++ {
 		item := GenerateTestItem(sponsor, i)
 		eheap.Add(item)
-		require.True(eheap.Has(item.ID()), "TX not included")
+		require.True(eheap.Has(item.GetID()), "TX not included")
 	}
 	// Remove half
 	removed := eheap.SetMin(5)
@@ -97,10 +97,10 @@ func TestSetMin(t *testing.T) {
 	// All timestamps less than 5
 	seen := make(map[int64]bool)
 	for _, item := range removed {
-		require.Less(item.Expiry(), int64(5))
-		_, ok := seen[item.Expiry()]
+		require.Less(item.GetExpiry(), int64(5))
+		_, ok := seen[item.GetExpiry()]
 		require.False(ok, "Incorrect item removed.")
-		seen[item.Expiry()] = true
+		seen[item.GetExpiry()] = true
 	}
 	// ExpiryHeap has same length
 	require.Equal(5, eheap.Len(), "ExpiryHeap has incorrect number of txs.")
@@ -115,7 +115,7 @@ func TestSetMinRemovesAll(t *testing.T) {
 		item := GenerateTestItem(sponsor, i)
 		items = append(items, item)
 		eheap.Add(item)
-		require.True(eheap.Has(item.ID()), "TX not included")
+		require.True(eheap.Has(item.GetID()), "TX not included")
 	}
 	// Remove more than exists
 	removed := eheap.SetMin(10)
@@ -136,19 +136,19 @@ func TestPeekMin(t *testing.T) {
 	require.Nil(min, "Peek UnitPrice is incorrect")
 	// Check PeekMin
 	eheap.Add(itemMed)
-	require.True(eheap.Has(itemMed.ID()), "TX not included")
+	require.True(eheap.Has(itemMed.GetID()), "TX not included")
 	min, ok = eheap.PeekMin()
 	require.True(ok)
 	require.Equal(itemMed, min, "Peek value is incorrect")
 
 	eheap.Add(itemMin)
-	require.True(eheap.Has(itemMin.ID()), "TX not included")
+	require.True(eheap.Has(itemMin.GetID()), "TX not included")
 	min, ok = eheap.PeekMin()
 	require.True(ok)
 	require.Equal(itemMin, min, "Peek value is incorrect")
 
 	eheap.Add(itemMax)
-	require.True(eheap.Has(itemMax.ID()), "TX not included")
+	require.True(eheap.Has(itemMax.GetID()), "TX not included")
 	min, ok = eheap.PeekMin()
 	require.True(ok)
 	require.Equal(itemMin, min, "Peek value is incorrect")
@@ -185,9 +185,9 @@ func TestHas(t *testing.T) {
 
 	eheap := New[*TestItem](0)
 	item := GenerateTestItem(testSponsor, 1)
-	require.False(eheap.Has(item.ID()), "Found an item that was not added.")
+	require.False(eheap.Has(item.GetID()), "Found an item that was not added.")
 	eheap.Add(item)
-	require.True(eheap.Has(item.ID()), "Did not find item.")
+	require.True(eheap.Has(item.GetID()), "Did not find item.")
 }
 
 func TestLen(t *testing.T) {
@@ -197,7 +197,7 @@ func TestLen(t *testing.T) {
 	for i := int64(0); i <= 4; i++ {
 		item := GenerateTestItem(testSponsor, i)
 		eheap.Add(item)
-		require.True(eheap.Has(item.ID()), "TX not included")
+		require.True(eheap.Has(item.GetID()), "TX not included")
 	}
 	require.Equal(5, eheap.Len(), "Length of mempool is not as expected.")
 }

--- a/internal/emap/emap.go
+++ b/internal/emap/emap.go
@@ -19,8 +19,8 @@ type bucket struct {
 
 // Item defines an interface accepted by EMap
 type Item interface {
-	ID() ids.ID    // method for returning an id of the item
-	Expiry() int64 // method for returning this items timestamp
+	GetID() ids.ID    // method for returning an id of the item
+	GetExpiry() int64 // method for returning this items timestamp
 }
 
 // A Emap implements en eviction map that stores the status
@@ -49,7 +49,7 @@ func (e *EMap[T]) Add(items []T) {
 	defer e.mu.Unlock()
 
 	for _, item := range items {
-		e.add(item.ID(), item.Expiry())
+		e.add(item.GetID(), item.GetExpiry())
 	}
 }
 
@@ -118,7 +118,7 @@ func (e *EMap[T]) Any(items []T) bool {
 	defer e.mu.RUnlock()
 
 	for _, item := range items {
-		if e.seen.Contains(item.ID()) {
+		if e.seen.Contains(item.GetID()) {
 			return true
 		}
 	}
@@ -133,7 +133,7 @@ func (e *EMap[T]) Contains(items []T, marker set.Bits, stop bool) set.Bits {
 		if marker.Contains(i) {
 			continue
 		}
-		if e.seen.Contains(item.ID()) {
+		if e.seen.Contains(item.GetID()) {
 			marker.Add(i)
 			if stop {
 				return marker

--- a/internal/emap/emap_test.go
+++ b/internal/emap/emap_test.go
@@ -18,8 +18,8 @@ type TestTx struct {
 	t  int64
 }
 
-func (tx *TestTx) ID() ids.ID    { return tx.id }
-func (tx *TestTx) Expiry() int64 { return tx.t }
+func (tx *TestTx) GetID() ids.ID    { return tx.id }
+func (tx *TestTx) GetExpiry() int64 { return tx.t }
 
 func TestEmapNew(t *testing.T) {
 	require := require.New(t)
@@ -46,7 +46,7 @@ func TestEmapAddIDGenesis(t *testing.T) {
 	txs := []*TestTx{tx}
 	e.Add(txs)
 	// Seen was updated
-	_, okSeen := e.seen[tx.ID()]
+	_, okSeen := e.seen[tx.GetID()]
 	require.False(okSeen, "Genesis timestamp was incorrectly added")
 	// Get bucket
 	_, okBucket := e.times[0]
@@ -71,7 +71,7 @@ func TestEmapAddIDNewBucket(t *testing.T) {
 	e.Add(txs)
 
 	// seen was updated
-	_, okSeen := e.seen[tx.ID()]
+	_, okSeen := e.seen[tx.GetID()]
 	require.True(okSeen, "Could not find id in seen map")
 	// get bucket
 	b, okBucket := e.times[timestamp]
@@ -94,7 +94,7 @@ func TestEmapAddIDExists(t *testing.T) {
 	}
 	txs := []*TestTx{tx1}
 	e.Add(txs)
-	_, okSeen := e.seen[tx1.ID()]
+	_, okSeen := e.seen[tx1.GetID()]
 	require.True(okSeen, "Could not find id in seen map")
 
 	entry, ok := e.bh.Get(id)
@@ -140,12 +140,12 @@ func TestEmapAddIDBucketExists(t *testing.T) {
 	}
 	txs := []*TestTx{tx1}
 	e.Add(txs)
-	_, okSeen := e.seen[tx1.ID()]
+	_, okSeen := e.seen[tx1.GetID()]
 	require.True(okSeen, "Could not find id in seen map")
 	txs = []*TestTx{tx2}
 	e.Add(txs)
 	// seen was updated
-	_, okSeen = e.seen[tx2.ID()]
+	_, okSeen = e.seen[tx2.GetID()]
 	require.True(okSeen, "Could not find id in seen map")
 	// get bucket
 	b, okBucket := e.times[timestamp]

--- a/internal/gossiper/dependencies.go
+++ b/internal/gossiper/dependencies.go
@@ -35,7 +35,7 @@ type ValidatorSet interface {
 }
 
 type Tx interface {
-	ID() ids.ID
-	Expiry() int64
+	GetID() ids.ID
+	GetExpiry() int64
 	Size() int
 }

--- a/internal/gossiper/manual.go
+++ b/internal/gossiper/manual.go
@@ -73,7 +73,7 @@ func (g *Manual[T]) Force(ctx context.Context) error {
 		g.targetGossipDuration,
 		func(_ context.Context, next T) (cont bool, rest bool, err error) {
 			// Remove txs that are expired
-			if next.Expiry() < now {
+			if next.GetExpiry() < now {
 				return true, false, nil
 			}
 

--- a/internal/gossiper/proposer.go
+++ b/internal/gossiper/proposer.go
@@ -153,12 +153,12 @@ func (g *Proposer[T]) Force(ctx context.Context) error {
 		g.targetGossipDuration,
 		func(_ context.Context, next T) (cont bool, rest bool, err error) {
 			// Remove txs that are expired
-			if next.Expiry() < now {
+			if next.GetExpiry() < now {
 				return true, false, nil
 			}
 
 			// Don't gossip txs that are about to expire
-			life := next.Expiry() - now
+			life := next.GetExpiry() - now
 			if life < g.cfg.GossipMinLife {
 				return true, true, nil
 			}
@@ -172,7 +172,7 @@ func (g *Proposer[T]) Force(ctx context.Context) error {
 			// Don't remove anything from mempool
 			// that will be dropped (this seems
 			// like we sent it then got sent it back?)
-			txID := next.ID()
+			txID := next.GetID()
 			if _, ok := g.cache.Get(txID); ok {
 				return true, true, nil
 			}
@@ -211,7 +211,7 @@ func (g *Proposer[T]) HandleAppGossip(ctx context.Context, nodeID ids.NodeID, ms
 		// Add incoming txs to the cache to make
 		// sure we never gossip anything we receive (someone
 		// else will)
-		if g.cache.Put(tx.ID(), nil) {
+		if g.cache.Put(tx.GetID(), nil) {
 			seen++
 		}
 	}

--- a/internal/list/list.go
+++ b/internal/list/list.go
@@ -11,8 +11,8 @@ import "github.com/ava-labs/avalanchego/ids"
 // allows us to avoid wrapping [Element] when using it with [emap]
 // and/or [eheap].
 type Item interface {
-	ID() ids.ID    // method for returning an id of the item
-	Expiry() int64 // method for returning this items timestamp
+	GetID() ids.ID    // method for returning an id of the item
+	GetExpiry() int64 // method for returning this items timestamp
 }
 
 // List implements a double-linked list. It offers
@@ -56,12 +56,12 @@ func (e *Element[T]) Value() T {
 	return e.value
 }
 
-func (e *Element[T]) ID() ids.ID {
-	return e.value.ID()
+func (e *Element[T]) GetID() ids.ID {
+	return e.value.GetID()
 }
 
-func (e *Element[T]) Expiry() int64 {
-	return e.value.Expiry()
+func (e *Element[T]) GetExpiry() int64 {
+	return e.value.GetExpiry()
 }
 
 func (l *List[T]) First() *Element[T] {

--- a/internal/list/list_test.go
+++ b/internal/list/list_test.go
@@ -17,7 +17,7 @@ type TestItem struct {
 	timestamp int64
 }
 
-func (mti *TestItem) ID() ids.ID {
+func (mti *TestItem) GetID() ids.ID {
 	return mti.id
 }
 
@@ -25,7 +25,7 @@ func (mti *TestItem) Str() string {
 	return mti.str
 }
 
-func (mti *TestItem) Expiry() int64 {
+func (mti *TestItem) GetExpiry() int64 {
 	return mti.timestamp
 }
 

--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -116,7 +116,7 @@ func (m *Mempool[T]) add(items []T, front bool) {
 		sender := item.Sponsor()
 
 		// Ensure no duplicate
-		itemID := item.ID()
+		itemID := item.GetID()
 		if m.streamedItems != nil && m.streamedItems.Contains(itemID) {
 			continue
 		}
@@ -182,7 +182,7 @@ func (m *Mempool[T]) popNext() (T, bool) {
 		return *new(T), false
 	}
 	v := m.queue.Remove(first)
-	m.eh.Remove(v.ID())
+	m.eh.Remove(v.GetID())
 	m.removeFromOwned(v)
 	m.pendingSize -= v.Size()
 	return v, true
@@ -197,7 +197,7 @@ func (m *Mempool[T]) Remove(ctx context.Context, items []T) {
 	defer m.mu.Unlock()
 
 	for _, item := range items {
-		elem, ok := m.eh.Remove(item.ID())
+		elem, ok := m.eh.Remove(item.GetID())
 		if !ok {
 			continue
 		}
@@ -335,7 +335,7 @@ func (m *Mempool[T]) streamItems(count int) []T {
 		if !ok {
 			break
 		}
-		m.streamedItems.Add(item.ID())
+		m.streamedItems.Add(item.GetID())
 		txs = append(txs, item)
 	}
 	return txs

--- a/internal/mempool/mempool_test.go
+++ b/internal/mempool/mempool_test.go
@@ -22,7 +22,7 @@ type TestItem struct {
 	timestamp int64
 }
 
-func (mti *TestItem) ID() ids.ID {
+func (mti *TestItem) GetID() ids.ID {
 	return mti.id
 }
 
@@ -30,7 +30,7 @@ func (mti *TestItem) Sponsor() codec.Address {
 	return mti.sponsor
 }
 
-func (mti *TestItem) Expiry() int64 {
+func (mti *TestItem) GetExpiry() int64 {
 	return mti.timestamp
 }
 
@@ -61,7 +61,7 @@ func TestMempool(t *testing.T) {
 	}
 	next, ok := txm.PeekNext(ctx)
 	require.True(ok)
-	require.Equal(int64(100), next.Expiry())
+	require.Equal(int64(100), next.GetExpiry())
 	require.Equal(3, txm.Len(ctx))
 	require.Equal(6, txm.Size(ctx))
 }
@@ -78,7 +78,7 @@ func TestMempoolAddDuplicates(t *testing.T) {
 	require.Equal(1, txm.Len(ctx), "Item not added.")
 	next, ok := txm.PeekNext(ctx)
 	require.True(ok)
-	require.Equal(int64(300), next.Expiry())
+	require.Equal(int64(300), next.GetExpiry())
 	// Add again
 	txm.Add(ctx, items)
 	require.Equal(1, txm.Len(ctx), "Item not added.")
@@ -114,16 +114,16 @@ func TestMempoolAddExceedMaxSize(t *testing.T) {
 		items := []*TestItem{item}
 		txm.Add(ctx, items)
 		if i < 3 {
-			require.True(txm.Has(ctx, item.ID()), "TX not included")
+			require.True(txm.Has(ctx, item.GetID()), "TX not included")
 		} else {
-			require.False(txm.Has(ctx, item.ID()), "TX included")
+			require.False(txm.Has(ctx, item.GetID()), "TX included")
 		}
 	}
 	// Pop and check values
 	for i := int64(0); i < 3; i++ {
 		popped, ok := txm.PopNext(ctx)
 		require.True(ok)
-		require.Equal(i, popped.Expiry(), "Mempool did not pop correct tx.")
+		require.Equal(i, popped.GetExpiry(), "Mempool did not pop correct tx.")
 	}
 	_, ok := txm.owned[testSponsor]
 	require.False(ok, "Sponsor not removed from owned.")
@@ -140,7 +140,7 @@ func TestMempoolRemoveTxs(t *testing.T) {
 	item := GenerateTestItem(testSponsor, 10)
 	items := []*TestItem{item}
 	txm.Add(ctx, items)
-	require.True(txm.Has(ctx, item.ID()), "TX not included")
+	require.True(txm.Has(ctx, item.GetID()), "TX not included")
 	// Remove
 	itemNotIn := GenerateTestItem(testSponsor, 10)
 	items = []*TestItem{item, itemNotIn}
@@ -159,7 +159,7 @@ func TestMempoolSetMinTimestamp(t *testing.T) {
 		item := GenerateTestItem(testSponsor, i)
 		items := []*TestItem{item}
 		txm.Add(ctx, items)
-		require.True(txm.Has(ctx, item.ID()), "TX not included")
+		require.True(txm.Has(ctx, item.GetID()), "TX not included")
 	}
 	// Remove half
 	removed := txm.SetMinTimestamp(ctx, 5)
@@ -167,10 +167,10 @@ func TestMempoolSetMinTimestamp(t *testing.T) {
 	// All timestamps less than 5
 	seen := make(map[int64]bool)
 	for _, item := range removed {
-		require.Less(item.Expiry(), int64(5))
-		_, ok := seen[item.Expiry()]
+		require.Less(item.GetExpiry(), int64(5))
+		_, ok := seen[item.GetExpiry()]
 		require.False(ok)
-		seen[item.Expiry()] = true
+		seen[item.GetExpiry()] = true
 	}
 	// Mempool has same length
 	require.Equal(5, txm.Len(ctx), "Mempool has incorrect number of txs.")

--- a/internal/validitywindow/validitywindow.go
+++ b/internal/validitywindow/validitywindow.go
@@ -110,7 +110,7 @@ func (v *TimeValidityWindow[Container]) isRepeat(
 			if marker.Contains(i) {
 				continue
 			}
-			if ancestorBlk.ContainsTx(tx.ID()) {
+			if ancestorBlk.ContainsTx(tx.GetID()) {
 				marker.Add(i)
 				if stop {
 					return marker, nil

--- a/tests/integration/integration.go
+++ b/tests/integration/integration.go
@@ -611,7 +611,7 @@ var _ = ginkgo.Describe("[Tx Processing]", ginkgo.Serial, func() {
 		// Read decision from connection
 		txID, dErr, result, err := cli.ListenTx(context.TODO())
 		require.NoError(err)
-		require.Equal(txID, tx.ID())
+		require.Equal(txID, tx.GetID())
 		require.NoError(dErr)
 		require.True(result.Success)
 		require.Equal(result, results[0])

--- a/tests/integration/network.go
+++ b/tests/integration/network.go
@@ -120,7 +120,7 @@ func (i *instance) confirmTxs(ctx context.Context, txs []*chain.Transaction) err
 	expectBlk(i)(false)
 
 	for _, tx := range txs {
-		err := i.confirmTx(ctx, tx.ID())
+		err := i.confirmTx(ctx, tx.GetID())
 		if err != nil {
 			return err
 		}
@@ -164,7 +164,7 @@ func (i *instance) confirmTx(ctx context.Context, txid ids.ID) error {
 			return ErrTxNotFound
 		}
 		for _, tx := range stflBlk.StatelessBlock.Txs {
-			if tx.ID() == txid {
+			if tx.GetID() == txid {
 				// found.
 				return nil
 			}

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -978,7 +978,7 @@ func (vm *VM) Submit(
 	validTxs := []*chain.Transaction{}
 	for _, tx := range txs {
 		// Avoid any sig verification or state lookup if we already have tx in mempool
-		txID := tx.ID()
+		txID := tx.GetID()
 		if vm.mempool.Has(ctx, txID) {
 			// Don't remove from listeners, it will be removed elsewhere if not
 			// included

--- a/x/dsmr/storage.go
+++ b/x/dsmr/storage.go
@@ -315,10 +315,10 @@ type emapChunk[T Tx] struct {
 	chunk Chunk[T]
 }
 
-func (e emapChunk[_]) ID() ids.ID {
+func (e emapChunk[_]) GetID() ids.ID {
 	return e.chunk.id
 }
 
-func (e emapChunk[_]) Expiry() int64 {
+func (e emapChunk[_]) GetExpiry() int64 {
 	return e.chunk.Expiry
 }


### PR DESCRIPTION
## What ?

As part of having the shared `validitywindow` implementation being used within the `dsmr`, the entries that would be contained would be better off implementing the same interface.

The dsmr's interface ( i.e. `Tx` ) already using `GetID()` and `GetExpiry()`, which seems to be "better" compared to the `emap.Item`'s  `ID()` and `Expiry()` as there would clash with member names.

This PR is a followup on https://github.com/ava-labs/hypersdk/pull/1782, and part of [Generalize expiry based de-duplication]( https://github.com/ava-labs/hypersdk/issues/1771)

