### PR TITLE
Remove accepted type from generic snow vm

### DIFF
--- a/snow/application.go
+++ b/snow/application.go
@@ -14,8 +14,8 @@ import (
 	"github.com/ava-labs/hypersdk/event"
 )
 
-type Application[I Block, O Block, A Block] struct {
-	vm *VM[I, O, A]
+type Application[I Block, O Block] struct {
+	vm *VM[I, O]
 
 	Version         string
 	Handlers        map[string]http.Handler
@@ -30,66 +30,66 @@ type Application[I Block, O Block, A Block] struct {
 
 	VerifiedSubs         []event.Subscription[O]
 	RejectedSubs         []event.Subscription[O]
-	AcceptedSubs         []event.Subscription[A]
+	AcceptedSubs         []event.Subscription[O]
 	PreReadyAcceptedSubs []event.Subscription[I]
 }
 
 // GetCovariantVM returns the VM implementation returning the wrapper around the generic types
-func (a *Application[I, O, A]) GetCovariantVM() *CovariantVM[I, O, A] {
+func (a *Application[I, O]) GetCovariantVM() *CovariantVM[I, O] {
 	return a.vm.covariantVM
 }
 
 // GetInputCovariantVM returns the VM implementation that returns the wrapper around the generic
 // types (instead of the snowman.Block type)
-func (a *Application[I, O, A]) GetInputCovariantVM() *InputCovariantVM[I, O, A] {
-	return &InputCovariantVM[I, O, A]{a.vm.covariantVM}
+func (a *Application[I, O]) GetInputCovariantVM() *InputCovariantVM[I, O] {
+	return &InputCovariantVM[I, O]{a.vm.covariantVM}
 }
 
-func (a *Application[I, O, A]) WithAcceptedSub(sub ...event.Subscription[A]) {
+func (a *Application[I, O]) WithAcceptedSub(sub ...event.Subscription[O]) {
 	a.AcceptedSubs = append(a.AcceptedSubs, sub...)
 }
 
-func (a *Application[I, O, A]) WithRejectedSub(sub ...event.Subscription[O]) {
+func (a *Application[I, O]) WithRejectedSub(sub ...event.Subscription[O]) {
 	a.RejectedSubs = append(a.RejectedSubs, sub...)
 }
 
-func (a *Application[I, O, A]) WithVerifiedSub(sub ...event.Subscription[O]) {
+func (a *Application[I, O]) WithVerifiedSub(sub ...event.Subscription[O]) {
 	a.VerifiedSubs = append(a.VerifiedSubs, sub...)
 }
 
-func (a *Application[I, O, A]) WithPreReadyAcceptedSub(sub ...event.Subscription[I]) {
+func (a *Application[I, O]) WithPreReadyAcceptedSub(sub ...event.Subscription[I]) {
 	a.PreReadyAcceptedSubs = append(a.PreReadyAcceptedSubs, sub...)
 }
 
-func (a *Application[I, O, A]) WithHandler(name string, handler http.Handler) {
+func (a *Application[I, O]) WithHandler(name string, handler http.Handler) {
 	a.Handlers[name] = handler
 }
 
-func (a *Application[I, O, A]) WithHealthChecker(healthChecker health.Checker) {
+func (a *Application[I, O]) WithHealthChecker(healthChecker health.Checker) {
 	a.HealthChecker = healthChecker
 }
 
-func (a *Application[I, O, A]) WithCloser(closer func() error) {
+func (a *Application[I, O]) WithCloser(closer func() error) {
 	a.Closers = append(a.Closers, closer)
 }
 
-func (a *Application[I, O, A]) WithStateSyncStarted(onStateSyncStarted ...func(context.Context) error) {
+func (a *Application[I, O]) WithStateSyncStarted(onStateSyncStarted ...func(context.Context) error) {
 	a.OnStateSyncStarted = append(a.OnStateSyncStarted, onStateSyncStarted...)
 }
 
-func (a *Application[I, O, A]) WithNormalOpStarted(onNormalOpStartedF ...func(context.Context) error) {
+func (a *Application[I, O]) WithNormalOpStarted(onNormalOpStartedF ...func(context.Context) error) {
 	a.OnNormalOperationStarted = append(a.OnNormalOperationStarted, onNormalOpStartedF...)
 }
 
 // StartStateSync notifies the VM to enter DynamicStateSync mode.
 // The caller is responsible to eventually call FinishStateSync with a fully populated
 // last accepted state.
-func (a *Application[I, O, A]) StartStateSync(ctx context.Context, block I) error {
+func (a *Application[I, O]) StartStateSync(ctx context.Context, block I) error {
 	return a.vm.StartStateSync(ctx, block)
 }
 
 // FinishStateSync completes dynamic state sync mode and sets the last accepted block to
 // the given input/output/accepted value.
-func (a *Application[I, O, A]) FinishStateSync(ctx context.Context, input I, output O, accepted A) error {
-	return a.vm.FinishStateSync(ctx, input, output, accepted)
+func (a *Application[I, O]) FinishStateSync(ctx context.Context, input I, output O) error {
+	return a.vm.FinishStateSync(ctx, input, output)
 }

--- a/snow/network.go
+++ b/snow/network.go
@@ -12,26 +12,26 @@ import (
 	"github.com/ava-labs/avalanchego/version"
 )
 
-func (v *VM[I, O, A]) AppRequest(ctx context.Context, nodeID ids.NodeID, requestID uint32, deadline time.Time, request []byte) error {
+func (v *VM[I, O]) AppRequest(ctx context.Context, nodeID ids.NodeID, requestID uint32, deadline time.Time, request []byte) error {
 	return v.app.Network.AppRequest(ctx, nodeID, requestID, deadline, request)
 }
 
-func (v *VM[I, O, A]) AppResponse(ctx context.Context, nodeID ids.NodeID, requestID uint32, response []byte) error {
+func (v *VM[I, O]) AppResponse(ctx context.Context, nodeID ids.NodeID, requestID uint32, response []byte) error {
 	return v.app.Network.AppResponse(ctx, nodeID, requestID, response)
 }
 
-func (v *VM[I, O, A]) AppRequestFailed(ctx context.Context, nodeID ids.NodeID, requestID uint32, appErr *common.AppError) error {
+func (v *VM[I, O]) AppRequestFailed(ctx context.Context, nodeID ids.NodeID, requestID uint32, appErr *common.AppError) error {
 	return v.app.Network.AppRequestFailed(ctx, nodeID, requestID, appErr)
 }
 
-func (v *VM[I, O, A]) AppGossip(ctx context.Context, nodeID ids.NodeID, msg []byte) error {
+func (v *VM[I, O]) AppGossip(ctx context.Context, nodeID ids.NodeID, msg []byte) error {
 	return v.app.Network.AppGossip(ctx, nodeID, msg)
 }
 
-func (v *VM[I, O, A]) Connected(ctx context.Context, nodeID ids.NodeID, nodeVersion *version.Application) error {
+func (v *VM[I, O]) Connected(ctx context.Context, nodeID ids.NodeID, nodeVersion *version.Application) error {
 	return v.app.Network.Connected(ctx, nodeID, nodeVersion)
 }
 
-func (v *VM[I, O, A]) Disconnected(ctx context.Context, nodeID ids.NodeID) error {
+func (v *VM[I, O]) Disconnected(ctx context.Context, nodeID ids.NodeID) error {
 	return v.app.Network.Disconnected(ctx, nodeID)
 }

--- a/snow/statesync.go
+++ b/snow/statesync.go
@@ -10,15 +10,15 @@ import (
 	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
 )
 
-var _ block.StateSyncableVM = (*VM[Block, Block, Block])(nil)
+var _ block.StateSyncableVM = (*VM[Block, Block])(nil)
 
-func (a *Application[I, O, A]) WithStateSyncableVM(stateSyncableVM block.StateSyncableVM) {
+func (a *Application[I, O]) WithStateSyncableVM(stateSyncableVM block.StateSyncableVM) {
 	a.StateSyncableVM = stateSyncableVM
 }
 
 // StartStateSync marks the VM as "not ready" so that blocks are verified / accepted vaccuously
 // in DynamicStateSync mode until FinishStateSync is called.
-func (v *VM[I, O, A]) StartStateSync(ctx context.Context, block I) error {
+func (v *VM[I, O]) StartStateSync(ctx context.Context, block I) error {
 	if err := v.inputChainIndex.UpdateLastAccepted(ctx, block); err != nil {
 		return err
 	}
@@ -29,7 +29,7 @@ func (v *VM[I, O, A]) StartStateSync(ctx context.Context, block I) error {
 // FinishStateSync is responsible for setting the last accepted block of the VM after state sync completes.
 // This function must grab the lock because it's called from a thread the VM controls instead of the consensus
 // engine.
-func (v *VM[I, O, A]) FinishStateSync(ctx context.Context, input I, output O, accepted A) error {
+func (v *VM[I, O]) FinishStateSync(ctx context.Context, input I, output O) error {
 	v.snowCtx.Lock.Lock()
 	defer v.snowCtx.Lock.Unlock()
 
@@ -40,7 +40,7 @@ func (v *VM[I, O, A]) FinishStateSync(ctx context.Context, input I, output O, ac
 
 	// If the block is already the last accepted block, update the fields and return
 	if input.ID() == v.lastAcceptedBlock.ID() {
-		v.lastAcceptedBlock.setAccepted(output, accepted)
+		v.lastAcceptedBlock.setAccepted(output)
 		v.MarkReady(true)
 		return nil
 	}
@@ -48,7 +48,7 @@ func (v *VM[I, O, A]) FinishStateSync(ctx context.Context, input I, output O, ac
 	// Dynamic state sync notifies completion async, so we may have verified/accepted new blocks in
 	// the interim (before successfully grabbing the lock).
 	// Create the block and reprocess all blocks in the range (blk, lastAcceptedBlock]
-	blk := NewAcceptedBlock(v.covariantVM, input, output, accepted)
+	blk := NewAcceptedBlock(v.covariantVM, input, output)
 	reprocessBlks, err := v.covariantVM.getExclusiveBlockRange(ctx, blk, v.lastAcceptedBlock)
 	if err != nil {
 		return fmt.Errorf("failed to get block range while completing state sync: %w", err)
@@ -61,7 +61,7 @@ func (v *VM[I, O, A]) FinishStateSync(ctx context.Context, input I, output O, ac
 		if err := reprocessBlk.verify(ctx, parent.Output); err != nil {
 			return fmt.Errorf("failed to finish state sync while verifying block %s in range (%s, %s): %w", reprocessBlk, blk, v.lastAcceptedBlock, err)
 		}
-		if err := reprocessBlk.accept(ctx, parent.Accepted); err != nil {
+		if err := reprocessBlk.accept(ctx, parent.Output); err != nil {
 			return fmt.Errorf("failed to finish state sync while accepting block %s in range (%s, %s): %w", reprocessBlk, blk, v.lastAcceptedBlock, err)
 		}
 		parent = reprocessBlk
@@ -71,22 +71,22 @@ func (v *VM[I, O, A]) FinishStateSync(ctx context.Context, input I, output O, ac
 	return nil
 }
 
-func (v *VM[I, O, A]) StateSyncEnabled(ctx context.Context) (bool, error) {
+func (v *VM[I, O]) StateSyncEnabled(ctx context.Context) (bool, error) {
 	return v.app.StateSyncableVM.StateSyncEnabled(ctx)
 }
 
-func (v *VM[I, O, A]) GetOngoingSyncStateSummary(ctx context.Context) (block.StateSummary, error) {
+func (v *VM[I, O]) GetOngoingSyncStateSummary(ctx context.Context) (block.StateSummary, error) {
 	return v.app.StateSyncableVM.GetOngoingSyncStateSummary(ctx)
 }
 
-func (v *VM[I, O, A]) GetLastStateSummary(ctx context.Context) (block.StateSummary, error) {
+func (v *VM[I, O]) GetLastStateSummary(ctx context.Context) (block.StateSummary, error) {
 	return v.app.StateSyncableVM.GetLastStateSummary(ctx)
 }
 
-func (v *VM[I, O, A]) ParseStateSummary(ctx context.Context, summaryBytes []byte) (block.StateSummary, error) {
+func (v *VM[I, O]) ParseStateSummary(ctx context.Context, summaryBytes []byte) (block.StateSummary, error) {
 	return v.app.StateSyncableVM.ParseStateSummary(ctx, summaryBytes)
 }
 
-func (v *VM[I, O, A]) GetStateSummary(ctx context.Context, summaryHeight uint64) (block.StateSummary, error) {
+func (v *VM[I, O]) GetStateSummary(ctx context.Context, summaryHeight uint64) (block.StateSummary, error) {
 	return v.app.StateSyncableVM.GetStateSummary(ctx, summaryHeight)
 }

--- a/vm/defaultvm/vm.go
+++ b/vm/defaultvm/vm.go
@@ -66,7 +66,7 @@ func NewSnowVM(
 	outputCodec *codec.TypeParser[codec.Typed],
 	authEngine map[uint8]vm.AuthEngine,
 	options ...vm.Option,
-) (*snow.VM[*chain.ExecutionBlock, *chain.OutputBlock, *chain.OutputBlock], error) {
+) (*snow.VM[*chain.ExecutionBlock, *chain.OutputBlock], error) {
 	options = append(options, NewDefaultOptions()...)
 	hyperVM, err := New(
 		genesisFactory,
@@ -82,5 +82,5 @@ func NewSnowVM(
 		return nil, err
 	}
 
-	return snow.NewVM[*chain.ExecutionBlock, *chain.OutputBlock, *chain.OutputBlock](v.String(), hyperVM), nil
+	return snow.NewVM[*chain.ExecutionBlock, *chain.OutputBlock](v.String(), hyperVM), nil
 }

--- a/vm/statesync.go
+++ b/vm/statesync.go
@@ -117,7 +117,7 @@ func (vm *VM) initStateSync(ctx context.Context) error {
 			if err != nil {
 				return fmt.Errorf("failed to extract latest output block while finishing state sync: %w", err)
 			}
-			if err := vm.snowApp.FinishStateSync(ctx, outputBlock.ExecutionBlock, outputBlock, outputBlock); err != nil {
+			if err := vm.snowApp.FinishStateSync(ctx, outputBlock.ExecutionBlock, outputBlock); err != nil {
 				return err
 			}
 			return nil

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -62,13 +62,13 @@ var (
 	_ hsnow.Block = (*chain.ExecutionBlock)(nil)
 	_ hsnow.Block = (*chain.OutputBlock)(nil)
 
-	_ hsnow.Chain[*chain.ExecutionBlock, *chain.OutputBlock, *chain.OutputBlock] = (*VM)(nil)
-	_ hsnow.BlockChainIndex[*chain.ExecutionBlock]                               = (*chainstore.ChainStore[*chain.ExecutionBlock])(nil)
+	_ hsnow.Chain[*chain.ExecutionBlock, *chain.OutputBlock] = (*VM)(nil)
+	_ hsnow.BlockChainIndex[*chain.ExecutionBlock]           = (*chainstore.ChainStore[*chain.ExecutionBlock])(nil)
 )
 
 type VM struct {
 	snowInput hsnow.ChainInput
-	snowApp   *hsnow.Application[*chain.ExecutionBlock, *chain.OutputBlock, *chain.OutputBlock]
+	snowApp   *hsnow.Application[*chain.ExecutionBlock, *chain.OutputBlock]
 
 	proposerMonitor *validators.ProposerMonitor
 
@@ -85,7 +85,7 @@ type VM struct {
 	syncer                  *validitywindow.Syncer[*chain.Transaction]
 	SyncClient              *statesync.Client[*chain.ExecutionBlock]
 
-	chainIndex *hsnow.ChainIndex[*chain.ExecutionBlock, *chain.OutputBlock, *chain.OutputBlock]
+	chainIndex *hsnow.ChainIndex[*chain.ExecutionBlock, *chain.OutputBlock]
 	chainStore *chainstore.ChainStore[*chain.ExecutionBlock]
 
 	builder  builder.Builder
@@ -149,8 +149,8 @@ func New(
 func (vm *VM) Initialize(
 	ctx context.Context,
 	chainInput hsnow.ChainInput,
-	makeChainIndex hsnow.MakeChainIndexFunc[*chain.ExecutionBlock, *chain.OutputBlock, *chain.OutputBlock],
-	snowApp *hsnow.Application[*chain.ExecutionBlock, *chain.OutputBlock, *chain.OutputBlock],
+	makeChainIndex hsnow.MakeChainIndexFunc[*chain.ExecutionBlock, *chain.OutputBlock],
+	snowApp *hsnow.Application[*chain.ExecutionBlock, *chain.OutputBlock],
 ) (hsnow.BlockChainIndex[*chain.ExecutionBlock], error) {
 	var (
 		snowCtx      = chainInput.SnowCtx
@@ -323,7 +323,7 @@ func (vm *VM) Initialize(
 		return nil, err
 	}
 	// Switch away from true
-	chainIndex, err := makeChainIndex(ctx, vm.chainStore, lastAccepted, lastAccepted, true)
+	chainIndex, err := makeChainIndex(ctx, vm.chainStore, lastAccepted, true)
 	if err != nil {
 		return nil, err
 	}
@@ -588,11 +588,11 @@ func (vm *VM) Execute(ctx context.Context, parent *chain.OutputBlock, block *cha
 	return vm.chain.Execute(ctx, parent, block)
 }
 
-func (*VM) AcceptBlock(ctx context.Context, _ *chain.OutputBlock, block *chain.OutputBlock) (*chain.OutputBlock, error) {
+func (*VM) AcceptBlock(ctx context.Context, _ *chain.OutputBlock, block *chain.OutputBlock) error {
 	if err := block.View.CommitToDB(ctx); err != nil {
-		return nil, fmt.Errorf("failed to commit state for block %s: %w", block, err)
+		return fmt.Errorf("failed to commit state for block %s: %w", block, err)
 	}
-	return block, nil
+	return nil
 }
 
 func (vm *VM) Submit(

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -65,7 +65,7 @@ type VM struct {
 	appSender *enginetest.Sender
 	toEngine  chan common.Message
 
-	SnowVM *snow.VM[*chain.ExecutionBlock, *chain.OutputBlock, *chain.OutputBlock]
+	SnowVM *snow.VM[*chain.ExecutionBlock, *chain.OutputBlock]
 	VM     *vm.VM
 
 	server *httptest.Server
@@ -146,7 +146,7 @@ func NewTestVM(
 	}
 }
 
-func (vm *VM) BuildAndSetPreference(ctx context.Context) *snow.StatefulBlock[*chain.ExecutionBlock, *chain.OutputBlock, *chain.OutputBlock] {
+func (vm *VM) BuildAndSetPreference(ctx context.Context) *snow.StatefulBlock[*chain.ExecutionBlock, *chain.OutputBlock] {
 	vm.snowCtx.Lock.Lock()
 	defer vm.snowCtx.Lock.Unlock()
 
@@ -158,7 +158,7 @@ func (vm *VM) BuildAndSetPreference(ctx context.Context) *snow.StatefulBlock[*ch
 	return blk
 }
 
-func (vm *VM) ParseAndSetPreference(ctx context.Context, bytes []byte) *snow.StatefulBlock[*chain.ExecutionBlock, *chain.OutputBlock, *chain.OutputBlock] {
+func (vm *VM) ParseAndSetPreference(ctx context.Context, bytes []byte) *snow.StatefulBlock[*chain.ExecutionBlock, *chain.OutputBlock] {
 	vm.snowCtx.Lock.Lock()
 	defer vm.snowCtx.Lock.Unlock()
 
@@ -426,7 +426,7 @@ func (n *TestNetwork) SubmitTxs(ctx context.Context, txs []*chain.Transaction) {
 // This function assumes that all VMs in the TestNetwork have verified at least up to the current preference
 // of the initial VM, so that it correctly mimics the engine's behavior of guaranteeing that all VMs have
 // verified the parent block before verifying its child.
-func (n *TestNetwork) BuildBlockAndUpdateHead(ctx context.Context) []*snow.StatefulBlock[*chain.ExecutionBlock, *chain.OutputBlock, *chain.OutputBlock] {
+func (n *TestNetwork) BuildBlockAndUpdateHead(ctx context.Context) []*snow.StatefulBlock[*chain.ExecutionBlock, *chain.OutputBlock] {
 	n.require.NoError(n.VMs[0].VM.Builder().Force(ctx))
 	select {
 	case <-n.VMs[0].toEngine:
@@ -437,7 +437,7 @@ func (n *TestNetwork) BuildBlockAndUpdateHead(ctx context.Context) []*snow.State
 	buildVM := n.VMs[0]
 	blk := buildVM.BuildAndSetPreference(ctx)
 
-	blks := make([]*snow.StatefulBlock[*chain.ExecutionBlock, *chain.OutputBlock, *chain.OutputBlock], len(n.VMs))
+	blks := make([]*snow.StatefulBlock[*chain.ExecutionBlock, *chain.OutputBlock], len(n.VMs))
 	blks[0] = blk
 	blkBytes := blk.Bytes()
 	for i, otherVM := range n.VMs[1:] {


### PR DESCRIPTION
This is a draft of what it looks like to remove the `Accepted` block type from the snow vm refactor.

The original intent of three block types is to:
- support both DSMR and non-DSMR cases
- provide a block type for each state transition that the consensus engine goes through (input -> verify -> accept/reject)

The Vryx design can result in higher latency (chunk building + block building) and the potential for a lower temporary censorship threshold for an individual tx issuer, so chains that do not need to scale bandwidth to go beyond ~10k TPS may prefer not to use DSMR.

The current HyperVM implementation without DSMR uses the following block types:
- Input -> ExecutionBlock
- Output -> OutputBlock which includes ExecutionResults and the merkledb.View
- Accepted -> OutputBlock identical to the above

Since Output and Accepted are identical it seems like we should be able to get rid of one.

However, in the DSMR case we have a different set of block types:
- Input -> chunk based block type
- Output -> identical to above chunk based block type
- Accepted -> fetch chunks and assemble + execute inner block type (OutputBlock as above)

Both cases have two types that are identical, but they are opposite cases, so we need both.

Alternatively, we could eliminate the `Accepted` block type and move creating and executing the inner block type into DSMR instead of making it an explicit part of the snow package.