### PR TITLE
Add `authtest` package

### DIFF
--- a/auth/authtest/mockauth.go
+++ b/auth/authtest/mockauth.go
@@ -1,0 +1,52 @@
+// Copyright (C) 2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package authtest
+
+import (
+	"context"
+
+	"github.com/ava-labs/hypersdk/chain"
+	"github.com/ava-labs/hypersdk/codec"
+)
+
+type MockAuth struct {
+	Start             int64
+	End               int64
+	ComputeUnitsValue uint64
+	ActorAddr         codec.Address
+	SponsorAddr       codec.Address
+	VerifyError       error
+}
+
+func (m *MockAuth) Actor() codec.Address {
+	return m.ActorAddr
+}
+
+func (m *MockAuth) ComputeUnits(chain.Rules) uint64 {
+	return m.ComputeUnitsValue
+}
+
+func (*MockAuth) GetTypeID() uint8 {
+	panic("unimplemented")
+}
+
+func (*MockAuth) Marshal(*codec.Packer) {
+	panic("unimplemented")
+}
+
+func (*MockAuth) Size() int {
+	panic("unimplemented")
+}
+
+func (m *MockAuth) Sponsor() codec.Address {
+	return m.SponsorAddr
+}
+
+func (m *MockAuth) ValidRange(chain.Rules) (int64, int64) {
+	return m.Start, m.End
+}
+
+func (m *MockAuth) Verify(context.Context, []byte) error {
+	return m.VerifyError
+}

--- a/auth/authtest/noauth.go
+++ b/auth/authtest/noauth.go
@@ -1,0 +1,56 @@
+// Copyright (C) 2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package authtest
+
+import (
+	"context"
+	"math"
+
+	"github.com/ava-labs/hypersdk/chain"
+	"github.com/ava-labs/hypersdk/codec"
+)
+
+type NoAuthFactory struct{}
+
+func (NoAuthFactory) Sign([]byte) (chain.Auth, error) {
+	return NoAuth{}, nil
+}
+
+func (NoAuthFactory) MaxUnits() (uint64, uint64) {
+	return 0, 0
+}
+
+func (NoAuthFactory) Address() codec.Address {
+	return codec.EmptyAddress
+}
+
+type NoAuth struct{}
+
+func (NoAuth) GetTypeID() uint8 {
+	return 0
+}
+
+func (NoAuth) ValidRange(chain.Rules) (start int64, end int64) {
+	return 0, math.MaxInt64
+}
+
+func (NoAuth) Marshal(*codec.Packer) {}
+
+func (NoAuth) Size() int { return 0 }
+
+func (NoAuth) ComputeUnits(chain.Rules) uint64 {
+	return 0
+}
+
+func (NoAuth) Verify(context.Context, []byte) error {
+	return nil
+}
+
+func (NoAuth) Actor() codec.Address {
+	return codec.EmptyAddress
+}
+
+func (NoAuth) Sponsor() codec.Address {
+	return codec.EmptyAddress
+}

--- a/chain/pre_executor_test.go
+++ b/chain/pre_executor_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/stretchr/testify/require"
 
+	"github.com/ava-labs/hypersdk/auth/authtest"
 	"github.com/ava-labs/hypersdk/chain"
 	"github.com/ava-labs/hypersdk/genesis"
 	"github.com/ava-labs/hypersdk/internal/validitywindow"
@@ -42,9 +43,9 @@ func TestPreExecutor(t *testing.T) {
 				),
 			},
 		},
-		Auth: &mockAuth{
-			start: -1,
-			end:   -1,
+		Auth: &authtest.MockAuth{
+			Start: -1,
+			End:   -1,
 		},
 	}
 
@@ -109,7 +110,7 @@ func TestPreExecutor(t *testing.T) {
 						},
 					},
 				},
-				Auth: &mockAuth{},
+				Auth: &authtest.MockAuth{},
 			},
 			validityWindow: &validitywindowtest.MockTimeValidityWindow[*chain.Transaction]{},
 			err:            chain.ErrInvalidKeyValue,
@@ -123,8 +124,8 @@ func TestPreExecutor(t *testing.T) {
 				TransactionData: chain.TransactionData{
 					Base: &chain.Base{},
 				},
-				Auth: &mockAuth{
-					verifyError: errMockAuth,
+				Auth: &authtest.MockAuth{
+					VerifyError: errMockAuth,
 				},
 			},
 			validityWindow: &validitywindowtest.MockTimeValidityWindow[*chain.Transaction]{},
@@ -139,7 +140,7 @@ func TestPreExecutor(t *testing.T) {
 				TransactionData: chain.TransactionData{
 					Base: &chain.Base{},
 				},
-				Auth: &mockAuth{},
+				Auth: &authtest.MockAuth{},
 			},
 			validityWindow: &validitywindowtest.MockTimeValidityWindow[*chain.Transaction]{},
 			err:            validitywindow.ErrTimestampExpired,

--- a/chain/transaction_test.go
+++ b/chain/transaction_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/hypersdk/auth"
+	"github.com/ava-labs/hypersdk/auth/authtest"
 	"github.com/ava-labs/hypersdk/chain"
 	"github.com/ava-labs/hypersdk/chain/chaintest"
 	"github.com/ava-labs/hypersdk/codec"
@@ -33,7 +34,6 @@ var (
 	_ chain.Action         = (*mockTransferAction)(nil)
 	_ chain.Action         = (*action2)(nil)
 	_ chain.BalanceHandler = (*mockBalanceHandler)(nil)
-	_ chain.Auth           = (*mockAuth)(nil)
 )
 
 var errMockInsufficientBalance = errors.New("mock insufficient balance error")
@@ -121,47 +121,6 @@ func (*mockBalanceHandler) GetBalance(_ context.Context, _ codec.Address, _ stat
 
 func (*mockBalanceHandler) SponsorStateKeys(_ codec.Address) state.Keys {
 	return state.Keys{}
-}
-
-type mockAuth struct {
-	start        int64
-	end          int64
-	computeUnits uint64
-	actor        codec.Address
-	sponsor      codec.Address
-	verifyError  error
-}
-
-func (m *mockAuth) Actor() codec.Address {
-	return m.actor
-}
-
-func (m *mockAuth) ComputeUnits(chain.Rules) uint64 {
-	return m.computeUnits
-}
-
-func (*mockAuth) GetTypeID() uint8 {
-	panic("unimplemented")
-}
-
-func (*mockAuth) Marshal(*codec.Packer) {
-	panic("unimplemented")
-}
-
-func (*mockAuth) Size() int {
-	panic("unimplemented")
-}
-
-func (m *mockAuth) Sponsor() codec.Address {
-	return m.sponsor
-}
-
-func (m *mockAuth) ValidRange(chain.Rules) (int64, int64) {
-	return m.start, m.end
-}
-
-func (m *mockAuth) Verify(context.Context, []byte) error {
-	return m.verifyError
 }
 
 func TestJSONMarshalUnmarshal(t *testing.T) {
@@ -358,7 +317,7 @@ func TestPreExecute(t *testing.T) {
 				TransactionData: chain.TransactionData{
 					Base: &chain.Base{},
 				},
-				Auth: &mockAuth{},
+				Auth: &authtest.MockAuth{},
 			},
 			bh: &mockBalanceHandler{},
 		},
@@ -463,8 +422,8 @@ func TestPreExecute(t *testing.T) {
 				TransactionData: chain.TransactionData{
 					Base: &chain.Base{},
 				},
-				Auth: &mockAuth{
-					start: 1 * consts.MillisecondsPerSecond,
+				Auth: &authtest.MockAuth{
+					Start: 1 * consts.MillisecondsPerSecond,
 				},
 			},
 			err: chain.ErrAuthNotActivated,
@@ -477,8 +436,8 @@ func TestPreExecute(t *testing.T) {
 						Timestamp: 2 * consts.MillisecondsPerSecond,
 					},
 				},
-				Auth: &mockAuth{
-					end: 1 * consts.MillisecondsPerSecond,
+				Auth: &authtest.MockAuth{
+					End: 1 * consts.MillisecondsPerSecond,
 				},
 			},
 			timestamp: 2 * consts.MillisecondsPerSecond,
@@ -495,7 +454,7 @@ func TestPreExecute(t *testing.T) {
 						},
 					},
 				},
-				Auth: &mockAuth{},
+				Auth: &authtest.MockAuth{},
 			},
 			fm: func() *fees.Manager {
 				fm := fees.NewManager([]byte{})
@@ -518,7 +477,7 @@ func TestPreExecute(t *testing.T) {
 						},
 					},
 				},
-				Auth: &mockAuth{},
+				Auth: &authtest.MockAuth{},
 			},
 			bh: &mockBalanceHandler{
 				canDeductError: errMockInsufficientBalance,

--- a/internal/chain/bond_test.go
+++ b/internal/chain/bond_test.go
@@ -5,7 +5,6 @@ package chain
 
 import (
 	"context"
-	"math"
 	"testing"
 
 	"github.com/ava-labs/avalanchego/database/memdb"
@@ -13,6 +12,7 @@ import (
 	"github.com/ava-labs/avalanchego/x/merkledb"
 	"github.com/stretchr/testify/require"
 
+	"github.com/ava-labs/hypersdk/auth/authtest"
 	"github.com/ava-labs/hypersdk/chain"
 	"github.com/ava-labs/hypersdk/codec"
 	"github.com/ava-labs/hypersdk/state"
@@ -33,7 +33,7 @@ func TestBond(t *testing.T) {
 				tx, err := chain.NewTxData(
 					&chain.Base{Timestamp: 123, ChainID: ids.Empty, MaxFee: 456},
 					nil,
-				).Sign(&NoAuthFactory{})
+				).Sign(&authtest.NoAuthFactory{})
 				require.NoError(t, err)
 
 				return tx
@@ -47,7 +47,7 @@ func TestBond(t *testing.T) {
 				tx, err := chain.NewTxData(
 					&chain.Base{Timestamp: 123, ChainID: ids.Empty, MaxFee: 456},
 					nil,
-				).Sign(&NoAuthFactory{})
+				).Sign(&authtest.NoAuthFactory{})
 				require.NoError(t, err)
 
 				return tx
@@ -61,7 +61,7 @@ func TestBond(t *testing.T) {
 				tx, err := chain.NewTxData(
 					&chain.Base{Timestamp: 123, ChainID: ids.Empty, MaxFee: 456},
 					nil,
-				).Sign(&NoAuthFactory{})
+				).Sign(&authtest.NoAuthFactory{})
 				require.NoError(t, err)
 
 				return tx
@@ -75,7 +75,7 @@ func TestBond(t *testing.T) {
 				tx, err := chain.NewTxData(
 					&chain.Base{Timestamp: 123, ChainID: ids.Empty, MaxFee: 456},
 					nil,
-				).Sign(&NoAuthFactory{})
+				).Sign(&authtest.NoAuthFactory{})
 				require.NoError(t, err)
 
 				return tx
@@ -90,7 +90,7 @@ func TestBond(t *testing.T) {
 				tx, err := chain.NewTxData(
 					&chain.Base{Timestamp: 123, ChainID: ids.Empty, MaxFee: 456},
 					nil,
-				).Sign(&NoAuthFactory{})
+				).Sign(&authtest.NoAuthFactory{})
 				require.NoError(t, err)
 
 				return tx
@@ -105,7 +105,7 @@ func TestBond(t *testing.T) {
 				tx, err := chain.NewTxData(
 					&chain.Base{Timestamp: 123, ChainID: ids.Empty, MaxFee: 456},
 					nil,
-				).Sign(&NoAuthFactory{})
+				).Sign(&authtest.NoAuthFactory{})
 				require.NoError(t, err)
 
 				return tx
@@ -141,7 +141,7 @@ func TestUnbond_NoBondCalled(t *testing.T) {
 	tx, err := chain.NewTxData(
 		&chain.Base{Timestamp: 123, ChainID: ids.Empty, MaxFee: 456},
 		nil,
-	).Sign(&NoAuthFactory{})
+	).Sign(&authtest.NoAuthFactory{})
 	r.NoError(err)
 
 	r.NoError(b.Unbond(tx))
@@ -157,7 +157,7 @@ func TestUnbond_DuplicateUnbond(t *testing.T) {
 	tx, err := chain.NewTxData(
 		&chain.Base{Timestamp: 123, ChainID: ids.Empty, MaxFee: 456},
 		nil,
-	).Sign(&NoAuthFactory{})
+	).Sign(&authtest.NoAuthFactory{})
 	r.NoError(err)
 
 	ok, err := b.Bond(context.Background(), view, tx, 0)
@@ -178,7 +178,7 @@ func TestUnbond_UnbondAfterFailedBond(t *testing.T) {
 	tx, err := chain.NewTxData(
 		&chain.Base{Timestamp: 123, ChainID: ids.Empty, MaxFee: 456},
 		nil,
-	).Sign(&NoAuthFactory{})
+	).Sign(&authtest.NoAuthFactory{})
 	r.NoError(err)
 
 	ok, err := b.Bond(context.Background(), view, tx, 1)
@@ -194,7 +194,7 @@ func TestSetMaxBalanceDuringBond(t *testing.T) {
 
 	ts := tstate.New(0)
 	view := ts.NewView(state.CompletePermissions, newDB(t), 0)
-	authFactory := &NoAuthFactory{}
+	authFactory := &authtest.NoAuthFactory{}
 
 	tx1, err := chain.NewTxData(&chain.Base{Timestamp: 0}, nil).Sign(authFactory)
 	r.NoError(err)
@@ -236,50 +236,6 @@ func newDB(t *testing.T) merkledb.MerkleDB {
 	)
 	require.NoError(t, err)
 	return db
-}
-
-type NoAuthFactory struct{}
-
-func (NoAuthFactory) Sign([]byte) (chain.Auth, error) {
-	return NoAuth{}, nil
-}
-
-func (NoAuthFactory) MaxUnits() (uint64, uint64) {
-	return 0, 0
-}
-
-func (NoAuthFactory) Address() codec.Address {
-	return codec.EmptyAddress
-}
-
-type NoAuth struct{}
-
-func (NoAuth) GetTypeID() uint8 {
-	return 0
-}
-
-func (NoAuth) ValidRange(chain.Rules) (start int64, end int64) {
-	return 0, math.MaxInt64
-}
-
-func (NoAuth) Marshal(*codec.Packer) {}
-
-func (NoAuth) Size() int { return 0 }
-
-func (NoAuth) ComputeUnits(chain.Rules) uint64 {
-	return 0
-}
-
-func (NoAuth) Verify(context.Context, []byte) error {
-	return nil
-}
-
-func (NoAuth) Actor() codec.Address {
-	return codec.EmptyAddress
-}
-
-func (NoAuth) Sponsor() codec.Address {
-	return codec.EmptyAddress
 }
 
 func newBalance(balance uint64) *uint64 {


### PR DESCRIPTION
This PR creates the `authtest` package and moves both the `NoAuth` and `MockAuth` types from `internal/chain` and `chain_test`, respectively, to `authtest`.