### PR TITLE
Refactor Processor `Execute()`

### DIFF
--- a/chain/chain.go
+++ b/chain/chain.go
@@ -89,13 +89,6 @@ func (c *Chain) Execute(
 	return c.processor.Execute(ctx, parentView, b, isNormalOp)
 }
 
-func (c *Chain) AsyncVerify(
-	ctx context.Context,
-	b *ExecutionBlock,
-) error {
-	return c.processor.asyncVerify(ctx, b)
-}
-
 func (c *Chain) PreExecute(
 	ctx context.Context,
 	parentBlk *ExecutionBlock,

--- a/chain/chain.go
+++ b/chain/chain.go
@@ -93,7 +93,7 @@ func (c *Chain) AsyncVerify(
 	ctx context.Context,
 	b *ExecutionBlock,
 ) error {
-	return c.processor.AsyncVerify(ctx, b)
+	return c.processor.asyncVerify(ctx, b)
 }
 
 func (c *Chain) PreExecute(

--- a/chain/errors.go
+++ b/chain/errors.go
@@ -58,7 +58,9 @@ var (
 	ErrKeyNotSpecified = errors.New("key not specified")
 
 	// State Correctness
-	ErrFailedToFetchFee = errors.New("failed to fetch fee")
+	ErrFailedToFetchParentHeight    = errors.New("failed to fetch height from state")
+	ErrFailedToFetchParentTimestamp = errors.New("failed to fetch timestamp from state")
+	ErrFailedToFetchParentFee       = errors.New("failed to fetch fee manager from state")
 
 	// Misc
 	ErrNotImplemented         = errors.New("not implemented")

--- a/chain/pre_executor.go
+++ b/chain/pre_executor.go
@@ -42,7 +42,7 @@ func (p *PreExecutor) PreExecute(
 ) error {
 	feeRaw, err := im.GetValue(ctx, FeeKey(p.metadataManager.FeePrefix()))
 	if err != nil {
-		return fmt.Errorf("%w: %w", ErrFailedToFetchFee, err)
+		return fmt.Errorf("%w: %w", ErrFailedToFetchParentFee, err)
 	}
 	feeManager := internalfees.NewManager(feeRaw)
 	now := time.Now().UnixMilli()

--- a/chain/pre_executor_test.go
+++ b/chain/pre_executor_test.go
@@ -66,7 +66,7 @@ func TestPreExecutor(t *testing.T) {
 		{
 			name: "raw fee missing",
 			tx:   validTx,
-			err:  chain.ErrFailedToFetchFee,
+			err:  chain.ErrFailedToFetchParentFee,
 		},
 		{
 			name: "validity window error",


### PR DESCRIPTION
This PR modifies up the `Execute()` method of the Processor by delegating several components of the method into independent functions which `Execute()` can then call. As a result, this PR allows for the following:

- Easier legibility of `Execute()`
- The possibility for UTs to test these new functions, allowing for better test coverage.