### PR TITLE
refactor: replace golang.org/x/exp/rand with math/rand

### DIFF
--- a/examples/morpheusvm/throughput/helper.go
+++ b/examples/morpheusvm/throughput/helper.go
@@ -11,7 +11,7 @@ import (
 	"encoding/binary"
 	"sync/atomic"
 
-	"golang.org/x/exp/rand"
+	"math/rand"
 
 	"github.com/ava-labs/hypersdk/api/ws"
 	"github.com/ava-labs/hypersdk/auth"

--- a/throughput/issuer.go
+++ b/throughput/issuer.go
@@ -10,7 +10,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"golang.org/x/exp/rand"
+	"math/rand"
 
 	"github.com/ava-labs/hypersdk/api/ws"
 	"github.com/ava-labs/hypersdk/chain"


### PR DESCRIPTION
replaces the use of `golang.org/x/exp/rand` with the standard library `math/rand`,  reduces dependency on experimental packages
, This change leverages the improved performance and features of `math/rand` available in Go 1.21 and later versions