### PR TITLE
tests: init pre-funded local authFactories and URIs usage

### DIFF
--- a/examples/morpheusvm/tests/transfer.go
+++ b/examples/morpheusvm/tests/transfer.go
@@ -26,15 +26,16 @@ var TestsRegistry = &registry.Registry{}
 var _ = registry.Register(TestsRegistry, "Transfer Transaction",
 	func(t ginkgo.FullGinkgoTInterface, tn tworkload.TestNetwork, authFactories ...chain.AuthFactory) {
 		require := require.New(t)
+		ctx := context.Background()
 		targetFactory := authFactories[0]
+		authFactory := tn.Configuration().AuthFactories()[0]
 
 		client := jsonrpc.NewJSONRPCClient(tn.URIs()[0])
-		balance, err := client.GetBalance(context.Background(), targetFactory.Address())
+		balance, err := client.GetBalance(ctx, targetFactory.Address())
 		require.NoError(err)
 		require.Equal(uint64(1000), balance)
 
-		authFactory := tn.Configuration().AuthFactories()[0]
-		tx, err := tn.GenerateTx(context.Background(), []chain.Action{&actions.Transfer{
+		tx, err := tn.GenerateTx(ctx, []chain.Action{&actions.Transfer{
 			To:    targetFactory.Address(),
 			Value: 1,
 		}},
@@ -46,7 +47,7 @@ var _ = registry.Register(TestsRegistry, "Transfer Transaction",
 		defer timeoutCtxFnc()
 		require.NoError(tn.ConfirmTxs(timeoutCtx, []*chain.Transaction{tx}))
 
-		balance, err = client.GetBalance(context.Background(), targetFactory.Address())
+		balance, err = client.GetBalance(ctx, targetFactory.Address())
 		require.NoError(err)
 		require.Equal(uint64(1001), balance)
 	}, 1000)

--- a/examples/morpheusvm/tests/transfer.go
+++ b/examples/morpheusvm/tests/transfer.go
@@ -9,9 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ava-labs/hypersdk/auth"
 	"github.com/ava-labs/hypersdk/chain"
-	"github.com/ava-labs/hypersdk/crypto/ed25519"
 	"github.com/ava-labs/hypersdk/examples/morpheusvm/actions"
 	"github.com/ava-labs/hypersdk/tests/registry"
 
@@ -24,23 +22,22 @@ import (
 // ref https://onsi.github.io/ginkgo/#mental-model-how-ginkgo-traverses-the-spec-hierarchy
 var TestsRegistry = &registry.Registry{}
 
-var _ = registry.Register(TestsRegistry, "Transfer Transaction", func(t ginkgo.FullGinkgoTInterface, tn tworkload.TestNetwork) {
-	require := require.New(t)
-	other, err := ed25519.GeneratePrivateKey()
-	require.NoError(err)
-	toAddress := auth.NewED25519Address(other.PublicKey())
+var _ = registry.Register(TestsRegistry, "Transfer Transaction",
+	func(t ginkgo.FullGinkgoTInterface, tn tworkload.TestNetwork, authFactories ...chain.AuthFactory) {
+		require := require.New(t)
+		targetFactory := authFactories[0]
 
-	authFactory := tn.Configuration().AuthFactories()[0]
-	tx, err := tn.GenerateTx(context.Background(), []chain.Action{&actions.Transfer{
-		To:    toAddress,
-		Value: 1,
-	}},
-		authFactory,
-	)
-	require.NoError(err)
+		authFactory := tn.Configuration().AuthFactories()[0]
+		tx, err := tn.GenerateTx(context.Background(), []chain.Action{&actions.Transfer{
+			To:    targetFactory.Address(),
+			Value: 1,
+		}},
+			authFactory,
+		)
+		require.NoError(err)
 
-	timeoutCtx, timeoutCtxFnc := context.WithDeadline(context.Background(), time.Now().Add(30*time.Second))
-	defer timeoutCtxFnc()
+		timeoutCtx, timeoutCtxFnc := context.WithDeadline(context.Background(), time.Now().Add(30*time.Second))
+		defer timeoutCtxFnc()
 
-	require.NoError(tn.ConfirmTxs(timeoutCtx, []*chain.Transaction{tx}))
-})
+		require.NoError(tn.ConfirmTxs(timeoutCtx, []*chain.Transaction{tx}))
+	}, 1000)

--- a/examples/morpheusvm/tests/workload/genesis.go
+++ b/examples/morpheusvm/tests/workload/genesis.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ava-labs/hypersdk/codec"
 	"github.com/ava-labs/hypersdk/crypto/ed25519"
 	"github.com/ava-labs/hypersdk/examples/morpheusvm/consts"
+	"github.com/ava-labs/hypersdk/examples/morpheusvm/tests"
 	"github.com/ava-labs/hypersdk/examples/morpheusvm/vm"
 	"github.com/ava-labs/hypersdk/fees"
 	"github.com/ava-labs/hypersdk/genesis"
@@ -32,7 +33,7 @@ var ed25519HexKeys = []string{
 	"8a7be2e0c9a2d09ac2861c34326d6fe5a461d920ba9c2b345ae28e603d517df148735063f8d5d8ba79ea4668358943e5c80bc09e9b2b9a15b5b15db6c1862e88", //nolint:lll
 }
 
-func newGenesis(authFactories []chain.AuthFactory, minBlockGap time.Duration) *genesis.DefaultGenesis {
+func newGenesis(authFactories []chain.AuthFactory, testsLocalAllocations []*genesis.CustomAllocation, minBlockGap time.Duration) *genesis.DefaultGenesis {
 	// allocate the initial balance to the addresses
 	customAllocs := make([]*genesis.CustomAllocation, 0, len(authFactories))
 	for _, authFactory := range authFactories {
@@ -41,6 +42,7 @@ func newGenesis(authFactories []chain.AuthFactory, minBlockGap time.Duration) *g
 			Balance: InitialBalance,
 		})
 	}
+	customAllocs = append(customAllocs, testsLocalAllocations...)
 
 	genesis := genesis.NewDefaultGenesis(customAllocs)
 
@@ -72,7 +74,8 @@ func newDefaultAuthFactories() []chain.AuthFactory {
 
 func NewTestNetworkConfig(minBlockGap time.Duration) (workload.DefaultTestNetworkConfiguration, error) {
 	keys := newDefaultAuthFactories()
-	genesis := newGenesis(keys, minBlockGap)
+	testsLocalAllocations := tests.TestsRegistry.GetRequestedAllocations()
+	genesis := newGenesis(keys, testsLocalAllocations, minBlockGap)
 	genesisBytes, err := json.Marshal(genesis)
 	if err != nil {
 		return workload.DefaultTestNetworkConfiguration{}, err

--- a/examples/morpheusvm/tests/workload/genesis.go
+++ b/examples/morpheusvm/tests/workload/genesis.go
@@ -74,7 +74,16 @@ func newDefaultAuthFactories() []chain.AuthFactory {
 
 func NewTestNetworkConfig(minBlockGap time.Duration) (workload.DefaultTestNetworkConfiguration, error) {
 	keys := newDefaultAuthFactories()
-	testsLocalAllocations := tests.TestsRegistry.GetRequestedAllocations()
+	testsLocalAllocations, err := tests.TestsRegistry.GenerateCustomAllocations(func() (chain.AuthFactory, error) {
+		privateKey, err := ed25519.GeneratePrivateKey()
+		if err != nil {
+			return nil, err
+		}
+		return auth.NewED25519Factory(privateKey), nil
+	})
+	if err != nil {
+		return workload.DefaultTestNetworkConfiguration{}, err
+	}
 	genesis := newGenesis(keys, testsLocalAllocations, minBlockGap)
 	genesisBytes, err := json.Marshal(genesis)
 	if err != nil {

--- a/tests/e2e/e2e.go
+++ b/tests/e2e/e2e.go
@@ -249,7 +249,7 @@ var _ = ginkgo.Describe("[Custom VM Tests]", ginkgo.Serial, func() {
 		for _, test := range testRegistry.List() {
 			ginkgo.It(test.Name, func() {
 				testNetwork := NewNetwork(tc)
-				test.Fnc(ginkgo.GinkgoT(), testNetwork)
+				test.Fnc(ginkgo.GinkgoT(), testNetwork, test.AuthFactories...)
 			})
 		}
 	}

--- a/tests/integration/integration.go
+++ b/tests/integration/integration.go
@@ -624,7 +624,7 @@ var _ = ginkgo.Describe("[Tx Processing]", ginkgo.Serial, func() {
 		for _, test := range testRegistry.List() {
 			ginkgo.It(fmt.Sprintf("Custom VM Test '%s'", test.Name), func() {
 				require.NoError(testNetwork.SynchronizeNetwork(context.Background()))
-				test.Fnc(ginkgo.GinkgoT(), testNetwork)
+				test.Fnc(ginkgo.GinkgoT(), testNetwork, test.AuthFactories...)
 			})
 		}
 	}

--- a/tests/registry/registry.go
+++ b/tests/registry/registry.go
@@ -6,21 +6,36 @@ package registry
 import (
 	"github.com/onsi/ginkgo/v2"
 
+	"github.com/ava-labs/hypersdk/auth"
+	"github.com/ava-labs/hypersdk/chain"
+	"github.com/ava-labs/hypersdk/crypto/ed25519"
+	"github.com/ava-labs/hypersdk/genesis"
 	"github.com/ava-labs/hypersdk/tests/workload"
 )
 
-type TestFunc func(t ginkgo.FullGinkgoTInterface, tn workload.TestNetwork)
+type TestFunc func(t ginkgo.FullGinkgoTInterface, tn workload.TestNetwork, authFactories ...chain.AuthFactory)
 
 type namedTest struct {
-	Fnc  TestFunc
-	Name string
+	Fnc           TestFunc
+	Name          string
+	AuthFactories []chain.AuthFactory
 }
 type Registry struct {
-	tests []namedTest
+	tests                []namedTest
+	requestedAllocations []*genesis.CustomAllocation
 }
 
-func (r *Registry) Add(name string, f TestFunc) {
-	r.tests = append(r.tests, namedTest{Fnc: f, Name: name})
+func (r *Registry) Add(name string, f TestFunc, requestedBalances ...uint64) {
+	allocations := make([]*genesis.CustomAllocation, 0, len(requestedBalances))
+	authFactories := make([]chain.AuthFactory, 0, len(requestedBalances))
+	for _, requestedBalance := range requestedBalances {
+		private, _ := ed25519.GeneratePrivateKey()
+		authFactory := auth.NewED25519Factory(private)
+		authFactories = append(authFactories, authFactory)
+		allocations = append(allocations, &genesis.CustomAllocation{Address: authFactory.Address(), Balance: requestedBalance})
+	}
+	r.tests = append(r.tests, namedTest{Fnc: f, Name: name, AuthFactories: authFactories})
+	r.requestedAllocations = append(r.requestedAllocations, allocations...)
 }
 
 func (r *Registry) List() []namedTest {
@@ -30,13 +45,17 @@ func (r *Registry) List() []namedTest {
 	return r.tests
 }
 
+func (r *Registry) GetRequestedAllocations() []*genesis.CustomAllocation {
+	return r.requestedAllocations
+}
+
 // we need to pre-register all the test registries that are created externally in order to comply with the ginko execution order.
 // i.e. the global `var _ = ginkgo.Describe` used in the integration/e2e tests need to have this field populated before the iteration
 // over the top level nodes.
 var testRegistries = map[*Registry]bool{}
 
-func Register(registry *Registry, name string, f TestFunc) bool {
-	registry.Add(name, f)
+func Register(registry *Registry, name string, f TestFunc, requestedBalances ...uint64) bool {
+	registry.Add(name, f, requestedBalances...)
 	testRegistries[registry] = true
 	return true
 }


### PR DESCRIPTION
This PR is proposing a way to init pre-funded isolated authFactories.
It also adds an example of interacting with URIs to MorpheusVM transfer workload test.