### PR TITLE
Improve dynamic state sync transition comments

### DIFF
--- a/snow/block.go
+++ b/snow/block.go
@@ -137,7 +137,7 @@ func (b *StatefulBlock[I, O, A]) Verify(ctx context.Context) error {
 		b.vm.metrics.blockVerify.Observe(float64(time.Since(start)))
 	}()
 
-	ready := b.vm.ready.Load()
+	ready := b.vm.ready
 	ctx, span := b.vm.tracer.Start(
 		ctx, "StatefulBlock.Verify",
 		trace.WithAttributes(
@@ -260,7 +260,7 @@ func (b *StatefulBlock[I, O, A]) Accept(ctx context.Context) error {
 	defer b.vm.log.Info("accepting block", zap.Stringer("block", b))
 
 	// If I'm not ready yet, mark myself as accepted, and return early.
-	isReady := b.vm.ready.Load()
+	isReady := b.vm.ready
 	if !isReady {
 		return b.markAccepted(ctx, nil)
 	}

--- a/snow/statesync.go
+++ b/snow/statesync.go
@@ -26,7 +26,7 @@ func (v *VM[I, O, A]) StartStateSync(ctx context.Context, block I) error {
 	if err := v.inputChainIndex.UpdateLastAccepted(ctx, block); err != nil {
 		return err
 	}
-	v.ready.Store(false)
+	v.ready = false
 	v.setLastAccepted(NewInputBlock(v, block))
 	return nil
 }
@@ -38,7 +38,7 @@ func (v *VM[I, O, A]) FinishStateSync(ctx context.Context, input I, output O, ac
 	defer v.chainLock.Unlock()
 
 	// Cannot call FinishStateSync if already marked as ready and in normal operation
-	if v.ready.Load() {
+	if v.ready {
 		return fmt.Errorf("can't finish dynamic state sync from normal operation: %s", input)
 	}
 
@@ -68,7 +68,7 @@ func (v *VM[I, O, A]) FinishStateSync(ctx context.Context, input I, output O, ac
 		return err
 	}
 
-	v.ready.Store(true)
+	v.ready = true
 	return nil
 }
 

--- a/snow/vm.go
+++ b/snow/vm.go
@@ -104,7 +104,7 @@ type VM[I Block, O Block, A Block] struct {
 	version              string
 
 	// chainLock provides a synchronization point between state sync and normal operation.
-	// To complete dynamic state sync, we may:
+	// To complete dynamic state sync, we must:
 	// 1. Accept a sequence of blocks from the final state sync target to the last accepted block
 	// 2. Re-process all outstanding processing blocks
 	// 3. Mark the VM as ready for normal operation

--- a/snow/vm.go
+++ b/snow/vm.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"net/http"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/ava-labs/avalanchego/api/health"
@@ -104,9 +103,17 @@ type VM[I Block, O Block, A Block] struct {
 	preReadyAcceptedSubs []event.Subscription[I]
 	version              string
 
-	// chainLock must be held to process a block with chain (Build/Verify/Accept).
-	chainLock       sync.Mutex
-	chain           Chain[I, O, A]
+	// chainLock provides a synchronization point between state sync and normal operation.
+	// To complete dynamic state sync, we may:
+	// 1. Accept a sequence of blocks from the final state sync target to the last accepted block
+	// 2. Re-process all outstanding processing blocks
+	// 3. Mark the VM as ready for normal operation
+	//
+	// During this time, we must not allow any new blocks to be verified/accepted.
+	chainLock sync.Mutex
+	chain     Chain[I, O, A]
+	ready     bool
+
 	inputChainIndex ChainIndex[I]
 	consensusIndex  *ConsensusIndex[I, O, A]
 
@@ -130,8 +137,6 @@ type VM[I Block, O Block, A Block] struct {
 	metaLock          sync.Mutex
 	lastAcceptedBlock *StatefulBlock[I, O, A]
 	preferredBlkID    ids.ID
-
-	ready atomic.Bool
 
 	metrics *Metrics
 	log     logging.Logger
@@ -283,10 +288,6 @@ func (v *VM[I, O, A]) GetBlock(ctx context.Context, blkID ids.ID) (*StatefulBloc
 	}
 	v.verifiedL.RUnlock()
 
-	// Check if last accepted block or recently accepted
-	if v.lastAcceptedBlock.ID() == blkID {
-		return v.lastAcceptedBlock, nil
-	}
 	if blk, ok := v.acceptedBlocksByID.Get(blkID); ok {
 		return blk, nil
 	}


### PR DESCRIPTION
Update the comments around `chainLock` used to synchronize between finishing dynamic state sync and entering normal operation.