### PR TITLE
Remove unnecessary handle preexecute

### DIFF
--- a/chain/builder.go
+++ b/chain/builder.go
@@ -272,9 +272,10 @@ func (c *Builder) BuildBlock(ctx context.Context, parentOutputBlock *OutputBlock
 					len(stateKeys),
 				)
 				if err := tx.PreExecute(ctx, feeManager, c.balanceHandler, r, tsv, nextTime); err != nil {
+					// Ignore the error and drop the transaction.
 					// We don't need to rollback [tsv] here because it will never
 					// be committed.
-					return nil
+					return nil //nolint:nilerr
 				}
 				result, err := tx.Execute(
 					ctx,

--- a/chain/builder.go
+++ b/chain/builder.go
@@ -36,27 +36,6 @@ const (
 
 var errBlockFull = errors.New("block full")
 
-func HandlePreExecute(log logging.Logger, err error) bool {
-	switch {
-	case errors.Is(err, ErrInsufficientPrice):
-		return false
-	case errors.Is(err, ErrTimestampTooEarly):
-		return true
-	case errors.Is(err, ErrTimestampTooLate):
-		return false
-	case errors.Is(err, ErrAuthNotActivated):
-		return false
-	case errors.Is(err, ErrAuthFailed):
-		return false
-	case errors.Is(err, ErrActionNotActivated):
-		return false
-	default:
-		// If unknown error, drop
-		log.Warn("unknown PreExecute error", zap.Error(err))
-		return false
-	}
-}
-
 type Builder struct {
 	tracer          trace.Tracer
 	ruleFactory     RuleFactory
@@ -295,9 +274,6 @@ func (c *Builder) BuildBlock(ctx context.Context, parentOutputBlock *OutputBlock
 				if err := tx.PreExecute(ctx, feeManager, c.balanceHandler, r, tsv, nextTime); err != nil {
 					// We don't need to rollback [tsv] here because it will never
 					// be committed.
-					if HandlePreExecute(c.log, err) {
-						restore = true
-					}
 					return nil
 				}
 				result, err := tx.Execute(


### PR DESCRIPTION
This PR removes `HandlePreExecute` from the block builder.

HandlePreExecute checks an error and returns true iff the error indicates the transaction should be added back to the mempool, which adds additional complexity for developers to understand.

The only error that returns true and triggers adding the transaction back to the mempool is `ErrTimestampTooEarly`, which can occur:

https://github.com/ava-labs/hypersdk/blob/606db625ae6dceb3cf8ea2a8c76dee084e2b3eb1/chain/base.go#L40

This indicates that the transaction's timestamp is > a full validity window ahead of the timestamp of the block itself. In other words, this will add the tx back to the mempool if it's possible that it will become valid in the future. However, this should never happen because we will not allow such a transaction into the mempool in the first place because both the block builder and pre-executor (used when submitting a tx to the mempool) both use wall clock time to verify the tx:


https://github.com/ava-labs/hypersdk/blob/606db625ae6dceb3cf8ea2a8c76dee084e2b3eb1/chain/pre_executor.go#L48
https://github.com/ava-labs/hypersdk/blob/606db625ae6dceb3cf8ea2a8c76dee084e2b3eb1/chain/builder.go#L104