### PR TITLE
Target metrics

### DIFF
--- a/internal/gossiper/metrics.go
+++ b/internal/gossiper/metrics.go
@@ -8,28 +8,54 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+const namespace = "gossiper"
+
 type metrics struct {
-	txsReceived     prometheus.Counter
-	seenTxsReceived prometheus.Counter
-	txsGossiped     prometheus.Counter
+	txsReceived            prometheus.Counter
+	seenTxsReceived        prometheus.Counter
+	txsGossiped            prometheus.Counter
+	selectTxsToGossipCount prometheus.Counter
+	selectTxsToGossipSum   prometheus.Gauge
+	selectedTxsToGossip    prometheus.Counter
+	targetTxsSum           prometheus.Gauge
 }
 
 func newMetrics(r prometheus.Registerer) (*metrics, error) {
 	m := &metrics{
 		txsReceived: prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: "gossiper",
+			Namespace: namespace,
 			Name:      "txs_received",
 			Help:      "number of txs received over gossip",
 		}),
 		txsGossiped: prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: "gossiper",
+			Namespace: namespace,
 			Name:      "txs_gossiped",
 			Help:      "number of txs gossiped",
 		}),
 		seenTxsReceived: prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: "gossiper",
+			Namespace: namespace,
 			Name:      "seen_txs_received",
 			Help:      "number of txs received over gossip that were already seen",
+		}),
+		selectTxsToGossipCount: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "select_txs_to_gossip_count",
+			Help:      "number of times gossiper iterates mempool to select txs for gossip",
+		}),
+		selectTxsToGossipSum: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "select_txs_to_gossip_sum",
+			Help:      "sum of time spent iterating mempool to select txs for gossip",
+		}),
+		selectedTxsToGossip: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "selected_txs_to_gossip",
+			Help:      "number of txs selected for gossip",
+		}),
+		targetTxsSum: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "target_txs_sum",
+			Help:      "sum of time spent selecting target for txs gossip",
 		}),
 	}
 	errs := wrappers.Errs{}
@@ -37,6 +63,10 @@ func newMetrics(r prometheus.Registerer) (*metrics, error) {
 		r.Register(m.txsReceived),
 		r.Register(m.txsGossiped),
 		r.Register(m.seenTxsReceived),
+		r.Register(m.selectTxsToGossipCount),
+		r.Register(m.selectTxsToGossipSum),
+		r.Register(m.selectedTxsToGossip),
+		r.Register(m.targetTxsSum),
 	)
 	return m, errs.Err
 }

--- a/internal/gossiper/strategy.go
+++ b/internal/gossiper/strategy.go
@@ -12,6 +12,11 @@ import (
 	"github.com/ava-labs/avalanchego/utils/set"
 )
 
+var (
+	_ TargetStrategy[Tx] = (*TargetProposers[Tx])(nil)
+	_ TargetStrategy[Tx] = (*TargetAssigner[Tx])(nil)
+)
+
 type TargetStrategy[T any] interface {
 	Target(ctx context.Context, txs []T) ([]GossipContainer[T], error)
 }


### PR DESCRIPTION
This PR add target specific metrics into the gossiper and renames `g` to `t` as the pointer receiver for `*gossiper.Target`.