### PR TITLE
Bump Ubuntu Version

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -1,3 +1,3 @@
 self-hosted-runner:
     labels:
-      - ubuntu-20.04-32
+      - ubuntu-22.04-32

--- a/.github/workflows/hypersdk-ci.yml
+++ b/.github/workflows/hypersdk-ci.yml
@@ -57,7 +57,7 @@ jobs:
         run: scripts/tests.actionlint.sh
 
   hypersdk-unit-tests:
-    runs-on: ubuntu-20.04-32
+    runs-on: ubuntu-22.04-32
     timeout-minutes: 10
     steps:
       - name: Checkout
@@ -69,7 +69,7 @@ jobs:
         run: scripts/tests.unit.sh
 
   hypersdk-benchmark-tests:
-    runs-on: ubuntu-20.04-32
+    runs-on: ubuntu-22.04-32
     timeout-minutes: 10
     steps:
       - name: Checkout
@@ -103,7 +103,7 @@ jobs:
         run: scripts/build.sh
 
   morpheusvm-unit-tests:
-    runs-on: ubuntu-20.04-32
+    runs-on: ubuntu-22.04-32
     timeout-minutes: 10
     steps:
       - name: Checkout
@@ -120,7 +120,7 @@ jobs:
         run: scripts/tests.unit.sh
 
   morpheusvm-e2e-tests:
-    runs-on: ubuntu-20.04-32
+    runs-on: ubuntu-22.04-32
     timeout-minutes: 25
     steps:
       - name: Checkout


### PR DESCRIPTION
This PR bumps the minimum Ubuntu version used in the HyperSDK GH actions from `20.04` to `22.04`