### PR TITLE
Separate TX Generation From API

### DIFF
--- a/api/jsonrpc/client.go
+++ b/api/jsonrpc/client.go
@@ -17,7 +17,6 @@ import (
 	"github.com/ava-labs/hypersdk/codec"
 	"github.com/ava-labs/hypersdk/fees"
 	"github.com/ava-labs/hypersdk/requester"
-	"github.com/ava-labs/hypersdk/utils"
 )
 
 const unitPricesCacheRefresh = 10 * time.Second
@@ -113,62 +112,6 @@ func (cli *JSONRPCClient) SubmitTx(ctx context.Context, d []byte) (ids.ID, error
 		resp,
 	)
 	return resp.TxID, err
-}
-
-func (cli *JSONRPCClient) GenerateTransaction(
-	ctx context.Context,
-	parser chain.Parser,
-	actions []chain.Action,
-	authFactory chain.AuthFactory,
-) (func(context.Context) error, *chain.Transaction, uint64, error) {
-	// Get latest fee info
-	unitPrices, err := cli.UnitPrices(ctx, true)
-	if err != nil {
-		return nil, nil, 0, err
-	}
-
-	units, err := chain.EstimateUnits(parser.Rules(time.Now().UnixMilli()), actions, authFactory)
-	if err != nil {
-		return nil, nil, 0, err
-	}
-	maxFee, err := fees.MulSum(unitPrices, units)
-	if err != nil {
-		return nil, nil, 0, err
-	}
-	f, tx, err := cli.GenerateTransactionManual(parser, actions, authFactory, maxFee)
-	if err != nil {
-		return nil, nil, 0, err
-	}
-	return f, tx, maxFee, nil
-}
-
-func (cli *JSONRPCClient) GenerateTransactionManual(
-	parser chain.Parser,
-	actions []chain.Action,
-	authFactory chain.AuthFactory,
-	maxFee uint64,
-) (func(context.Context) error, *chain.Transaction, error) {
-	// Construct transaction
-	now := time.Now().UnixMilli()
-	rules := parser.Rules(now)
-	base := &chain.Base{
-		Timestamp: utils.UnixRMilli(now, rules.GetValidityWindow()),
-		ChainID:   rules.GetChainID(),
-		MaxFee:    maxFee,
-	}
-
-	// Build transaction
-	unsignedTx := chain.NewTxData(base, actions)
-	tx, err := unsignedTx.Sign(authFactory)
-	if err != nil {
-		return nil, nil, fmt.Errorf("%w: failed to sign transaction", err)
-	}
-
-	// Return max fee and transaction for issuance
-	return func(ictx context.Context) error {
-		_, err := cli.SubmitTx(ictx, tx.Bytes())
-		return err
-	}, tx, nil
 }
 
 func (cli *JSONRPCClient) GetABI(ctx context.Context) (abi.ABI, error) {

--- a/examples/morpheusvm/cmd/morpheus-cli/cmd/resolutions.go
+++ b/examples/morpheusvm/cmd/morpheus-cli/cmd/resolutions.go
@@ -28,7 +28,13 @@ func sendAndWait(
 	if err != nil {
 		return false, ids.Empty, err
 	}
-	_, tx, _, err := cli.GenerateTransaction(ctx, parser, actions, factory)
+
+	unitPrices, err := cli.UnitPrices(ctx, true)
+	if err != nil {
+		return false, ids.Empty, err
+	}
+
+	tx, err := chain.GenerateTransaction(unitPrices, parser, actions, factory)
 	if err != nil {
 		return false, ids.Empty, err
 	}

--- a/examples/morpheusvm/tests/workload/generator.go
+++ b/examples/morpheusvm/tests/workload/generator.go
@@ -51,8 +51,14 @@ func (g *TxGenerator) GenerateTx(ctx context.Context, uri string) (*chain.Transa
 	if err != nil {
 		return nil, nil, err
 	}
-	_, tx, _, err := cli.GenerateTransaction(
-		ctx,
+
+	unitPrices, err := cli.UnitPrices(ctx, true)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	tx, err := chain.GenerateTransaction(
+		unitPrices,
 		parser,
 		[]chain.Action{&actions.Transfer{
 			To:    toAddress,

--- a/tests/e2e/network.go
+++ b/tests/e2e/network.go
@@ -110,13 +110,13 @@ func (n *Network) ConfirmTxs(ctx context.Context, txs []*chain.Transaction) erro
 func (n *Network) GenerateTx(ctx context.Context, actions []chain.Action, auth chain.AuthFactory) (*chain.Transaction, error) {
 	uris := n.URIs()
 	c := jsonrpc.NewJSONRPCClient(uris[0])
-	_, tx, _, err := c.GenerateTransaction(
-		ctx,
-		n.parser,
-		actions,
-		auth,
-	)
-	return tx, err
+
+	unitPrices, err := c.UnitPrices(ctx, true)
+	if err != nil {
+		return nil, err
+	}
+
+	return chain.GenerateTransaction(unitPrices, n.parser, actions, auth)
 }
 
 func (*Network) Configuration() workload.TestNetworkConfiguration {

--- a/throughput/issuer.go
+++ b/throughput/issuer.go
@@ -76,7 +76,7 @@ func (i *issuer) Start(ctx context.Context) {
 
 func (i *issuer) Send(ctx context.Context, actions []chain.Action, factory chain.AuthFactory, feePerTx uint64) error {
 	// Construct transaction
-	_, tx, err := i.cli.GenerateTransactionManual(i.parser, actions, factory, feePerTx)
+	tx, err := chain.GenerateTransactionManual(i.parser, actions, factory, feePerTx)
 	if err != nil {
 		utils.Outf("{{orange}}failed to generate tx:{{/}} %v\n", err)
 		return fmt.Errorf("failed to generate tx: %w", err)

--- a/throughput/spam.go
+++ b/throughput/spam.go
@@ -125,7 +125,7 @@ func (s *Spammer) Spam(ctx context.Context, sh SpamHelper, terminate bool, symbo
 	}
 
 	// distribute funds
-	accounts, factories, err := s.distributeFunds(ctx, cli, parser, feePerTx, sh)
+	accounts, factories, err := s.distributeFunds(ctx, parser, feePerTx, sh)
 	if err != nil {
 		return err
 	}
@@ -299,7 +299,7 @@ func (s *Spammer) createIssuers(parser chain.Parser) ([]*issuer, error) {
 	return issuers, nil
 }
 
-func (s *Spammer) distributeFunds(ctx context.Context, cli *jsonrpc.JSONRPCClient, parser chain.Parser, feePerTx uint64, sh SpamHelper) ([]*auth.PrivateKey, []chain.AuthFactory, error) {
+func (s *Spammer) distributeFunds(ctx context.Context, parser chain.Parser, feePerTx uint64, sh SpamHelper) ([]*auth.PrivateKey, []chain.AuthFactory, error) {
 	withholding := feePerTx * uint64(s.numAccounts)
 	if s.balance < withholding {
 		return nil, nil, fmt.Errorf("insufficient funds (have=%d need=%d)", s.balance, withholding)
@@ -336,7 +336,7 @@ func (s *Spammer) distributeFunds(ctx context.Context, cli *jsonrpc.JSONRPCClien
 
 		// Send funds
 		actions := sh.GetTransfer(pk.Address, distAmount, []byte{})
-		_, tx, err := cli.GenerateTransactionManual(parser, actions, s.authFactory, feePerTx)
+		tx, err := chain.GenerateTransactionManual(parser, actions, s.authFactory, feePerTx)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -393,7 +393,7 @@ func (s *Spammer) returnFunds(ctx context.Context, cli *jsonrpc.JSONRPCClient, p
 		// Send funds
 		returnAmt := balance - feePerTx
 		actions := sh.GetTransfer(s.authFactory.Address(), returnAmt, []byte{})
-		_, tx, err := cli.GenerateTransactionManual(parser, actions, factories[i], feePerTx)
+		tx, err := chain.GenerateTransactionManual(parser, actions, factories[i], feePerTx)
 		if err != nil {
 			return err
 		}

--- a/vm/vmtest/network.go
+++ b/vm/vmtest/network.go
@@ -428,8 +428,11 @@ func (n *TestNetwork) ConfirmTxs(ctx context.Context, txs []*chain.Transaction) 
 
 func (n *TestNetwork) GenerateTx(ctx context.Context, actions []chain.Action, authFactory chain.AuthFactory) (*chain.Transaction, error) {
 	cli := jsonrpc.NewJSONRPCClient(n.VMs[0].server.URL)
-	_, tx, _, err := cli.GenerateTransaction(ctx, n.VMs[0].VM, actions, authFactory)
-	return tx, err
+	unitPrices, err := cli.UnitPrices(ctx, true)
+	if err != nil {
+		return nil, err
+	}
+	return chain.GenerateTransaction(unitPrices, n.VMs[0].VM, actions, authFactory)
 }
 
 func (n *TestNetwork) ConfirmBlocks(ctx context.Context, numBlocks int, generateTxs func(i int) []*chain.Transaction) {


### PR DESCRIPTION
This PR separates the TX generation logic from `JSONRPCClient` and puts it in the `chain` package. This PR also updates any dependency to properly use `GenerateTransaction()` and `GenerateTransactionManual()`.