### PR TITLE
Use Interface for `validitywindow` in `chain` package

### DIFF
--- a/chain/chain.go
+++ b/chain/chain.go
@@ -11,13 +11,9 @@ import (
 	"github.com/ava-labs/avalanchego/x/merkledb"
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/ava-labs/hypersdk/internal/validitywindow"
 	"github.com/ava-labs/hypersdk/internal/workers"
 	"github.com/ava-labs/hypersdk/state"
 )
-
-// create a type alias for the concrete TimeWindowWindow type.
-type ValidityWindow = *validitywindow.TimeValidityWindow[*Transaction]
 
 type Chain struct {
 	builder     *Builder

--- a/chain/dependencies.go
+++ b/chain/dependencies.go
@@ -7,9 +7,11 @@ import (
 	"context"
 
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/set"
 
 	"github.com/ava-labs/hypersdk/codec"
 	"github.com/ava-labs/hypersdk/fees"
+	"github.com/ava-labs/hypersdk/internal/validitywindow"
 	"github.com/ava-labs/hypersdk/state"
 )
 
@@ -203,4 +205,19 @@ type AuthFactory interface {
 	Sign(msg []byte) (Auth, error)
 	MaxUnits() (bandwidth uint64, compute uint64)
 	Address() codec.Address
+}
+
+type ValidityWindow interface {
+	VerifyExpiryReplayProtection(
+		ctx context.Context,
+		blk validitywindow.ExecutionBlock[*Transaction],
+		oldestAllowed int64,
+	) error
+	Accept(blk validitywindow.ExecutionBlock[*Transaction])
+	IsRepeat(
+		ctx context.Context,
+		parentBlk validitywindow.ExecutionBlock[*Transaction],
+		txs []*Transaction,
+		oldestAllowed int64,
+	) (set.Bits, error)
 }

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -81,7 +81,7 @@ type VM struct {
 	options               []Option
 
 	chain                   *chain.Chain
-	chainTimeValidityWindow chain.ValidityWindow
+	chainTimeValidityWindow *validitywindow.TimeValidityWindow[*chain.Transaction]
 	syncer                  *validitywindow.Syncer[*chain.Transaction]
 	seenValidityWindowOnce  sync.Once
 	seenValidityWindow      chan struct{}


### PR DESCRIPTION
This PR modifies the `chain` package by defining a `ValidityWindow` interface which its components use, rather than the `validitywindow.TimeValidityWindow[*chain.Transaction]` type it currently uses. This change is especially useful to UTs.