### PR TITLE
Add P-Chain ctx into inner block and verify within snow pkg

### DIFF
--- a/chain/builder.go
+++ b/chain/builder.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
 	"github.com/ava-labs/avalanchego/trace"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"go.opentelemetry.io/otel/attribute"
@@ -72,7 +73,7 @@ func NewBuilder(
 	}
 }
 
-func (c *Builder) BuildBlock(ctx context.Context, parentOutputBlock *OutputBlock) (*ExecutionBlock, *OutputBlock, error) {
+func (c *Builder) BuildBlock(ctx context.Context, pChainCtx *block.Context, parentOutputBlock *OutputBlock) (*ExecutionBlock, *OutputBlock, error) {
 	ctx, span := c.tracer.Start(ctx, "Chain.BuildBlock")
 	defer span.End()
 
@@ -426,6 +427,7 @@ func (c *Builder) BuildBlock(ctx context.Context, parentOutputBlock *OutputBlock
 		height,
 		blockTransactions,
 		parentStateRoot,
+		pChainCtx,
 	)
 	if err != nil {
 		return nil, nil, err

--- a/chain/chain.go
+++ b/chain/chain.go
@@ -6,6 +6,7 @@ package chain
 import (
 	"context"
 
+	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
 	"github.com/ava-labs/avalanchego/trace"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/x/merkledb"
@@ -76,8 +77,8 @@ func NewChain(
 	}, nil
 }
 
-func (c *Chain) BuildBlock(ctx context.Context, parentOutputBlock *OutputBlock) (*ExecutionBlock, *OutputBlock, error) {
-	return c.builder.BuildBlock(ctx, parentOutputBlock)
+func (c *Chain) BuildBlock(ctx context.Context, pChainCtx *block.Context, parentOutputBlock *OutputBlock) (*ExecutionBlock, *OutputBlock, error) {
+	return c.builder.BuildBlock(ctx, pChainCtx, parentOutputBlock)
 }
 
 func (c *Chain) Execute(

--- a/chain/chaintest/block.go
+++ b/chain/chaintest/block.go
@@ -27,6 +27,7 @@ func GenerateEmptyExecutedBlocks(
 			parentHeight+1+uint64(i),
 			[]*chain.Transaction{},
 			ids.Empty,
+			nil,
 		)
 		require.NoError(err)
 		parentID = statelessBlock.GetID()

--- a/chain/stateless_block.go
+++ b/chain/stateless_block.go
@@ -21,7 +21,7 @@ type StatelessBlock struct {
 	Tmstmp int64  `json:"timestamp"`
 	Hght   uint64 `json:"height"`
 
-	BlockContext *block.Context `json:"pChainHeight"`
+	BlockContext *block.Context `json:"blockContext"`
 
 	Txs []*Transaction `json:"txs"`
 

--- a/chain/stateless_block.go
+++ b/chain/stateless_block.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
 
 	"github.com/ava-labs/hypersdk/codec"
 	"github.com/ava-labs/hypersdk/consts"
@@ -19,6 +20,8 @@ type StatelessBlock struct {
 	Prnt   ids.ID `json:"parent"`
 	Tmstmp int64  `json:"timestamp"`
 	Hght   uint64 `json:"height"`
+
+	BlockContext *block.Context `json:"pChainHeight"`
 
 	Txs []*Transaction `json:"txs"`
 
@@ -42,13 +45,15 @@ func NewStatelessBlock(
 	height uint64,
 	txs []*Transaction,
 	stateRoot ids.ID,
+	blockContext *block.Context,
 ) (*StatelessBlock, error) {
 	block := &StatelessBlock{
-		Prnt:      parentID,
-		Tmstmp:    timestamp,
-		Hght:      height,
-		Txs:       txs,
-		StateRoot: stateRoot,
+		Prnt:         parentID,
+		Tmstmp:       timestamp,
+		Hght:         height,
+		Txs:          txs,
+		StateRoot:    stateRoot,
+		BlockContext: blockContext,
 	}
 	blkBytes, err := block.Marshal()
 	if err != nil {
@@ -66,6 +71,9 @@ func (b *StatelessBlock) GetStateRoot() ids.ID { return b.StateRoot }
 func (b *StatelessBlock) GetHeight() uint64    { return b.Hght }
 func (b *StatelessBlock) GetTimestamp() int64  { return b.Tmstmp }
 func (b *StatelessBlock) GetParent() ids.ID    { return b.Prnt }
+func (b *StatelessBlock) GetContext() *block.Context {
+	return b.BlockContext
+}
 
 func (b *StatelessBlock) String() string {
 	return fmt.Sprintf("(BlockID=%s, Height=%d, ParentRoot=%s, NumTxs=%d, Size=%d)", b.id, b.Hght, b.Prnt, len(b.Txs), len(b.bytes))
@@ -82,6 +90,12 @@ func (b *StatelessBlock) Marshal() ([]byte, error) {
 	p.PackID(b.Prnt)
 	p.PackInt64(b.Tmstmp)
 	p.PackUint64(b.Hght)
+	if b.BlockContext == nil {
+		p.PackBool(false)
+	} else {
+		p.PackBool(true)
+		p.PackUint64(b.BlockContext.PChainHeight)
+	}
 
 	p.PackInt(uint32(len(b.Txs)))
 	for _, tx := range b.Txs {
@@ -107,6 +121,10 @@ func UnmarshalBlock(raw []byte, parser Parser) (*StatelessBlock, error) {
 	p.UnpackID(false, &b.Prnt)
 	b.Tmstmp = p.UnpackInt64(false)
 	b.Hght = p.UnpackUint64(false)
+	blockCtxExists := p.UnpackBool()
+	if blockCtxExists {
+		b.BlockContext = &block.Context{PChainHeight: p.UnpackUint64(false)}
+	}
 
 	// Parse transactions
 	txCount := p.UnpackInt(false) // can produce empty blocks
@@ -146,6 +164,7 @@ func NewGenesisBlock(root ids.ID) (*ExecutionBlock, error) {
 		0,
 		nil,
 		root, // StateRoot should include all allocates made when loading the genesis file
+		nil,
 	)
 	if err != nil {
 		return nil, err

--- a/snow/block.go
+++ b/snow/block.go
@@ -135,7 +135,7 @@ func (b *StatefulBlock[I, O, A]) accept(ctx context.Context, parentAccepted A) e
 	return nil
 }
 
-func (b *StatefulBlock[I, O, A]) ShouldVerifyWithContext(ctx context.Context) (bool, error) {
+func (*StatefulBlock[I, O, A]) ShouldVerifyWithContext(context.Context) (bool, error) {
 	return true, nil
 }
 

--- a/snow/block.go
+++ b/snow/block.go
@@ -177,9 +177,17 @@ func (b *StatefulBlock[I, O, A]) verifyWithContext(ctx context.Context, pChainCt
 			zap.Stringer("blkID", b.Input.GetID()),
 		)
 	case b.verified:
+		// Defensive: verify the inner and wrapper block contexts match to ensure
+		// we don't build a block with a mismatched P-Chain context that will be
+		// invalid to peers.
+		innerCtx := b.Input.GetContext()
+		if err := verifyPChainCtx(pChainCtx, innerCtx); err != nil {
+			return err
+		}
+
 		// If we built the block, the state will already be populated and we don't
 		// need to compute it (we assume that we built a correct block and it isn't
-		// necessary to re-verify anything).
+		// necessary to re-verify).
 		b.vm.log.Info(
 			"skipping verification of locally built block",
 			zap.Uint64("height", b.Input.GetHeight()),

--- a/snow/block.go
+++ b/snow/block.go
@@ -20,7 +20,8 @@ import (
 )
 
 var (
-	_ snowman.Block = (*StatefulBlock[Block, Block, Block])(nil)
+	_ snowman.Block           = (*StatefulBlock[Block, Block, Block])(nil)
+	_ block.WithVerifyContext = (*StatefulBlock[Block, Block, Block])(nil)
 
 	errParentFailedVerification = errors.New("parent failed verification")
 	errMismatchedPChainContext  = errors.New("mismatched P-Chain context")

--- a/snow/snow_vm.go
+++ b/snow/snow_vm.go
@@ -12,8 +12,9 @@ import (
 )
 
 var (
-	_ block.ChainVM         = (*SnowVM[Block, Block, Block])(nil)
-	_ block.StateSyncableVM = (*SnowVM[Block, Block, Block])(nil)
+	_ block.ChainVM                      = (*SnowVM[Block, Block, Block])(nil)
+	_ block.StateSyncableVM              = (*SnowVM[Block, Block, Block])(nil)
+	_ block.BuildBlockWithContextChainVM = (*SnowVM[Block, Block, Block])(nil)
 )
 
 // SnowVM wraps the VM and completes the implementation of block.ChainVM by providing
@@ -37,4 +38,8 @@ func (v *SnowVM[I, O, A]) ParseBlock(ctx context.Context, bytes []byte) (snowman
 
 func (v *SnowVM[I, O, A]) BuildBlock(ctx context.Context) (snowman.Block, error) {
 	return v.VM.BuildBlock(ctx)
+}
+
+func (v *SnowVM[I, O, A]) BuildBlockWithContext(ctx context.Context, blockContext *block.Context) (snowman.Block, error) {
+	return v.VM.BuildBlockWithContext(ctx, blockContext)
 }

--- a/snow/vm_test.go
+++ b/snow/vm_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow/engine/common"
 	"github.com/ava-labs/avalanchego/snow/engine/enginetest"
+	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
 	"github.com/ava-labs/avalanchego/snow/snowtest"
 	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/hashing"
@@ -51,6 +52,8 @@ type TestBlock struct {
 	// Invalid marks a block that should return an error during execution.
 	// This should make it easy to construct a block that should fail execution.
 	Invalid bool `json:"invalid"`
+
+	BlockContext *block.Context `json:"pChainHeight"`
 
 	outputPopulated   bool
 	acceptedPopulated bool
@@ -87,6 +90,10 @@ func (t *TestBlock) GetBytes() []byte {
 
 func (t *TestBlock) GetHeight() uint64 {
 	return t.Hght
+}
+
+func (t *TestBlock) GetContext() *block.Context {
+	return t.BlockContext
 }
 
 func (t *TestBlock) String() string {
@@ -136,7 +143,7 @@ func (t *TestChain) Initialize(
 
 func (*TestChain) SetConsensusIndex(_ *ConsensusIndex[*TestBlock, *TestBlock, *TestBlock]) {}
 
-func (t *TestChain) BuildBlock(_ context.Context, parent *TestBlock) (*TestBlock, *TestBlock, error) {
+func (t *TestChain) BuildBlock(_ context.Context, _ *block.Context, parent *TestBlock) (*TestBlock, *TestBlock, error) {
 	t.require.True(parent.outputPopulated)
 	builtBlock := NewTestBlockFromParent(parent)
 	builtBlock.outputPopulated = true

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/network/p2p"
 	"github.com/ava-labs/avalanchego/snow"
+	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/x/merkledb"
 	"github.com/prometheus/client_golang/prometheus"
@@ -654,10 +655,10 @@ func (vm *VM) ParseBlock(ctx context.Context, source []byte) (*chain.ExecutionBl
 	return vm.chain.ParseBlock(ctx, source)
 }
 
-func (vm *VM) BuildBlock(ctx context.Context, parent *chain.OutputBlock) (*chain.ExecutionBlock, *chain.OutputBlock, error) {
+func (vm *VM) BuildBlock(ctx context.Context, pChainCtx *block.Context, parent *chain.OutputBlock) (*chain.ExecutionBlock, *chain.OutputBlock, error) {
 	defer vm.checkActivity(ctx)
 
-	return vm.chain.BuildBlock(ctx, parent)
+	return vm.chain.BuildBlock(ctx, pChainCtx, parent)
 }
 
 func (vm *VM) VerifyBlock(ctx context.Context, parent *chain.OutputBlock, block *chain.ExecutionBlock) (*chain.OutputBlock, error) {

--- a/vm/vmtest/network.go
+++ b/vm/vmtest/network.go
@@ -359,6 +359,7 @@ func (n *TestNetwork) ConfirmInvalidTx(ctx context.Context, invalidTx *chain.Tra
 		parentBlk.Hght+1,
 		[]*chain.Transaction{invalidTx},
 		parentRoot,
+		nil,
 	)
 	n.require.NoError(err)
 


### PR DESCRIPTION
This PR adds the P-Chain context into the inner block.

This embeds it directly into the inner block, so that it's always available to the inner block. By adding this into the inner block interface, we can verify it against the consensus context in the snow package, so that the inner VM/chain does not need to.