### PR TITLE
update avalanchego script to be mac compatible

### DIFF
--- a/scripts/update_avalanchego_version.sh
+++ b/scripts/update_avalanchego_version.sh
@@ -49,11 +49,11 @@ FULL_AVALANCHE_VERSION="$("${CURL_ARGS[@]}" "${CURL_URL}" | grep '"sha":' | head
 WORKFLOW_PATH=".github/workflows/hypersdk-ci.yml"
 for custom_action in "run-monitored-tmpnet-cmd" "install-nix"; do
   echo "Ensuring AvalancheGo version ${FULL_AVALANCHE_VERSION} for ${custom_action} custom action in ${WORKFLOW_PATH} "
-  sed -i "s|\(uses: ava-labs/avalanchego/.github/actions/${custom_action}\)@.*|\1@${FULL_AVALANCHE_VERSION}|g" "${WORKFLOW_PATH}"
+  sed -i .bak "s|\(uses: ava-labs/avalanchego/.github/actions/${custom_action}\)@.*|\1@${FULL_AVALANCHE_VERSION}|g" "${WORKFLOW_PATH}" && rm -f ${WORKFLOW_PATH}.bak
 done
 
 # Ensure the flake version is the same as the avalanche version
 FLAKE_DEP="github:ava-labs/avalanchego"
 FLAKE_FILE=flake.nix
 echo "Ensuring AvalancheGo version ${FULL_AVALANCHE_VERSION} for ${FLAKE_DEP} input of ${FLAKE_FILE}"
-sed -i "s|\(${FLAKE_DEP}?ref=\).*|\1${FULL_AVALANCHE_VERSION}\";|g" "${FLAKE_FILE}"
+sed -i .bak "s|\(${FLAKE_DEP}?ref=\).*|\1${FULL_AVALANCHE_VERSION}\";|g" "${FLAKE_FILE}" && rm -f ${FLAKE_FILE}.bak


### PR DESCRIPTION
## What ?

The `scripts/update_avalanchego_version.sh` script was GNU compatible, which is great. However, making it also Mac compatible is even better.

## What was the issue ?

On Mac, the `sed -i` have a mandatory backup file argument, whereas on GNU, it's optional.

## Solution

Specify a backup file, and delete it afterward.