### PR TITLE
Fix Inconsistent Usage of `consts` in `internal/fees`

### DIFF
--- a/internal/fees/manager.go
+++ b/internal/fees/manager.go
@@ -68,7 +68,7 @@ func (f *Manager) LastConsumed(d fees.Dimension) uint64 {
 }
 
 func (f *Manager) lastConsumed(d fees.Dimension) uint64 {
-	start := consts.IntLen + dimensionStateLen*d + consts.Uint64Len + window.WindowSliceSize
+	start := consts.Int64Len + dimensionStateLen*d + consts.Uint64Len + window.WindowSliceSize
 	return binary.BigEndian.Uint64(f.raw[start : start+consts.Uint64Len])
 }
 

--- a/internal/fees/manager_test.go
+++ b/internal/fees/manager_test.go
@@ -8,38 +8,81 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	externalFees "github.com/ava-labs/hypersdk/fees"
+	"github.com/ava-labs/hypersdk/fees"
 )
 
 func TestUnitsConsumed(t *testing.T) {
 	tests := []struct {
 		name           string
-		initialUnits   externalFees.Dimensions
-		unitsToConsume externalFees.Dimensions
-		expectedUnits  externalFees.Dimensions
-		maxUnits       externalFees.Dimensions
+		initialUnits   fees.Dimensions
+		unitsToConsume fees.Dimensions
+		expectedUnits  fees.Dimensions
+		maxUnits       fees.Dimensions
 		success        bool
 	}{
 		{
-			name:           "empty manager consumes",
-			unitsToConsume: externalFees.Dimensions{1, 2, 3, 4, 5},
-			expectedUnits:  externalFees.Dimensions{1, 2, 3, 4, 5},
-			maxUnits:       externalFees.Dimensions{1, 2, 3, 4, 5},
+			name:           "empty manager consumes max",
+			unitsToConsume: fees.Dimensions{2, 2, 2, 2, 2},
+			expectedUnits:  fees.Dimensions{2, 2, 2, 2, 2},
+			maxUnits:       fees.Dimensions{2, 2, 2, 2, 2},
 			success:        true,
 		},
 		{
-			name:           "nonempty manager consumes",
-			initialUnits:   externalFees.Dimensions{1, 2, 3, 4, 5},
-			unitsToConsume: externalFees.Dimensions{1, 2, 3, 4, 5},
-			expectedUnits:  externalFees.Dimensions{2, 4, 6, 8, 10},
-			maxUnits:       externalFees.Dimensions{2, 4, 6, 8, 10},
+			name:           "empty manager consumes less than max",
+			unitsToConsume: fees.Dimensions{1, 1, 1, 1, 1},
+			expectedUnits:  fees.Dimensions{1, 1, 1, 1, 1},
+			maxUnits:       fees.Dimensions{2, 2, 2, 2, 2},
 			success:        true,
 		},
 		{
-			name:           "consume fails if consumed > available",
-			initialUnits:   externalFees.Dimensions{1, 2, 3, 4, 5},
-			unitsToConsume: externalFees.Dimensions{1, 2, 3, 4, 5},
-			maxUnits:       externalFees.Dimensions{1, 2, 3, 4, 5},
+			name:           "empty manager exceeds max of one dimension",
+			unitsToConsume: fees.Dimensions{1, 2, 1, 1, 1},
+			maxUnits:       fees.Dimensions{1, 1, 1, 1, 1},
+			success:        false,
+		},
+		{
+			name:           "empty manager exceeds max of all dimensions",
+			unitsToConsume: fees.Dimensions{3, 3, 3, 3, 3},
+			maxUnits:       fees.Dimensions{2, 2, 2, 2, 2},
+			success:        false,
+		},
+		{
+			name:           "non-empty manager consumes less than max",
+			initialUnits:   fees.Dimensions{1, 1, 1, 1, 1},
+			unitsToConsume: fees.Dimensions{1, 1, 1, 1, 1},
+			expectedUnits:  fees.Dimensions{2, 2, 2, 2, 2},
+			maxUnits:       fees.Dimensions{3, 3, 3, 3, 3},
+			success:        true,
+		},
+		{
+			name:           "non-empty manager consumes max of one dimension",
+			initialUnits:   fees.Dimensions{1, 1, 1, 1, 1},
+			unitsToConsume: fees.Dimensions{1, 2, 1, 1, 1},
+			expectedUnits:  fees.Dimensions{2, 3, 2, 2, 2},
+			maxUnits:       fees.Dimensions{3, 3, 3, 3, 3},
+			success:        true,
+		},
+		{
+			name:           "non-empty manager consumes max of all dimension",
+			initialUnits:   fees.Dimensions{1, 1, 1, 1, 1},
+			unitsToConsume: fees.Dimensions{2, 2, 2, 2, 2},
+			expectedUnits:  fees.Dimensions{3, 3, 3, 3, 3},
+			maxUnits:       fees.Dimensions{3, 3, 3, 3, 3},
+			success:        true,
+		},
+		{
+			name:           "non-empty manager exceeds max of one dimension",
+			initialUnits:   fees.Dimensions{1, 1, 1, 1, 1},
+			unitsToConsume: fees.Dimensions{1, 3, 1, 1, 1},
+			maxUnits:       fees.Dimensions{3, 3, 3, 3, 3},
+			success:        false,
+		},
+		{
+			name:           "non-empty manager exceeds max of all dimension",
+			initialUnits:   fees.Dimensions{1, 1, 1, 1, 1},
+			unitsToConsume: fees.Dimensions{3, 3, 3, 3, 3},
+			maxUnits:       fees.Dimensions{3, 3, 3, 3, 3},
+			success:        false,
 		},
 	}
 

--- a/internal/fees/manager_test.go
+++ b/internal/fees/manager_test.go
@@ -1,0 +1,30 @@
+// Copyright (C) 2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package fees
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	externalfees "github.com/ava-labs/hypersdk/fees"
+)
+
+func TestUnitsConsumedFuzz(t *testing.T) {
+	r := require.New(t)
+	rand := rand.New(rand.NewSource(0)) //nolint:gosec
+
+	for fuzzIteration := 0; fuzzIteration < 1000; fuzzIteration++ {
+		m := NewManager([]byte{})
+		dims := externalfees.Dimensions{}
+
+		for i := range dims {
+			dims[i] = rand.Uint64()
+			m.SetLastConsumed(externalfees.Dimension(i), dims[i])
+		}
+
+		r.Equal(dims, m.UnitsConsumed())
+	}
+}

--- a/internal/fees/manager_test.go
+++ b/internal/fees/manager_test.go
@@ -16,12 +16,14 @@ func TestUnitsConsumed(t *testing.T) {
 		name           string
 		initialUnits   externalFees.Dimensions
 		unitsToConsume externalFees.Dimensions
+		expectedUnits  externalFees.Dimensions
 		maxUnits       externalFees.Dimensions
 		success        bool
 	}{
 		{
 			name:           "empty manager consumes",
 			unitsToConsume: externalFees.Dimensions{1, 2, 3, 4, 5},
+			expectedUnits:  externalFees.Dimensions{1, 2, 3, 4, 5},
 			maxUnits:       externalFees.Dimensions{1, 2, 3, 4, 5},
 			success:        true,
 		},
@@ -29,6 +31,7 @@ func TestUnitsConsumed(t *testing.T) {
 			name:           "nonempty manager consumes",
 			initialUnits:   externalFees.Dimensions{1, 2, 3, 4, 5},
 			unitsToConsume: externalFees.Dimensions{1, 2, 3, 4, 5},
+			expectedUnits:  externalFees.Dimensions{2, 4, 6, 8, 10},
 			maxUnits:       externalFees.Dimensions{2, 4, 6, 8, 10},
 			success:        true,
 		},
@@ -53,7 +56,7 @@ func TestUnitsConsumed(t *testing.T) {
 			ok, _ = manager.Consume(tt.unitsToConsume, tt.maxUnits)
 			r.Equal(tt.success, ok)
 			if tt.success {
-				r.Equal(tt.maxUnits, manager.UnitsConsumed())
+				r.Equal(tt.expectedUnits, manager.UnitsConsumed())
 			}
 		})
 	}


### PR DESCRIPTION
This PR does the following:

- Fixes `manager.lastConsumed()` to use `consts.Int64Len` instead of `consts.IntLen` for the size of timestamp
- Adds a table test for internal fee manager