### PR TITLE
Add Genesis Creation Functionality to Binary

### DIFF
--- a/examples/morpheusvm/cmd/morpheusvm/genesis/genesis.go
+++ b/examples/morpheusvm/cmd/morpheusvm/genesis/genesis.go
@@ -1,0 +1,36 @@
+// Copyright (C) 2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package genesis
+
+import (
+	"fmt"
+
+	"github.com/ava-labs/hypersdk/examples/morpheusvm/tests/workload"
+	"github.com/spf13/cobra"
+)
+
+const minBlockGap = 100
+
+func init() {
+	cobra.EnablePrefixMatching = true
+}
+
+func NewCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "genesis",
+		Short: "Prints out the genesis",
+		RunE:  genesisFunc,
+	}
+	return cmd
+}
+
+func genesisFunc(*cobra.Command, []string) error {
+	networkConfig, err := workload.NewTestNetworkConfig(minBlockGap)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(networkConfig.GenesisBytes())
+	return nil
+}

--- a/examples/morpheusvm/cmd/morpheusvm/genesis/genesis.go
+++ b/examples/morpheusvm/cmd/morpheusvm/genesis/genesis.go
@@ -6,8 +6,9 @@ package genesis
 import (
 	"fmt"
 
-	"github.com/ava-labs/hypersdk/examples/morpheusvm/tests/workload"
 	"github.com/spf13/cobra"
+
+	"github.com/ava-labs/hypersdk/examples/morpheusvm/tests/workload"
 )
 
 const minBlockGap = 100

--- a/examples/morpheusvm/cmd/morpheusvm/main.go
+++ b/examples/morpheusvm/cmd/morpheusvm/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/rpcchainvm"
 	"github.com/spf13/cobra"
 
+	"github.com/ava-labs/hypersdk/examples/morpheusvm/cmd/morpheusvm/genesis"
 	"github.com/ava-labs/hypersdk/examples/morpheusvm/cmd/morpheusvm/version"
 	"github.com/ava-labs/hypersdk/examples/morpheusvm/vm"
 )
@@ -31,6 +32,7 @@ func init() {
 func init() {
 	rootCmd.AddCommand(
 		version.NewCommand(),
+		genesis.NewCommand(),
 	)
 }
 


### PR DESCRIPTION
This PR adds a `genesis` command to the `morpheusvm` binary. When called, `morpheusvm genesis` prints out the genesis bytes used in `NewTestNetworkConfig()`. 

This PR would help with #1786 as users wouldn't have to copy-paste the genesis.