### PR TITLE
Sync test improvements

### DIFF
--- a/snow/vm.go
+++ b/snow/vm.go
@@ -408,10 +408,9 @@ func (v *VM[I, O, A]) LastAccepted(context.Context) (ids.ID, error) {
 }
 
 func (v *VM[I, O, A]) SetState(ctx context.Context, state snow.State) error {
+	v.log.Info("Setting state to %s", zap.Stringer("state", state))
 	switch state {
 	case snow.StateSyncing:
-		v.log.Info("Starting state sync")
-
 		for _, startStateSyncF := range v.onStateSyncStarted {
 			if err := startStateSyncF(ctx); err != nil {
 				return err
@@ -419,8 +418,6 @@ func (v *VM[I, O, A]) SetState(ctx context.Context, state snow.State) error {
 		}
 		return nil
 	case snow.Bootstrapping:
-		v.log.Info("Starting bootstrapping")
-
 		for _, startBootstrappingF := range v.onBootstrapStarted {
 			if err := startBootstrappingF(ctx); err != nil {
 				return err
@@ -428,7 +425,6 @@ func (v *VM[I, O, A]) SetState(ctx context.Context, state snow.State) error {
 		}
 		return nil
 	case snow.NormalOp:
-		v.log.Info("Starting normal operation")
 		for _, startNormalOpF := range v.onNormalOperationsStarted {
 			if err := startNormalOpF(ctx); err != nil {
 				return err

--- a/tests/e2e/e2e.go
+++ b/tests/e2e/e2e.go
@@ -141,8 +141,8 @@ var _ = ginkgo.Describe("[HyperSDK Syncing]", ginkgo.Serial, func() {
 		blockchainID := e2e.GetEnv(tc).GetNetwork().GetSubnet(networkConfig.Name()).Chains[0].ChainID
 
 		uris := getE2EURIs(tc, blockchainID)
-		ginkgo.By("Generate 128 blocks", func() {
-			txWorkload.GenerateBlocks(tc.ContextWithTimeout(5*time.Minute), require, uris, 128)
+		ginkgo.By("Generate 32 blocks", func() {
+			txWorkload.GenerateBlocks(tc.ContextWithTimeout(5*time.Minute), require, uris, 32)
 		})
 
 		var (
@@ -161,8 +161,8 @@ var _ = ginkgo.Describe("[HyperSDK Syncing]", ginkgo.Serial, func() {
 		ginkgo.By("Restart the node", func() {
 			require.NoError(e2e.GetEnv(tc).GetNetwork().RestartNode(tc.DefaultContext(), ginkgo.GinkgoWriter, bootstrapNode))
 		})
-		ginkgo.By("Generate > StateSyncMinBlocks=512", func() {
-			txWorkload.GenerateBlocks(tc.ContextWithTimeout(20*time.Minute), require, uris, 512)
+		ginkgo.By("Generate > StateSyncMinBlocks=128", func() {
+			txWorkload.GenerateBlocks(tc.ContextWithTimeout(20*time.Minute), require, uris, 128)
 		})
 		var (
 			syncNode    *tmpnet.Node
@@ -191,10 +191,10 @@ var _ = ginkgo.Describe("[HyperSDK Syncing]", ginkgo.Serial, func() {
 			require.Error(err) //nolint:forbidigo
 			require.False(ok)
 		})
-		ginkgo.By("Generate 256 blocks", func() {
+		ginkgo.By("Generate 32 blocks", func() {
 			// Generate blocks on all nodes except the paused node
 			runningURIs := uris[:len(uris)-1]
-			txWorkload.GenerateBlocks(tc.ContextWithTimeout(5*time.Minute), require, runningURIs, 256)
+			txWorkload.GenerateBlocks(tc.ContextWithTimeout(5*time.Minute), require, runningURIs, 32)
 		})
 		ginkgo.By("Resume the node", func() {
 			require.NoError(e2e.GetEnv(tc).GetNetwork().StartNode(tc.DefaultContext(), ginkgo.GinkgoWriter, syncNode))

--- a/tests/fixture/subnet.go
+++ b/tests/fixture/subnet.go
@@ -17,7 +17,7 @@ func NewHyperVMSubnet(name string, vmID ids.ID, genesisBytes []byte, nodes ...*t
 				Genesis: genesisBytes,
 				Config: `{
 					"statesync": {
-						"minBlocks": 512
+						"minBlocks": 128
 					}
 				}`,
 			},

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -656,7 +656,10 @@ func TestSkipStateSync(t *testing.T) {
 	r.Equal(block.StateSyncSkipped, stateSyncMode)
 	r.Equal(lastAccepted.GetID(), initialVMGenesisBlock.GetID())
 
+	r.NoError(vm.SnowVM.SetState(ctx, avasnow.Bootstrapping))
 	r.NoError(vm.SnowVM.SetState(ctx, avasnow.NormalOp))
+	_, err = vm.SnowVM.HealthCheck(ctx)
+	r.NoError(err)
 
 	network.SynchronizeNetwork(ctx)
 	blk, err := vm.SnowVM.GetConsensusIndex().GetLastAccepted(ctx)
@@ -750,6 +753,8 @@ func TestStateSync(t *testing.T) {
 	defer cancel()
 	err = vm.VM.SyncClient.Wait(awaitSyncCtx)
 	close(stopCh)
+	r.NoError(err)
+	_, err = vm.SnowVM.HealthCheck(ctx)
 	r.NoError(err)
 	<-stoppedCh
 


### PR DESCRIPTION
Adds a few small improvements to sync:

- improve `SetState` log to clearly indicate which state it's being set to
- Add a check that the health check is passing after `TestStateSync` and `TestSkipStateSync`
- Cut down e2e test time by reducing test block sequences by a factor of 4