### PR TITLE
Compute Time For Tracker

### DIFF
--- a/throughput/tracker.go
+++ b/throughput/tracker.go
@@ -65,7 +65,7 @@ func (t *tracker) logState(ctx context.Context, cli *jsonrpc.JSONRPCClient) {
 					}
 					currSent := t.sent.Load()
 					currTime := time.Now()
-					diff := min(currTime.Sub(prevTime).Seconds(), 1)
+					diff := max(currTime.Sub(prevTime).Seconds(), 0.001)
 					utils.Outf(
 						"{{yellow}}txs seen:{{/}} %d {{yellow}}success rate:{{/}} %.2f%% {{yellow}}inflight:{{/}} %d {{yellow}}issued/s:{{/}} %d {{yellow}}unit prices:{{/}} [%s]\n", //nolint:lll
 						t.totalTxs,


### PR DESCRIPTION
This PR updates the `issued/s` metric for the throughput test tracker to use a more precise calculation.

Previously, we were solely relying on `time.Ticker` to compute 1-second intervals. However, the time spent computing the stats for each 1-second interval is positive and therefore, `issued/second` was actually `issued/X seconds` where `X >= 1`.

This PR implements logic that computes `X` and applies it to the `issued/s` metric.