### PR TITLE
Improve confirm invalid tx

### DIFF
--- a/x/dsmr/node.go
+++ b/x/dsmr/node.go
@@ -320,7 +320,6 @@ func (n *Node[T]) Verify(ctx context.Context, parent Block, block Block) error {
 
 	// Find repeats
 	oldestAllowed := max(0, block.Timestamp-int64(n.validityWindowDuration))
-
 	if err := n.validityWindow.VerifyExpiryReplayProtection(ctx, NewValidityWindowBlock(block), oldestAllowed); err != nil {
 		return fmt.Errorf("%w: block %s oldestAllowed - %d", err, block.GetID(), oldestAllowed)
 	}


### PR DESCRIPTION
This PR adds a step to `ConfirmInvalidTx` which will:
- construct a block on top of the currently preferred block including the invalid tx
- parse and verify the block and assert that it hits the same `targetErr` as for `SubmitTx`

This PR additionally fixes a bug in block verification found in the improved tests where the `parentTimestamp` was used as the `oldestAllowed` value rather than using `b.Tmstmp - r.GetValidityWindow()`.