### PR TITLE
Set AVAGO_PLUGIN_DIR env var in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,9 @@ RUN . ./build_env.sh && \
 # ============= Cleanup Stage ================
 FROM $AVALANCHEGO_NODE_IMAGE AS execution
 
-# Copy the VM binary into the correct location in the container
+# Place the VM binary and set the AVAGO_PLUGIN_DIR env variable, so that
+# AvalancheGo reads it correctly without additional configuration.
 ARG VM_ID
+ENV AVAGO_PLUGIN_DIR="/avalanchego/build/plugins"
+
 COPY --from=builder /build/build/vm /avalanchego/build/plugins/$VM_ID


### PR DESCRIPTION
This PR sets the env variable for `AVAGO_PLUGIN_DIR` variable in the Dockerfile, so that the docker image is preset with the required plugin directory and does not require additional configuration to recognize the location of the VM binary.

This relies on AvalancheGo's env var prefix: https://github.com/ava-labs/avalanchego/blob/667c6b02315cfc86d9ff7a46440e891f47c04d2f/config/viper.go#L18 and the plugin directory flag: https://github.com/ava-labs/avalanchego/blob/667c6b02315cfc86d9ff7a46440e891f47c04d2f/config/flags.go#L92