### PR TITLE
Add Processor Benchmarks

### DIFF
--- a/chain/chaintest/block.go
+++ b/chain/chaintest/block.go
@@ -4,11 +4,19 @@
 package chaintest
 
 import (
+	"context"
+	"encoding/binary"
+
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/x/merkledb"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/hypersdk/chain"
 	"github.com/ava-labs/hypersdk/fees"
+	"github.com/ava-labs/hypersdk/state"
+	"github.com/ava-labs/hypersdk/state/tstate"
+
+	internalfees "github.com/ava-labs/hypersdk/internal/fees"
 )
 
 func GenerateEmptyExecutedBlocks(
@@ -41,4 +49,73 @@ func GenerateEmptyExecutedBlocks(
 		executedBlocks[i] = blk
 	}
 	return executedBlocks
+}
+
+func GenerateEmptyExecutionBlocks(
+	ctx context.Context,
+	rules chain.Rules,
+	metadataManager chain.MetadataManager,
+	parentView state.View,
+	parentID ids.ID,
+	parentHeight uint64,
+	parentTimestamp int64,
+	timestampOffset int64,
+	numBlocks int,
+) ([]*chain.ExecutionBlock, error) {
+	executionBlocks := make([]*chain.ExecutionBlock, numBlocks)
+	for i := range executionBlocks {
+		timestamp := parentTimestamp + timestampOffset*(int64(i)+1)
+		height := parentHeight + 1 + uint64(i)
+
+		ts := tstate.New(0)
+		tsv := ts.NewView(state.CompletePermissions, parentView, 0)
+
+		feeBytes, err := tsv.GetValue(ctx, chain.FeeKey(metadataManager.FeePrefix()))
+		if err != nil {
+			return nil, err
+		}
+		feeManager := internalfees.NewManager(feeBytes)
+		feeManager = feeManager.ComputeNext(timestamp, rules)
+
+		if err := tsv.Insert(ctx, chain.HeightKey(metadataManager.HeightPrefix()), binary.BigEndian.AppendUint64(nil, height)); err != nil {
+			return nil, err
+		}
+		if err := tsv.Insert(ctx, chain.TimestampKey(metadataManager.TimestampPrefix()), binary.BigEndian.AppendUint64(nil, uint64(timestamp))); err != nil {
+			return nil, err
+		}
+		if err := tsv.Insert(ctx, chain.FeeKey(metadataManager.FeePrefix()), feeManager.Bytes()); err != nil {
+			return nil, err
+		}
+		tsv.Commit()
+
+		root, err := parentView.GetMerkleRoot(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		parentView, err = parentView.NewView(ctx, merkledb.ViewChanges{
+			MapOps:       ts.ChangedKeys(),
+			ConsumeBytes: true,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		statelessBlock, err := chain.NewStatelessBlock(
+			parentID,
+			timestamp,
+			height,
+			[]*chain.Transaction{},
+			root,
+			nil,
+		)
+		if err != nil {
+			return nil, err
+		}
+		parentID = statelessBlock.GetID()
+
+		blk := chain.NewExecutionBlock(statelessBlock)
+		executionBlocks[i] = blk
+	}
+	return executionBlocks, nil
 }

--- a/chain/chaintest/block.go
+++ b/chain/chaintest/block.go
@@ -59,9 +59,9 @@ func GenerateEmptyExecutionBlocks(
 	parentID ids.ID,
 	parentHeight uint64,
 	parentTimestamp int64,
-	timestampOffset int64,
 	numBlocks int,
 ) ([]*chain.ExecutionBlock, error) {
+	timestampOffset := rules.GetMinEmptyBlockGap()
 	executionBlocks := make([]*chain.ExecutionBlock, numBlocks)
 	for i := range executionBlocks {
 		timestamp := parentTimestamp + timestampOffset*(int64(i)+1)

--- a/chain/processor_test.go
+++ b/chain/processor_test.go
@@ -544,7 +544,7 @@ func BenchmarkProcessorExecuteEmptyBlocks(b *testing.B) {
 		&genesis.ImmutableRuleFactory{Rules: testRules},
 		workers.NewSerial(),
 		&mockAuthVM{},
-		metadata.NewDefaultManager(),
+		metadataManager,
 		&mockBalanceHandler{},
 		&validitywindowtest.MockTimeValidityWindow[*chain.Transaction]{},
 		metrics,
@@ -562,7 +562,6 @@ func BenchmarkProcessorExecuteEmptyBlocks(b *testing.B) {
 		genesisBlock.GetID(),
 		genesisBlock.GetHeight(),
 		genesisBlock.GetTimestamp(),
-		testRules.GetMinEmptyBlockGap(),
 		b.N,
 	)
 	r.NoError(err)


### PR DESCRIPTION
This PR adds a benchmark functions which tests the processor execution time of `N` blocks. This PR also adds a helper function which, when called, generates and returns `N` valid execution blocks.