### PR TITLE
Clean Up Prefixes 

### DIFF
--- a/chain/pre_executor_test.go
+++ b/chain/pre_executor_test.go
@@ -22,17 +22,17 @@ import (
 	"github.com/ava-labs/hypersdk/utils"
 )
 
-var (
-	feeKey = string(chain.FeeKey([]byte{2}))
-
-	errMockValidityWindow = errors.New("mock validity window error")
-)
+var errMockValidityWindow = errors.New("mock validity window error")
 
 func TestPreExecutor(t *testing.T) {
 	testRules := genesis.NewDefaultRules()
 	ruleFactory := genesis.ImmutableRuleFactory{
 		Rules: testRules,
 	}
+
+	testMetadataManager := metadata.NewDefaultManager()
+	feeKey := string(chain.FeeKey(testMetadataManager.FeePrefix()))
+
 	validTx := &chain.Transaction{
 		TransactionData: chain.TransactionData{
 			Base: chain.Base{
@@ -154,7 +154,7 @@ func TestPreExecutor(t *testing.T) {
 			preExecutor := chain.NewPreExecutor(
 				&ruleFactory,
 				tt.validityWindow,
-				metadata.NewDefaultManager(),
+				testMetadataManager,
 				&mockBalanceHandler{},
 			)
 

--- a/chain/processor_test.go
+++ b/chain/processor_test.go
@@ -36,14 +36,17 @@ import (
 var (
 	_ chain.AuthVM = (*mockAuthVM)(nil)
 
-	heightKey    = string(chain.HeightKey([]byte{0}))
-	timestampKey = string(chain.TimestampKey([]byte{1}))
-
 	errMockVerifyExpiryReplayProtection = errors.New("mock validity window error")
 )
 
 func TestProcessorExecute(t *testing.T) {
 	testRules := genesis.NewDefaultRules()
+
+	testMetadataManager := metadata.NewDefaultManager()
+	feeKey := string(chain.FeeKey(testMetadataManager.FeePrefix()))
+	heightKey := string(chain.HeightKey(testMetadataManager.HeightPrefix()))
+	timestampKey := string(chain.TimestampKey(testMetadataManager.TimestampPrefix()))
+
 	tests := []struct {
 		name           string
 		validityWindow chain.ValidityWindow
@@ -486,7 +489,7 @@ func TestProcessorExecute(t *testing.T) {
 				&genesis.ImmutableRuleFactory{Rules: testRules},
 				workers.NewSerial(),
 				&mockAuthVM{},
-				metadata.NewDefaultManager(),
+				testMetadataManager,
 				&mockBalanceHandler{},
 				tt.validityWindow,
 				metrics,


### PR DESCRIPTION
Prior to this PR, metadata prefixes were being shared across different test files which made reading these tests more difficult. This PR makes it so that each test clearly defines the metadata prefixes that it'll use for testing.