### PR TITLE
[chain] Add Timestamp as Parameter to TX Generation Functions

### DIFF
--- a/chain/transaction.go
+++ b/chain/transaction.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
-	"time"
 
 	"github.com/StephenButtolph/canoto"
 	"github.com/ava-labs/avalanchego/ids"
@@ -574,10 +573,11 @@ func (*Transaction) CanotoSpec(types ...reflect.Type) *canoto.Spec {
 func GenerateTransaction(
 	ruleFactory RuleFactory,
 	unitPrices fees.Dimensions,
+	timestamp int64,
 	actions []Action,
 	authFactory AuthFactory,
 ) (*Transaction, error) {
-	rules := ruleFactory.GetRules(time.Now().UnixMilli())
+	rules := ruleFactory.GetRules(timestamp)
 	units, err := EstimateUnits(rules, actions, authFactory)
 	if err != nil {
 		return nil, err
@@ -586,7 +586,7 @@ func GenerateTransaction(
 	if err != nil {
 		return nil, err
 	}
-	tx, err := GenerateTransactionManual(rules, actions, authFactory, maxFee)
+	tx, err := GenerateTransactionManual(rules, timestamp, actions, authFactory, maxFee)
 	if err != nil {
 		return nil, err
 	}
@@ -595,13 +595,14 @@ func GenerateTransaction(
 
 func GenerateTransactionManual(
 	rules Rules,
+	timestamp int64,
 	actions []Action,
 	authFactory AuthFactory,
 	maxFee uint64,
 ) (*Transaction, error) {
 	unsignedTx := NewTxData(
 		Base{
-			Timestamp: utils.UnixRMilli(time.Now().UnixMilli(), rules.GetValidityWindow()),
+			Timestamp: utils.UnixRMilli(timestamp, rules.GetValidityWindow()),
 			ChainID:   rules.GetChainID(),
 			MaxFee:    maxFee,
 		},

--- a/examples/morpheusvm/cmd/morpheus-cli/cmd/resolutions.go
+++ b/examples/morpheusvm/cmd/morpheus-cli/cmd/resolutions.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"time"
 
 	"github.com/ava-labs/avalanchego/ids"
 
@@ -34,7 +35,7 @@ func sendAndWait(
 		return false, ids.Empty, err
 	}
 
-	tx, err := chain.GenerateTransaction(ruleFactory, unitPrices, actions, authFactory)
+	tx, err := chain.GenerateTransaction(ruleFactory, unitPrices, time.Now().UnixMilli(), actions, authFactory)
 	if err != nil {
 		return false, ids.Empty, err
 	}

--- a/examples/morpheusvm/tests/workload/generator.go
+++ b/examples/morpheusvm/tests/workload/generator.go
@@ -59,6 +59,7 @@ func (g *TxGenerator) GenerateTx(ctx context.Context, uri string) (*chain.Transa
 	tx, err := chain.GenerateTransaction(
 		ruleFactory,
 		unitPrices,
+		time.Now().UnixMilli(),
 		[]chain.Action{&actions.Transfer{
 			To:    toAddress,
 			Value: 1,

--- a/tests/e2e/network.go
+++ b/tests/e2e/network.go
@@ -143,7 +143,7 @@ func (n *Network) GenerateTx(ctx context.Context, actions []chain.Action, auth c
 		return nil, err
 	}
 
-	return chain.GenerateTransaction(ruleFactory, unitPrices, actions, auth)
+	return chain.GenerateTransaction(ruleFactory, unitPrices, time.Now().UnixMilli(), actions, auth)
 }
 
 func (*Network) Configuration() workload.TestNetworkConfiguration {

--- a/throughput/issuer.go
+++ b/throughput/issuer.go
@@ -81,7 +81,7 @@ func (i *issuer) start(ctx context.Context) {
 func (i *issuer) send(actions []chain.Action, factory chain.AuthFactory, feePerTx uint64) error {
 	// Construct transaction
 	rules := i.ruleFactory.GetRules(time.Now().UnixMilli())
-	tx, err := chain.GenerateTransactionManual(rules, actions, factory, feePerTx)
+	tx, err := chain.GenerateTransactionManual(rules, time.Now().UnixMilli(), actions, factory, feePerTx)
 	if err != nil {
 		utils.Outf("{{orange}}failed to generate tx:{{/}} %v\n", err)
 		return fmt.Errorf("failed to generate tx: %w", err)

--- a/throughput/spam.go
+++ b/throughput/spam.go
@@ -359,7 +359,7 @@ func (s *Spammer) distributeFunds(ctx context.Context, feePerTx uint64, sh SpamH
 
 		// Send funds
 		actions := sh.GetTransfer(pk.Address, distAmount, []byte{})
-		tx, err := chain.GenerateTransactionManual(rules, actions, s.authFactory, feePerTx)
+		tx, err := chain.GenerateTransactionManual(rules, time.Now().UnixMilli(), actions, s.authFactory, feePerTx)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -418,7 +418,7 @@ func (s *Spammer) returnFunds(ctx context.Context, cli *jsonrpc.JSONRPCClient, m
 		// Send funds
 		returnAmt := balance - feePerTx
 		actions := sh.GetTransfer(s.authFactory.Address(), returnAmt, []byte{})
-		tx, err := chain.GenerateTransactionManual(rules, actions, factories[i], feePerTx)
+		tx, err := chain.GenerateTransactionManual(rules, time.Now().UnixMilli(), actions, factories[i], feePerTx)
 		if err != nil {
 			return err
 		}

--- a/vm/vmtest/network.go
+++ b/vm/vmtest/network.go
@@ -438,6 +438,7 @@ func (n *TestNetwork) GenerateTx(ctx context.Context, actions []chain.Action, au
 	return chain.GenerateTransaction(
 		n.VMs[0].VM.GetRuleFactory(),
 		unitPrices,
+		time.Now().UnixMilli(),
 		actions,
 		authFactory,
 	)


### PR DESCRIPTION
This PR allows for the timestamp to be passed into the TX generation functions, which makes it possible for applications like #1955 to create TXs while using their own timestamp (instead of `time.Now().UnixMilli()`.