### PR TITLE
Clean Up Tracker

### DIFF
--- a/throughput/issuer.go
+++ b/throughput/issuer.go
@@ -46,7 +46,7 @@ func (i *issuer) Start(ctx context.Context) {
 			i.l.Lock()
 			i.outstandingTxs--
 			i.l.Unlock()
-			i.tracker.inflightTxs.Add(-1)
+			i.tracker.inflight.Add(-1)
 			i.tracker.logResult(txID, result)
 		}
 	}()
@@ -87,7 +87,7 @@ func (i *issuer) Send(ctx context.Context, actions []chain.Action, factory chain
 	i.l.Lock()
 	i.outstandingTxs++
 	i.l.Unlock()
-	i.tracker.inflightTxs.Add(1)
+	i.tracker.inflight.Add(1)
 
 	// Register transaction and recover upon failure
 	if err := i.ws.RegisterTx(tx); err != nil {

--- a/throughput/spam.go
+++ b/throughput/spam.go
@@ -146,7 +146,7 @@ func (s *Spammer) Spam(ctx context.Context, sh SpamHelper, terminate bool, symbo
 	}
 
 	// start logging
-	s.tracker.start(ctx, cli)
+	s.tracker.startPeriodicLog(ctx, cli)
 
 	// broadcast transactions
 	err = s.broadcast(cctx, sh, factories, issuers, feePerTx, terminate)

--- a/throughput/spam.go
+++ b/throughput/spam.go
@@ -200,7 +200,7 @@ func (s Spammer) broadcast(
 			start := time.Now()
 
 			// Check to see if we should wait for pending txs
-			if int64(currentTarget)+s.tracker.inflightTxs.Load() > int64(currentTarget*pendingTargetMultiplier) {
+			if int64(currentTarget)+s.tracker.inflight.Load() > int64(currentTarget*pendingTargetMultiplier) {
 				consecutiveUnderBacklog = 0
 				consecutiveAboveBacklog++
 				if consecutiveAboveBacklog >= failedRunsToDecreaseTarget {

--- a/throughput/spam.go
+++ b/throughput/spam.go
@@ -151,15 +151,15 @@ func (s *Spammer) Spam(ctx context.Context, sh SpamHelper, terminate bool, symbo
 	// broadcast transactions
 	err = s.broadcast(cctx, sh, factories, issuers, feePerTx, terminate)
 	cancel()
-	// Stop logging
-	s.tracker.Stop()
 	if err != nil {
+		s.tracker.Stop()
 		return err
 	}
 
 	// Wait for all issuers to finish
 	utils.Outf("{{yellow}}waiting for issuers to return{{/}}\n")
 	s.issuerWg.Wait()
+	s.tracker.Stop()
 
 	maxUnits, err = chain.EstimateUnits(parser.Rules(time.Now().UnixMilli()), actions, s.authFactory)
 	if err != nil {

--- a/throughput/spam.go
+++ b/throughput/spam.go
@@ -86,7 +86,7 @@ func NewSpammer(sc *Config, sh SpamHelper) (*Spammer, error) {
 		numClients:       sc.numClients,
 		numAccounts:      sc.numAccounts,
 
-		tracker:  NewTracker(),
+		tracker:  newTracker(),
 		issuerWg: &sync.WaitGroup{},
 	}, nil
 }
@@ -146,20 +146,20 @@ func (s *Spammer) Spam(ctx context.Context, sh SpamHelper, terminate bool, symbo
 	}
 
 	// start logging
-	s.tracker.Start(ctx, cli)
+	s.tracker.start(ctx, cli)
 
 	// broadcast transactions
 	err = s.broadcast(cctx, sh, factories, issuers, feePerTx, terminate)
 	cancel()
 	if err != nil {
-		s.tracker.Stop()
+		s.tracker.stop()
 		return err
 	}
 
 	// Wait for all issuers to finish
 	utils.Outf("{{yellow}}waiting for issuers to return{{/}}\n")
 	s.issuerWg.Wait()
-	s.tracker.Stop()
+	s.tracker.stop()
 
 	maxUnits, err = chain.EstimateUnits(parser.Rules(time.Now().UnixMilli()), actions, s.authFactory)
 	if err != nil {
@@ -227,7 +227,7 @@ func (s Spammer) broadcast(
 					factory := factories[senderIndex]
 					// Send transaction
 					actions := sh.GetActions()
-					s.tracker.IncrementSent()
+					s.tracker.incrementSent()
 					// assumes the sender has the funds to pay for the transaction
 					return issuer.Send(ctx, actions, factory, feePerTx)
 				})

--- a/throughput/tracker.go
+++ b/throughput/tracker.go
@@ -54,7 +54,7 @@ func (t *tracker) logResult(txID ids.ID, result *chain.Result) {
 	}
 }
 
-func (t *tracker) start(ctx context.Context, cli *jsonrpc.JSONRPCClient) {
+func (t *tracker) startPeriodicLog(ctx context.Context, cli *jsonrpc.JSONRPCClient) {
 	// Log stats
 	t.ticker = time.NewTicker(time.Second)
 	cctx, cancel := context.WithCancel(ctx)

--- a/throughput/tracker.go
+++ b/throughput/tracker.go
@@ -71,7 +71,7 @@ func (t *tracker) Start(ctx context.Context, cli *jsonrpc.JSONRPCClient) {
 			case <-t.ticker.C:
 				t.l.Lock()
 				if t.totalTxs > 0 {
-					unitPrices, err := cli.UnitPrices(ctx, false)
+					unitPrices, err := cli.UnitPrices(cctx, false)
 					if err != nil {
 						continue
 					}

--- a/throughput/tracker.go
+++ b/throughput/tracker.go
@@ -30,7 +30,7 @@ type tracker struct {
 	done   chan struct{}
 }
 
-func NewTracker() *tracker {
+func newTracker() *tracker {
 	return &tracker{
 		done: make(chan struct{}),
 	}
@@ -54,7 +54,7 @@ func (t *tracker) logResult(txID ids.ID, result *chain.Result) {
 	}
 }
 
-func (t *tracker) Start(ctx context.Context, cli *jsonrpc.JSONRPCClient) {
+func (t *tracker) start(ctx context.Context, cli *jsonrpc.JSONRPCClient) {
 	// Log stats
 	t.ticker = time.NewTicker(time.Second)
 	cctx, cancel := context.WithCancel(ctx)
@@ -102,11 +102,11 @@ func (t *tracker) Start(ctx context.Context, cli *jsonrpc.JSONRPCClient) {
 	}()
 }
 
-func (t *tracker) IncrementSent() int64 {
+func (t *tracker) incrementSent() int64 {
 	return t.sent.Add(1)
 }
 
-func (t *tracker) Stop() {
+func (t *tracker) stop() {
 	t.ticker.Stop()
 	t.cancel()
 	<-t.done


### PR DESCRIPTION
This PR cleans up the `tracker` by doing the following:
- Adding a constructor for `tracker`
- Removing the `sync.WaitGroup` from the tracker and instead delegating it to the `Spammer`
    - The `tracker` is meant to track transactions, not coordinate issuers
- Adding a `Stop` function and making sure that `Start()` terminates prior to `Stop` returning.