### PR TITLE
Remove Error From `window.Roll()`

### DIFF
--- a/cli/chain.go
+++ b/cli/chain.go
@@ -125,10 +125,7 @@ func (h *Handler) WatchChain(hideTxs bool) error {
 		}
 		if lastBlock != 0 {
 			since := now.Unix() - lastBlock
-			newWindow, err := window.Roll(tpsWindow, since)
-			if err != nil {
-				return err
-			}
+			newWindow := window.Roll(tpsWindow, uint64(since))
 			tpsWindow = newWindow
 			window.Update(&tpsWindow, window.WindowSliceSize-consts.Uint64Len, uint64(len(blk.Txs)))
 			runningDuration := time.Since(start)

--- a/internal/window/window.go
+++ b/internal/window/window.go
@@ -35,16 +35,16 @@ type Window [WindowSliceSize]byte
 // Roll >= 4
 // [0, 0, 0, 0]
 // Assumes that [roll] is greater than or equal to 0
-func Roll(w Window, roll int64) (Window, error) {
+func Roll(w Window, roll uint64) Window {
 	// Note: make allocates a zeroed array, so we are guaranteed
 	// that what we do not copy into, will be set to 0
 	res := [WindowSliceSize]byte{}
 	bound := roll * consts.Uint64Len
 	if bound > WindowSliceSize {
-		return res, nil
+		return res
 	}
-	copy(res[:], w[roll*consts.Uint64Len:])
-	return res, nil
+	copy(res[:], w[bound:])
+	return res
 }
 
 // Sum sums [numUint64s] encoded in [window]. Assumes that the length of [window]

--- a/internal/window/window.go
+++ b/internal/window/window.go
@@ -34,7 +34,6 @@ type Window [WindowSliceSize]byte
 // [4, 0, 0, 0]
 // Roll >= 4
 // [0, 0, 0, 0]
-// Assumes that [roll] is greater than or equal to 0
 func Roll(w Window, roll uint64) Window {
 	// Note: make allocates a zeroed array, so we are guaranteed
 	// that what we do not copy into, will be set to 0

--- a/internal/window/window_test.go
+++ b/internal/window/window_test.go
@@ -19,8 +19,7 @@ func testRollup(t *testing.T, uint64s []uint64, roll int) {
 	for i := 0; i < numUint64s; i++ {
 		binary.BigEndian.PutUint64(slice[8*i:], uint64s[i])
 	}
-	newSlice, err := Roll(slice, int64(roll))
-	require.NoError(err)
+	newSlice := Roll(slice, uint64(roll))
 
 	// numCopies is the number of uint64s that should have been copied over from the previous
 	// slice as opposed to being left empty.


### PR DESCRIPTION
This PR removes the error return parameter from `window.Roll()` and modifies the `roll` parameter type from `int64` to `uint64`.

Currently, although `window.Roll()` returns an error, this is always set to `nil` and so for testing/code quality, this PR removes the error return parameter altogether.

Furthermore, the `roll` parameter is currently of type `int64` but after further inspection, we have that `roll = currTime - prevTime`. Assuming that `currTime - prevTime >= 0`, changing `roll` to uint64 is safer as we no longer run the risk of passing in a negative value when [indexing](https://github.com/ava-labs/hypersdk/blob/4c616547551d05aec457fac025f44bfe49d5cce2/internal/window/window.go#L46).