### PR TITLE
Fix chain index compaction offset

### DIFF
--- a/chainindex/chain_index.go
+++ b/chainindex/chain_index.go
@@ -137,7 +137,7 @@ func (c *ChainIndex[T]) UpdateLastAccepted(ctx context.Context, blk T) error {
 	}
 	c.metrics.deletedBlocks.Inc()
 
-	if expiryHeight%c.compactionOffset == 0 {
+	if expiryHeight%c.config.BlockCompactionFrequency == c.compactionOffset {
 		go func() {
 			start := time.Now()
 			if err := c.db.Compact([]byte{blockPrefix}, prefixBlockKey(expiryHeight)); err != nil {


### PR DESCRIPTION
Fixes https://github.com/ava-labs/hypersdk/issues/1904

This also fixes an issue where the chain index compacted at an incorrect interval (randomly calculated frequency between every block and the actual requested block compaction frequency instead of the requested block compaction frequency).