### PR TITLE
Fix Run Script

### DIFF
--- a/examples/morpheusvm/scripts/run.sh
+++ b/examples/morpheusvm/scripts/run.sh
@@ -74,7 +74,8 @@ prepare_ginkgo
 ACK_GINKGO_RC=true ginkgo build ./tests/e2e
 ./tests/e2e/e2e.test --help
 
-additional_args=("$@")
+additional_args=()
+additional_args+=("$@")
 
 if [[ ${MODE} == "run" ]]; then
   echo "applying ginkgo.focus=Ping and --reuse-network to setup local network"
@@ -87,4 +88,4 @@ echo "running e2e tests"
 --ginkgo.v \
 --avalanchego-path="${AVALANCHEGO_PATH}" \
 --plugin-dir="${AVALANCHEGO_PLUGIN_DIR}" \
-"${additional_args[@]}"
+${additional_args[@]+"${additional_args[@]}"}


### PR DESCRIPTION
This PR fixes a bug with the MorpheusVM run script. Currently, trying to execute `MODE=TEST ./scripts/run.sh` error results in an unbounded variable error for `additional_args`. This PR fixes the bug by initializing `additional_args`.