### PR TITLE
pin rust version to 1.83 to avoid breaking changes in 1.84

### DIFF
--- a/.github/actions/install-rust/action.yml
+++ b/.github/actions/install-rust/action.yml
@@ -14,8 +14,11 @@ runs:
   using: composite
   steps:
     - name: Install Rust
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@1.83.0
       with:
         targets: ${{ inputs.targets }}
     - if: ${{ inputs.cache == 'true' }}
       uses: Swatinem/rust-cache@v2
+    - name: Install rustfmt
+      shell: bash
+      run: rustup component add rustfmt clippy

--- a/.github/actions/install-rust/action.yml
+++ b/.github/actions/install-rust/action.yml
@@ -17,8 +17,6 @@ runs:
       uses: dtolnay/rust-toolchain@1.83.0
       with:
         targets: ${{ inputs.targets }}
+        components: clippy, rustfmt
     - if: ${{ inputs.cache == 'true' }}
       uses: Swatinem/rust-cache@v2
-    - name: Install rustfmt
-      shell: bash
-      run: rustup component add rustfmt clippy


### PR DESCRIPTION
## What ? 

The rust components started generating errors during the CI build due to rust upgrade.

## Workaround

pin rust version to 1.83 to avoid breaking changes in 1.84.