### PR TITLE
Fix `SimulateActions` State Keys

### DIFF
--- a/api/jsonrpc/server.go
+++ b/api/jsonrpc/server.go
@@ -6,6 +6,7 @@ package jsonrpc
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"net/http"
 	"time"
 
@@ -330,7 +331,7 @@ func (j *JSONRPCServer) SimulateActions(
 		if err != nil {
 			return err
 		}
-		actionResult.StateKeys = scope.StateKeys()
+		maps.Copy(actionResult.StateKeys, scope.StateKeys())
 		reply.ActionResults = append(reply.ActionResults, actionResult)
 		// Reset state keys for the next action
 		clear(scope)

--- a/api/jsonrpc/server.go
+++ b/api/jsonrpc/server.go
@@ -331,7 +331,7 @@ func (j *JSONRPCServer) SimulateActions(
 		if err != nil {
 			return err
 		}
-		maps.Copy(actionResult.StateKeys, scope.StateKeys())
+		actionResult.StateKeys = maps.Clone(scope.StateKeys())
 		reply.ActionResults = append(reply.ActionResults, actionResult)
 		// Reset state keys for the next action
 		clear(scope)


### PR DESCRIPTION
This PR fixes a bug relating to the state keys being returned by the `SimulateActions` API method.

Currently, `SimulateActions` takes in a slice of actions and executes them one-by-one, keeping track of the state key each action touches via the use of `scope`:

https://github.com/ava-labs/hypersdk/blob/23fa160c2e474c887f46f7faa611f7242b64b6f2/api/jsonrpc/server.go#L303

After each action is executed, the state keys that it touched are stored in its respective result and the for-loop moves on to the next action. Before moving onto the next iteration, `scope` is cleared. Since the underlying type of `state.SimulatedKeys` is a map (and therefore, a pointer), the recorded state keys of all previous actions is wiped, which should not be the case. 

This PR fixes the bug above by using `maps.Clone` to copy the KV-pairs of `scope` into the actions recorded state keys.