### PR TITLE
Add rules to dsmr and integrate validitywindow timestamp verification

### DIFF
--- a/chain/base.go
+++ b/chain/base.go
@@ -13,7 +13,11 @@ import (
 	"github.com/ava-labs/hypersdk/internal/validitywindow"
 )
 
-const BaseSize = consts.Uint64Len*2 + ids.IDLen
+const (
+	BaseSize = consts.Uint64Len*2 + ids.IDLen
+	// TODO: make this divisor configurable
+	validityWindowTimestampDivisor = consts.MillisecondsPerSecond
+)
 
 type Base struct {
 	// Timestamp is the expiry of the transaction (inclusive). Once this time passes and the
@@ -34,7 +38,7 @@ func (b *Base) Execute(r Rules, timestamp int64) error {
 	if b.ChainID != r.GetChainID() {
 		return fmt.Errorf("%w: chainID=%s, expected=%s", ErrInvalidChainID, b.ChainID, r.GetChainID())
 	}
-	return validitywindow.VerifyTimestamp(b.Timestamp, timestamp, r.GetValidityWindow())
+	return validitywindow.VerifyTimestamp(b.Timestamp, timestamp, validityWindowTimestampDivisor, r.GetValidityWindow())
 }
 
 func (*Base) Size() int {

--- a/internal/validitywindow/validitywindow.go
+++ b/internal/validitywindow/validitywindow.go
@@ -16,7 +16,6 @@ import (
 	"github.com/ava-labs/avalanchego/utils/set"
 	"go.uber.org/zap"
 
-	"github.com/ava-labs/hypersdk/consts"
 	"github.com/ava-labs/hypersdk/internal/emap"
 )
 
@@ -184,11 +183,10 @@ func (v *TimeValidityWindow[T]) calculateOldestAllowed(timestamp int64) int64 {
 	return max(0, timestamp-v.getTimeValidityWindow(timestamp))
 }
 
-func VerifyTimestamp(containerTimestamp int64, executionTimestamp int64, validityWindow int64) error {
+func VerifyTimestamp(containerTimestamp int64, executionTimestamp int64, divisor int64, validityWindow int64) error {
 	switch {
-	case containerTimestamp%consts.MillisecondsPerSecond != 0:
-		// TODO: make this modulus configurable
-		return fmt.Errorf("%w: timestamp=%d", ErrMisalignedTime, containerTimestamp)
+	case containerTimestamp%divisor != 0:
+		return fmt.Errorf("%w: timestamp (%d) %% divisor (%d) != 0", ErrMisalignedTime, containerTimestamp, divisor)
 	case containerTimestamp < executionTimestamp: // expiry: 100 block: 110
 		return fmt.Errorf("%w: timestamp (%d) < block timestamp (%d)", ErrTimestampExpired, containerTimestamp, executionTimestamp)
 	case containerTimestamp > executionTimestamp+validityWindow: // expiry: 100 block 10

--- a/x/dsmr/node_test.go
+++ b/x/dsmr/node_test.go
@@ -41,7 +41,12 @@ var (
 	_ Tx                    = (*dsmrtest.Tx)(nil)
 	_ Verifier[dsmrtest.Tx] = (*failVerifier)(nil)
 
-	chainID = ids.Empty
+	chainID         = ids.Empty
+	testRuleFactory = ruleFactory{
+		rules: rules{
+			validityWindow: int64(testingDefaultValidityWindowDuration),
+		},
+	}
 
 	errTestingInvalidValidityWindow = errors.New("time validity window testing error")
 )
@@ -469,7 +474,7 @@ func TestNode_GetChunkSignature_SignValidChunk(t *testing.T) {
 				},
 				1,
 				1,
-				testingDefaultValidityWindowDuration,
+				testRuleFactory,
 			),
 			wantErr:                   ErrInvalidChunk,
 			producerNode:              ids.GenerateTestNodeID(),
@@ -490,7 +495,7 @@ func TestNode_GetChunkSignature_SignValidChunk(t *testing.T) {
 				},
 				1,
 				1,
-				testingDefaultValidityWindowDuration,
+				testRuleFactory,
 			),
 			wantErr:                   ErrInvalidChunk,
 			producerNode:              nodeID,
@@ -511,12 +516,12 @@ func TestNode_GetChunkSignature_SignValidChunk(t *testing.T) {
 				},
 				1,
 				1,
-				testingDefaultValidityWindowDuration,
+				testRuleFactory,
 			),
 			wantErr:                   ErrInvalidChunk,
 			producerNode:              nodeID,
 			nodeLastAcceptedTimestamp: 1,
-			chunkExpiry:               1 + int64(testingDefaultValidityWindowDuration),
+			chunkExpiry:               2 + int64(testingDefaultValidityWindowDuration),
 		},
 		{
 			name:         "valid chunk",
@@ -533,7 +538,7 @@ func TestNode_GetChunkSignature_SignValidChunk(t *testing.T) {
 				},
 				1,
 				1,
-				testingDefaultValidityWindowDuration,
+				testRuleFactory,
 			),
 			nodeLastAcceptedTimestamp: 1,
 			chunkExpiry:               123,
@@ -603,7 +608,7 @@ func TestNode_GetChunkSignature_SignValidChunk(t *testing.T) {
 				1,
 				1,
 				&validitywindowtest.MockTimeValidityWindow[*emapChunkCertificate]{},
-				testingDefaultValidityWindowDuration,
+				testRuleFactory,
 			)
 			r.NoError(err)
 
@@ -1406,7 +1411,7 @@ func newTestNodes(t *testing.T, n int) []*Node[dsmrtest.Tx] {
 			pChain{validators: validators},
 			1,
 			1,
-			testingDefaultValidityWindowDuration,
+			testRuleFactory,
 		)
 		chunkStorage, err := NewChunkStorage[dsmrtest.Tx](verifier, memdb.New())
 		require.NoError(t, err)
@@ -1483,7 +1488,7 @@ func newTestNodes(t *testing.T, n int) []*Node[dsmrtest.Tx] {
 			1,
 			1,
 			&validitywindowtest.MockTimeValidityWindow[*emapChunkCertificate]{},
-			testingDefaultValidityWindowDuration,
+			testRuleFactory,
 		)
 		require.NoError(t, err)
 
@@ -1520,3 +1525,15 @@ func newTestNodes(t *testing.T, n int) []*Node[dsmrtest.Tx] {
 
 	return result
 }
+
+type ruleFactory struct {
+	rules rules
+}
+
+func (r ruleFactory) GetRules(int64) Rules { return r.rules }
+
+type rules struct {
+	validityWindow int64
+}
+
+func (r rules) GetValidityWindow() int64 { return r.validityWindow }


### PR DESCRIPTION
This PR switches from using a static validity window duration to using a rule factory + rules in the same pattern as in the chain package.

This also updates the timestamp check to take the divisor as a parameter, so that we can use divisor of 1 in DSMR (avoid updating the tests / adding further changes into this PR).