### PR TITLE
Remove vm level statesync health check

### DIFF
--- a/statesync/client.go
+++ b/statesync/client.go
@@ -17,8 +17,6 @@ import (
 
 var isSyncing = []byte("is_syncing")
 
-var errStateSyncIncomplete = errors.New("state syncing")
-
 type ChainClient[T StateSummaryBlock] interface {
 	LastAcceptedBlock(ctx context.Context) T
 	ParseBlock(ctx context.Context, bytes []byte) (T, error)

--- a/statesync/client.go
+++ b/statesync/client.go
@@ -231,14 +231,3 @@ func (c *Client[T]) PutDiskIsSyncing(v bool) error {
 	}
 	return c.db.Put(isSyncing, []byte{0x0})
 }
-
-func (c *Client[T]) HealthCheck(_ context.Context) (interface{}, error) {
-	select {
-	case <-c.done:
-		c.log.Info("Invoking state sync health check", zap.Error(c.err))
-		return nil, c.err
-	default:
-		c.log.Info("Invoking state sync health check", zap.Error(errStateSyncIncomplete))
-		return nil, errStateSyncIncomplete
-	}
-}

--- a/vm/statesync.go
+++ b/vm/statesync.go
@@ -144,5 +144,5 @@ func (vm *VM) initStateSync(ctx context.Context) error {
 	server := statesync.NewServer[*chain.ExecutionBlock](vm.snowCtx.Log, inputCovariantVM)
 	stateSyncableVM := statesync.NewStateSyncableVM(client, server)
 	vm.snowApp.SetStateSyncableVM(stateSyncableVM)
-	return vm.snowApp.RegisterHealthChecker(StateSyncNamespace, vm.SyncClient)
+	return nil
 }


### PR DESCRIPTION
This package removes the VM level statesync health check.

Fixes https://github.com/ava-labs/hypersdk/issues/1902