### PR TITLE
Remove Permissions From Fetcher

### DIFF
--- a/chain/processor.go
+++ b/chain/processor.go
@@ -321,10 +321,6 @@ func (p *Processor) executeTxs(
 			e.Stop()
 			return nil, nil, err
 		}
-		keys := make([]string, 0, len(stateKeys))
-		for k := range stateKeys {
-			keys = append(keys, k)
-		}
 
 		// Ensure we don't consume too many units
 		units, err := tx.Units(p.balanceHandler, r)
@@ -341,7 +337,7 @@ func (p *Processor) executeTxs(
 
 		// Prefetch state keys from disk
 		txID := tx.GetID()
-		if err := f.Fetch(ctx, txID, keys); err != nil {
+		if err := f.Fetch(ctx, txID, stateKeys.Strip()); err != nil {
 			return nil, nil, err
 		}
 		e.Run(stateKeys, func() error {

--- a/chain/processor.go
+++ b/chain/processor.go
@@ -337,7 +337,7 @@ func (p *Processor) executeTxs(
 
 		// Prefetch state keys from disk
 		txID := tx.GetID()
-		if err := f.Fetch(ctx, txID, stateKeys.Strip()); err != nil {
+		if err := f.Fetch(ctx, txID, stateKeys.WithoutPermissions()); err != nil {
 			return nil, nil, err
 		}
 		e.Run(stateKeys, func() error {

--- a/chain/processor.go
+++ b/chain/processor.go
@@ -321,6 +321,10 @@ func (p *Processor) executeTxs(
 			e.Stop()
 			return nil, nil, err
 		}
+		keys := make([]string, 0, len(stateKeys))
+		for k := range stateKeys {
+			keys = append(keys, k)
+		}
 
 		// Ensure we don't consume too many units
 		units, err := tx.Units(p.balanceHandler, r)
@@ -337,7 +341,7 @@ func (p *Processor) executeTxs(
 
 		// Prefetch state keys from disk
 		txID := tx.GetID()
-		if err := f.Fetch(ctx, txID, stateKeys); err != nil {
+		if err := f.Fetch(ctx, txID, keys); err != nil {
 			return nil, nil, err
 		}
 		e.Run(stateKeys, func() error {

--- a/internal/fetcher/fetcher_test.go
+++ b/internal/fetcher/fetcher_test.go
@@ -62,9 +62,13 @@ func TestFetchDifferentKeys(t *testing.T) {
 			stateKeys.Add(ids.GenerateTestID().String(), state.Read)
 		}
 		txID := ids.GenerateTestID()
+		keys := make([]string, 0, len(stateKeys))
+		for k := range stateKeys {
+			keys = append(keys, k)
+		}
 		// Since these are all different keys, we will
 		// fetch each key from disk
-		require.NoError(f.Fetch(ctx, txID, stateKeys))
+		require.NoError(f.Fetch(ctx, txID, keys))
 		go func() {
 			defer wg.Done()
 			// Get keys from cache
@@ -104,9 +108,13 @@ func TestFetchSameKeys(t *testing.T) {
 			stateKeys.Add(keyBase+strconv.Itoa(k), state.Read)
 		}
 		txID := ids.GenerateTestID()
+		keys := make([]string, 0, len(stateKeys))
+		for k := range stateKeys {
+			keys = append(keys, k)
+		}
 		// We are fetching the same keys, so we should
 		// be getting subsequent requests from cache
-		require.NoError(f.Fetch(ctx, txID, stateKeys))
+		require.NoError(f.Fetch(ctx, txID, keys))
 		go func() {
 			defer wg.Done()
 			storage, err := f.Get(txID)
@@ -142,12 +150,16 @@ func TestFetchSameKeysSlow(t *testing.T) {
 			stateKeys.Add(keyBase+strconv.Itoa(k), state.Read)
 		}
 		txID := ids.GenerateTestID()
+		keys := make([]string, 0, len(stateKeys))
+		for k := range stateKeys {
+			keys = append(keys, k)
+		}
 
 		// Empty chan to mimic timing out
 		delay := make(chan struct{})
 
 		// Fetch the key
-		require.NoError(f.Fetch(ctx, txID, stateKeys))
+		require.NoError(f.Fetch(ctx, txID, keys))
 		go func() {
 			defer wg.Done()
 			// Get the keys from cache
@@ -189,7 +201,11 @@ func TestFetcherStop(t *testing.T) {
 			stateKeys.Add(keyBase+strconv.Itoa(k), state.Read)
 		}
 		txID := ids.GenerateTestID()
-		err := f.Fetch(ctx, txID, stateKeys)
+		keys := make([]string, 0, len(stateKeys))
+		for k := range stateKeys {
+			keys = append(keys, k)
+		}
+		err := f.Fetch(ctx, txID, keys)
 		if err != nil {
 			// Some [Fetch] may return an error.
 			// This happens after we called [Stop]

--- a/internal/fetcher/fetcher_test.go
+++ b/internal/fetcher/fetcher_test.go
@@ -56,16 +56,11 @@ func TestFetchDifferentKeys(t *testing.T) {
 	wg.Add(numTxs)
 
 	for i := 0; i < numTxs; i++ {
-		stateKeys := make(state.Keys, (i + 1))
+		keys := make([]string, (i + 1))
 		for k := 0; k < i+1; k++ {
-			// Generate different read keys
-			stateKeys.Add(ids.GenerateTestID().String(), state.Read)
+			keys = append(keys, ids.GenerateTestID().String())
 		}
 		txID := ids.GenerateTestID()
-		keys := make([]string, 0, len(stateKeys))
-		for k := range stateKeys {
-			keys = append(keys, k)
-		}
 		// Since these are all different keys, we will
 		// fetch each key from disk
 		require.NoError(f.Fetch(ctx, txID, keys))
@@ -102,16 +97,11 @@ func TestFetchSameKeys(t *testing.T) {
 	wg.Add(numTxs)
 
 	for i := 0; i < numTxs; i++ {
-		stateKeys := make(state.Keys, (i + 1))
+		keys := make([]string, (i + 1))
 		for k := 0; k < i+1; k++ {
-			// Generate the same keys
-			stateKeys.Add(keyBase+strconv.Itoa(k), state.Read)
+			keys = append(keys, keyBase+strconv.Itoa(k))
 		}
 		txID := ids.GenerateTestID()
-		keys := make([]string, 0, len(stateKeys))
-		for k := range stateKeys {
-			keys = append(keys, k)
-		}
 		// We are fetching the same keys, so we should
 		// be getting subsequent requests from cache
 		require.NoError(f.Fetch(ctx, txID, keys))
@@ -144,16 +134,11 @@ func TestFetchSameKeysSlow(t *testing.T) {
 	)
 	wg.Add(numTxs)
 	for i := 0; i < numTxs; i++ {
-		stateKeys := make(state.Keys, (i + 1))
+		keys := make([]string, (i + 1))
 		for k := 0; k < i+1; k++ {
-			// Generate the same keys
-			stateKeys.Add(keyBase+strconv.Itoa(k), state.Read)
+			keys = append(keys, keyBase+strconv.Itoa(k))
 		}
 		txID := ids.GenerateTestID()
-		keys := make([]string, 0, len(stateKeys))
-		for k := range stateKeys {
-			keys = append(keys, k)
-		}
 
 		// Empty chan to mimic timing out
 		delay := make(chan struct{})
@@ -195,16 +180,11 @@ func TestFetcherStop(t *testing.T) {
 	)
 	wg.Add(numTxs)
 	for i := 0; i < numTxs; i++ {
-		stateKeys := make(state.Keys, (i + 1))
+		keys := make([]string, (i + 1))
 		for k := 0; k < i+1; k++ {
-			// Generate the same keys
-			stateKeys.Add(keyBase+strconv.Itoa(k), state.Read)
+			keys = append(keys, keyBase+strconv.Itoa(k))
 		}
 		txID := ids.GenerateTestID()
-		keys := make([]string, 0, len(stateKeys))
-		for k := range stateKeys {
-			keys = append(keys, k)
-		}
 		err := f.Fetch(ctx, txID, keys)
 		if err != nil {
 			// Some [Fetch] may return an error.

--- a/state/keys.go
+++ b/state/keys.go
@@ -61,7 +61,7 @@ func (k Keys) ChunkSizes() ([]uint16, bool) {
 	return chunks, true
 }
 
-// WithoutPermissions returns the database keys of k
+// WithoutPermissions returns the keys of k as a slice with permissions removed
 func (k Keys) WithoutPermissions() []string {
 	ks := make([]string, len(k))
 	for key := range k {

--- a/state/keys.go
+++ b/state/keys.go
@@ -61,8 +61,8 @@ func (k Keys) ChunkSizes() ([]uint16, bool) {
 	return chunks, true
 }
 
-// Strip returns the database keys of k
-func (k Keys) Strip() []string {
+// WithoutPermissions returns the database keys of k
+func (k Keys) WithoutPermissions() []string {
 	ks := make([]string, len(k))
 	for key := range k {
 		ks = append(ks, key)

--- a/state/keys.go
+++ b/state/keys.go
@@ -61,7 +61,7 @@ func (k Keys) ChunkSizes() ([]uint16, bool) {
 	return chunks, true
 }
 
-// Strips returns the database keys of k
+// Strip returns the database keys of k
 func (k Keys) Strip() []string {
 	ks := make([]string, len(k))
 	for key := range k {

--- a/state/keys.go
+++ b/state/keys.go
@@ -61,6 +61,15 @@ func (k Keys) ChunkSizes() ([]uint16, bool) {
 	return chunks, true
 }
 
+// Strips returns the database keys of k
+func (k Keys) Strip() []string {
+	ks := make([]string, len(k))
+	for key := range k {
+		ks = append(ks, key)
+	}
+	return ks
+}
+
 type keysJSON map[string]Permissions
 
 // MarshalJSON marshals Keys as readable JSON.


### PR DESCRIPTION
This PR removes permissions from `Fetcher` by having it take in a slice of strings (i.e. database keys) instead of `state.Keys`.

This PR also modifies the `Fetcher` tests to natively use database keys instead of state keys.