### PR TITLE
Move timestamp verification into validity window package

### DIFF
--- a/chain/base.go
+++ b/chain/base.go
@@ -13,7 +13,11 @@ import (
 	"github.com/ava-labs/hypersdk/internal/validitywindow"
 )
 
-const BaseSize = consts.Uint64Len*2 + ids.IDLen
+const (
+	BaseSize = consts.Uint64Len*2 + ids.IDLen
+	// TODO: make this divisor configurable
+	validityWindowTimestampDivisor = consts.MillisecondsPerSecond
+)
 
 type Base struct {
 	// Timestamp is the expiry of the transaction (inclusive). Once this time passes and the
@@ -34,7 +38,7 @@ func (b *Base) Execute(r Rules, timestamp int64) error {
 	if b.ChainID != r.GetChainID() {
 		return fmt.Errorf("%w: chainID=%s, expected=%s", ErrInvalidChainID, b.ChainID, r.GetChainID())
 	}
-	return validitywindow.VerifyTimestamp(b.Timestamp, timestamp, r.GetValidityWindow())
+	return validitywindow.VerifyTimestamp(b.Timestamp, timestamp, validityWindowTimestampDivisor, r.GetValidityWindow())
 }
 
 func (*Base) Size() int {

--- a/chain/base.go
+++ b/chain/base.go
@@ -54,7 +54,7 @@ func UnmarshalBase(p *codec.Packer) (*Base, error) {
 	base.Timestamp = p.UnpackInt64(true)
 	if base.Timestamp%consts.MillisecondsPerSecond != 0 {
 		// TODO: make this modulus configurable
-		return nil, fmt.Errorf("%w: timestamp=%d", ErrMisalignedTime, base.Timestamp)
+		return nil, fmt.Errorf("%w: timestamp=%d", validitywindow.ErrMisalignedTime, base.Timestamp)
 	}
 	p.UnpackID(true, &base.ChainID)
 	base.MaxFee = p.UnpackUint64(true)

--- a/chain/errors.go
+++ b/chain/errors.go
@@ -48,7 +48,6 @@ var (
 	ErrActionNotActivated   = errors.New("action not activated")
 	ErrAuthNotActivated     = errors.New("auth not activated")
 	ErrAuthFailed           = errors.New("auth failed")
-	ErrMisalignedTime       = errors.New("misaligned time")
 	ErrInvalidActor         = errors.New("invalid actor")
 	ErrInvalidSponsor       = errors.New("invalid sponsor")
 	ErrTooManyActions       = errors.New("too many actions")

--- a/chain/pre_executor_test.go
+++ b/chain/pre_executor_test.go
@@ -142,7 +142,7 @@ func TestPreExecutor(t *testing.T) {
 				Auth: &mockAuth{},
 			},
 			validityWindow: &validitywindowtest.MockTimeValidityWindow[*chain.Transaction]{},
-			err:            chain.ErrTimestampTooLate,
+			err:            validitywindow.ErrTimestampExpired,
 		},
 	}
 

--- a/chain/transaction_test.go
+++ b/chain/transaction_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ava-labs/hypersdk/crypto/ed25519"
 	"github.com/ava-labs/hypersdk/genesis"
 	"github.com/ava-labs/hypersdk/internal/fees"
+	"github.com/ava-labs/hypersdk/internal/validitywindow"
 	"github.com/ava-labs/hypersdk/state"
 	"github.com/ava-labs/hypersdk/utils"
 
@@ -370,10 +371,10 @@ func TestPreExecute(t *testing.T) {
 					},
 				},
 			},
-			err: chain.ErrMisalignedTime,
+			err: validitywindow.ErrMisalignedTime,
 		},
 		{
-			name: "base transaction timestamp too early (61ms > 60ms)",
+			name: "base transaction timestamp too far in future (61ms > 60ms)",
 			tx: &chain.Transaction{
 				TransactionData: chain.TransactionData{
 					Base: &chain.Base{
@@ -381,10 +382,10 @@ func TestPreExecute(t *testing.T) {
 					},
 				},
 			},
-			err: chain.ErrTimestampTooEarly,
+			err: validitywindow.ErrFutureTimestamp,
 		},
 		{
-			name: "base transaction timestamp too late (1ms < 2ms)",
+			name: "base transaction timestamp expired (1ms < 2ms)",
 			tx: &chain.Transaction{
 				TransactionData: chain.TransactionData{
 					Base: &chain.Base{
@@ -393,7 +394,7 @@ func TestPreExecute(t *testing.T) {
 				},
 			},
 			timestamp: 2 * consts.MillisecondsPerSecond,
-			err:       chain.ErrTimestampTooLate,
+			err:       validitywindow.ErrTimestampExpired,
 		},
 		{
 			name: "base transaction invalid chain id",

--- a/internal/validitywindow/validitywindow.go
+++ b/internal/validitywindow/validitywindow.go
@@ -16,7 +16,6 @@ import (
 	"github.com/ava-labs/avalanchego/utils/set"
 	"go.uber.org/zap"
 
-	"github.com/ava-labs/hypersdk/consts"
 	"github.com/ava-labs/hypersdk/internal/emap"
 )
 
@@ -184,11 +183,10 @@ func (v *TimeValidityWindow[T]) calculateOldestAllowed(timestamp int64) int64 {
 	return max(0, timestamp-v.getTimeValidityWindow(timestamp))
 }
 
-func VerifyTimestamp(containerTimestamp int64, executionTimestamp int64, validityWindow int64) error {
+func VerifyTimestamp(containerTimestamp int64, executionTimestamp int64, divisor int64, validityWindow int64) error {
 	switch {
-	case containerTimestamp%consts.MillisecondsPerSecond != 0:
-		// TODO: make this modulus configurable
-		return fmt.Errorf("%w: timestamp=%d", ErrMisalignedTime, containerTimestamp)
+	case containerTimestamp%divisor != 0:
+		return fmt.Errorf("%w: timestamp (%d) %% divisor (%d) != 0", ErrMisalignedTime, containerTimestamp, divisor)
 	case containerTimestamp < executionTimestamp: // expiry: 100 block: 110
 		return fmt.Errorf("%w: timestamp (%d) < block timestamp (%d)", ErrTimestampExpired, containerTimestamp, executionTimestamp)
 	case containerTimestamp > executionTimestamp+validityWindow: // expiry: 100 block 10

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/ava-labs/hypersdk/extension/externalsubscriber"
 	"github.com/ava-labs/hypersdk/genesis"
 	"github.com/ava-labs/hypersdk/internal/mempool"
+	"github.com/ava-labs/hypersdk/internal/validitywindow"
 	"github.com/ava-labs/hypersdk/keys"
 	"github.com/ava-labs/hypersdk/state"
 	"github.com/ava-labs/hypersdk/state/balance"
@@ -209,7 +210,7 @@ func TestSubmitTx(t *testing.T) {
 			targetErr: nil,
 		},
 		{
-			name: chain.ErrMisalignedTime.Error(),
+			name: validitywindow.ErrMisalignedTime.Error(),
 			makeTx: func(r *require.Assertions, network *vmtest.TestNetwork) *chain.Transaction {
 				unsignedTx := chain.NewTxData(
 					&chain.Base{
@@ -223,10 +224,10 @@ func TestSubmitTx(t *testing.T) {
 				r.NoError(err)
 				return tx
 			},
-			targetErr: chain.ErrMisalignedTime,
+			targetErr: validitywindow.ErrMisalignedTime,
 		},
 		{
-			name: chain.ErrTimestampTooLate.Error(),
+			name: validitywindow.ErrTimestampExpired.Error(),
 			makeTx: func(r *require.Assertions, network *vmtest.TestNetwork) *chain.Transaction {
 				unsignedTx := chain.NewTxData(
 					&chain.Base{
@@ -240,10 +241,10 @@ func TestSubmitTx(t *testing.T) {
 				r.NoError(err)
 				return tx
 			},
-			targetErr: chain.ErrTimestampTooLate,
+			targetErr: validitywindow.ErrTimestampExpired,
 		},
 		{
-			name: chain.ErrTimestampTooEarly.Error(),
+			name: validitywindow.ErrFutureTimestamp.Error(),
 			makeTx: func(r *require.Assertions, network *vmtest.TestNetwork) *chain.Transaction {
 				unsignedTx := chain.NewTxData(
 					&chain.Base{
@@ -257,7 +258,7 @@ func TestSubmitTx(t *testing.T) {
 				r.NoError(err)
 				return tx
 			},
-			targetErr: chain.ErrTimestampTooEarly,
+			targetErr: validitywindow.ErrFutureTimestamp,
 		},
 		{
 			name: "invalid auth",

--- a/x/dsmr/node_test.go
+++ b/x/dsmr/node_test.go
@@ -41,7 +41,12 @@ var (
 	_ Tx                    = (*dsmrtest.Tx)(nil)
 	_ Verifier[dsmrtest.Tx] = (*failVerifier)(nil)
 
-	chainID = ids.Empty
+	chainID         = ids.Empty
+	testRuleFactory = ruleFactory{
+		rules: rules{
+			validityWindow: int64(testingDefaultValidityWindowDuration),
+		},
+	}
 
 	errTestingInvalidValidityWindow = errors.New("time validity window testing error")
 )
@@ -469,7 +474,7 @@ func TestNode_GetChunkSignature_SignValidChunk(t *testing.T) {
 				},
 				1,
 				1,
-				testingDefaultValidityWindowDuration,
+				testRuleFactory,
 			),
 			wantErr:                   ErrInvalidChunk,
 			producerNode:              ids.GenerateTestNodeID(),
@@ -490,7 +495,7 @@ func TestNode_GetChunkSignature_SignValidChunk(t *testing.T) {
 				},
 				1,
 				1,
-				testingDefaultValidityWindowDuration,
+				testRuleFactory,
 			),
 			wantErr:                   ErrInvalidChunk,
 			producerNode:              nodeID,
@@ -511,12 +516,12 @@ func TestNode_GetChunkSignature_SignValidChunk(t *testing.T) {
 				},
 				1,
 				1,
-				testingDefaultValidityWindowDuration,
+				testRuleFactory,
 			),
 			wantErr:                   ErrInvalidChunk,
 			producerNode:              nodeID,
 			nodeLastAcceptedTimestamp: 1,
-			chunkExpiry:               1 + int64(testingDefaultValidityWindowDuration),
+			chunkExpiry:               2 + int64(testingDefaultValidityWindowDuration),
 		},
 		{
 			name:         "valid chunk",
@@ -533,7 +538,7 @@ func TestNode_GetChunkSignature_SignValidChunk(t *testing.T) {
 				},
 				1,
 				1,
-				testingDefaultValidityWindowDuration,
+				testRuleFactory,
 			),
 			nodeLastAcceptedTimestamp: 1,
 			chunkExpiry:               123,
@@ -603,7 +608,7 @@ func TestNode_GetChunkSignature_SignValidChunk(t *testing.T) {
 				1,
 				1,
 				&validitywindowtest.MockTimeValidityWindow[*emapChunkCertificate]{},
-				testingDefaultValidityWindowDuration,
+				testRuleFactory,
 			)
 			r.NoError(err)
 
@@ -1406,7 +1411,7 @@ func newTestNodes(t *testing.T, n int) []*Node[dsmrtest.Tx] {
 			pChain{validators: validators},
 			1,
 			1,
-			testingDefaultValidityWindowDuration,
+			testRuleFactory,
 		)
 		chunkStorage, err := NewChunkStorage[dsmrtest.Tx](verifier, memdb.New())
 		require.NoError(t, err)
@@ -1483,7 +1488,7 @@ func newTestNodes(t *testing.T, n int) []*Node[dsmrtest.Tx] {
 			1,
 			1,
 			&validitywindowtest.MockTimeValidityWindow[*emapChunkCertificate]{},
-			testingDefaultValidityWindowDuration,
+			testRuleFactory,
 		)
 		require.NoError(t, err)
 
@@ -1520,3 +1525,15 @@ func newTestNodes(t *testing.T, n int) []*Node[dsmrtest.Tx] {
 
 	return result
 }
+
+type ruleFactory struct {
+	rules rules
+}
+
+func (r ruleFactory) GetRules(int64) Rules { return r.rules }
+
+type rules struct {
+	validityWindow int64
+}
+
+func (r rules) GetValidityWindow() int64 { return r.validityWindow }


### PR DESCRIPTION
This PR moves timestamp verification checks into the time validity window package. Same code will be shared across tx and chunks.