### PR TITLE
Improve Pacer Error Handling

### DIFF
--- a/throughput/pacer.go
+++ b/throughput/pacer.go
@@ -45,6 +45,7 @@ func (p *pacer) Run(ctx context.Context, max int) {
 }
 
 func (p *pacer) Add(tx *chain.Transaction) error {
+	// If Run failed, return the first error immediately, otherwise register the next tx
 	select {
 	case <-p.done:
 		return p.err

--- a/throughput/pacer.go
+++ b/throughput/pacer.go
@@ -16,31 +16,29 @@ type pacer struct {
 	ws *ws.WebSocketClient
 
 	inflight chan struct{}
-	done     chan error
+	err      error
 }
 
 func (p *pacer) Run(ctx context.Context, max int) {
 	p.inflight = make(chan struct{}, max)
-	p.done = make(chan error, 1)
 
 	// Start a goroutine to process transaction results
 	for range p.inflight {
 		txID, result, err := p.ws.ListenTx(ctx)
 		if err != nil {
-			p.done <- fmt.Errorf("error listening to tx %s: %w", txID, err)
+			p.err = fmt.Errorf("error listening to tx %s: %w", txID, err)
 			return
 		}
 		if result == nil {
-			p.done <- fmt.Errorf("tx %s expired", txID)
+			p.err = fmt.Errorf("tx %s expired", txID)
 			return
 		}
 		if !result.Success {
 			// Should never happen
-			p.done <- fmt.Errorf("tx failure %w: %s", ErrTxFailed, result.Error)
+			p.err = fmt.Errorf("tx failure %w: %s", ErrTxFailed, result.Error)
 			return
 		}
 	}
-	p.done <- nil
 }
 
 func (p *pacer) Add(tx *chain.Transaction) error {
@@ -50,13 +48,17 @@ func (p *pacer) Add(tx *chain.Transaction) error {
 	select {
 	case p.inflight <- struct{}{}:
 		return nil
-	case err := <-p.done:
-		utils.Outf("{{red}} Error adding tx: %s\n", err)
-		return err
+	default:
+		if p.err != nil {
+			utils.Outf("{{red}} Error adding tx: %s\n", p.err)
+			return p.err
+		}
 	}
+	return nil
 }
 
+// Wait should be called at most once
 func (p *pacer) Wait() error {
 	close(p.inflight)
-	return <-p.done
+	return p.err
 }

--- a/throughput/pacer.go
+++ b/throughput/pacer.go
@@ -17,9 +17,8 @@ type pacer struct {
 
 	wg sync.WaitGroup
 
-	inflight  chan struct{}
-	done      chan struct{}
-	closeOnce sync.Once
+	inflight chan struct{}
+	done     chan struct{}
 
 	l       sync.RWMutex
 	errOnce sync.Once
@@ -82,9 +81,7 @@ func (p *pacer) Add(tx *chain.Transaction) error {
 }
 
 func (p *pacer) Wait() error {
-	p.closeOnce.Do(func() {
-		close(p.inflight)
-	})
+	close(p.inflight)
 	p.wg.Wait()
 	p.setError(nil)
 	return p.err

--- a/throughput/pacer.go
+++ b/throughput/pacer.go
@@ -72,7 +72,7 @@ func (p *pacer) Add(tx *chain.Transaction) error {
 
 func (p *pacer) Wait() error {
 	close(p.inflight)
-	// Wait for all inflight transactions to finish
+	// Wait for Run to complete
 	<-p.done
 	return p.err
 }

--- a/throughput/pacer.go
+++ b/throughput/pacer.go
@@ -6,59 +6,95 @@ package throughput
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/ava-labs/hypersdk/api/ws"
 	"github.com/ava-labs/hypersdk/chain"
-	"github.com/ava-labs/hypersdk/utils"
 )
 
 type pacer struct {
 	ws *ws.WebSocketClient
 
-	inflight chan struct{}
-	err      error
+	wg sync.WaitGroup
+
+	inflight  chan struct{}
+	done      chan struct{}
+	closeOnce sync.Once
+
+	l       sync.RWMutex
+	errOnce sync.Once
+	err     error
 }
 
 func (p *pacer) Run(ctx context.Context, max int) {
 	p.inflight = make(chan struct{}, max)
+	p.done = make(chan struct{}, 1)
 
-	// Start a goroutine to process transaction results
-	for range p.inflight {
-		txID, result, err := p.ws.ListenTx(ctx)
-		if err != nil {
-			p.err = fmt.Errorf("error listening to tx %s: %w", txID, err)
-			return
-		}
-		if result == nil {
-			p.err = fmt.Errorf("tx %s expired", txID)
-			return
-		}
-		if !result.Success {
-			// Should never happen
-			p.err = fmt.Errorf("tx failure %w: %s", ErrTxFailed, result.Error)
+	p.wg.Add(1)
+	defer p.wg.Done()
+
+	for {
+		select {
+		case _, ok := <-p.inflight:
+			if !ok {
+				return
+			}
+			txID, result, err := p.ws.ListenTx(ctx)
+			if err != nil {
+				p.setError(fmt.Errorf("error listening to tx %s: %w", txID, err))
+				return
+			}
+			if result == nil {
+				p.setError(fmt.Errorf("tx %s expired", txID))
+				return
+			}
+			if !result.Success {
+				// Should never happen
+				p.setError(fmt.Errorf("tx failure %w: %s", ErrTxFailed, result.Error))
+				return
+			}
+		case <-p.done:
 			return
 		}
 	}
 }
 
 func (p *pacer) Add(tx *chain.Transaction) error {
+	p.l.RLock()
+	if p.err != nil {
+		defer p.l.RUnlock()
+		return p.err
+	}
+	p.l.RUnlock()
+
 	if err := p.ws.RegisterTx(tx); err != nil {
-		return err
+		p.setError(err)
+		p.l.RLock()
+		defer p.l.RUnlock()
+		return p.err
 	}
 	select {
 	case p.inflight <- struct{}{}:
 		return nil
-	default:
-		if p.err != nil {
-			utils.Outf("{{red}} Error adding tx: %s\n", p.err)
-			return p.err
-		}
+	case <-p.done:
+		return p.err
 	}
-	return nil
 }
 
-// Wait should be called at most once
 func (p *pacer) Wait() error {
-	close(p.inflight)
+	p.closeOnce.Do(func() {
+		close(p.inflight)
+	})
+	p.wg.Wait()
+	p.setError(nil)
 	return p.err
+}
+
+func (p *pacer) setError(err error) {
+	p.errOnce.Do(func() {
+		p.l.Lock()
+		p.err = err
+		p.l.Unlock()
+		close(p.done)
+	})
 }

--- a/throughput/pacer.go
+++ b/throughput/pacer.go
@@ -24,7 +24,7 @@ type pacer struct {
 
 func (p *pacer) Run(ctx context.Context, max int) {
 	p.inflight = make(chan struct{}, max)
-	p.done = make(chan struct{}, 1)
+	p.done = make(chan struct{})
 
 	for {
 		select {

--- a/throughput/spam.go
+++ b/throughput/spam.go
@@ -341,6 +341,7 @@ func (s *Spammer) distributeFunds(ctx context.Context, parser chain.Parser, feeP
 			return nil, nil, err
 		}
 		if err := p.Add(tx); err != nil {
+			_ = p.Wait()
 			return nil, nil, fmt.Errorf("%w: failed to register tx", err)
 		}
 
@@ -398,6 +399,7 @@ func (s *Spammer) returnFunds(ctx context.Context, cli *jsonrpc.JSONRPCClient, p
 			return err
 		}
 		if err := p.Add(tx); err != nil {
+			_ = p.Wait()
 			return err
 		}
 		returnedBalance += returnAmt

--- a/throughput/spam.go
+++ b/throughput/spam.go
@@ -341,7 +341,6 @@ func (s *Spammer) distributeFunds(ctx context.Context, parser chain.Parser, feeP
 			return nil, nil, err
 		}
 		if err := p.Add(tx); err != nil {
-			_ = p.Wait()
 			return nil, nil, fmt.Errorf("%w: failed to register tx", err)
 		}
 
@@ -399,7 +398,6 @@ func (s *Spammer) returnFunds(ctx context.Context, cli *jsonrpc.JSONRPCClient, p
 			return err
 		}
 		if err := p.Add(tx); err != nil {
-			_ = p.Wait()
 			return err
 		}
 		returnedBalance += returnAmt


### PR DESCRIPTION
This PR improves the error handling of `pacer` by adding an `error` field which is written exactly once and utilizing the `done` channel as a signal to see whether if the pacer is still running (`done` is open) vs if the pacer has stopped run (`done` is closed).