### PR TITLE
Fix `nix` Script

### DIFF
--- a/scripts/dev_shell.sh
+++ b/scripts/dev_shell.sh
@@ -16,4 +16,8 @@ source "$SCRIPT_DIR"/constants.sh
 # Start a dev shell with the avalanchego flake
 FLAKE="github:ava-labs/avalanchego?ref=${AVALANCHE_VERSION}"
 echo "Starting nix shell for ${FLAKE}"
-nix develop "${FLAKE}" "${@}"
+if [ "$#" -eq 0 ]; then
+    nix develop "${FLAKE}"
+else
+    nix develop "${FLAKE}" "${@}"
+fi


### PR DESCRIPTION
From following the `nix` setup guide [here](https://github.com/ava-labs/hypersdk/blob/0fb6cc7431474ccf68b7901fa05f33fb335ea787/CONTRIBUTING.md#optional-dev-shell), running `./scripts/dev_shell.sh` locally (mac Sequoia 15.3.1) yields the following error:

```
./scripts/dev_shell.sh: line 19: @: unbound variable
```

This PR fixes this issue by not passing in `@` if no arguments are passed in.