### PR TITLE
Enable versioned install of all golang tools

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -2,12 +2,15 @@
 # - Requires a recent version of direnv (https://direnv.net/)
 # - For quieter direnv output, set `export DIRENV_LOG_FORMAT=`
 
-# Determine AVALANCHE_VERSION
-source ./scripts/constants.sh
+# set HYPERSDK_DIRENV_USE_FLAKE to a non-empty value to enable `use flake`
+if [ -n "HYPERSDK_DIRENV_USE_FLAKE" ]; then
+  # Determine AVALANCHE_VERSION
+  source ./scripts/constants.sh
 
-# - Starts an avalanchego dev shell
-# - Requires nix (https://github.com/DeterminateSystems/nix-installer?tab=readme-ov-file#install-nix)
-use flake "github:ava-labs/avalanchego?ref=${AVALANCHE_VERSION}"
+  # - Starts an avalanchego dev shell
+  # - Requires nix (https://github.com/DeterminateSystems/nix-installer?tab=readme-ov-file#install-nix)
+  use flake "github:ava-labs/avalanchego?ref=${AVALANCHE_VERSION}"
+fi
 
 # Repo-local commands like avalanchego and tmpnetctl
 PATH_add bin

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ tooling:
    installer](https://github.com/DeterminateSystems/nix-installer?tab=readme-ov-file#install-nix)
    is recommended.
  - Use ./scripts/dev_shell.sh to start a nix shell
- - Execute the dependency-requiring command (e.g. `ginkgo -v ./tests/e2e -- --start-collectors`)
+ - Execute the dependency-requiring command (e.g. `./bin/ginkgo -v ./tests/e2e -- --start-collectors`)
 
 This repo also defines a `.envrc` file to configure [devenv](https://direnv.net/). With `devenv`
 and `nix` installed, a shell at the root of the hypersdk repo will automatically start a nix dev

--- a/bin/actionlint
+++ b/bin/actionlint
@@ -1,0 +1,1 @@
+../scripts/run_actionlint.sh

--- a/bin/addlicense
+++ b/bin/addlicense
@@ -1,0 +1,1 @@
+../scripts/run_addlicense.sh

--- a/bin/gci
+++ b/bin/gci
@@ -1,0 +1,1 @@
+../scripts/run_gci.sh

--- a/bin/ginkgo
+++ b/bin/ginkgo
@@ -1,0 +1,1 @@
+../scripts/run_ginkgo.sh

--- a/bin/gofumpt
+++ b/bin/gofumpt
@@ -1,0 +1,1 @@
+../scripts/run_gofumpt.sh

--- a/bin/golangci-lint
+++ b/bin/golangci-lint
@@ -1,0 +1,1 @@
+../scripts/run_golangci-lint.sh

--- a/bin/proto-gen-go
+++ b/bin/proto-gen-go
@@ -1,0 +1,1 @@
+../scripts/run_proto-gen-go.sh

--- a/bin/proto-gen-go-grpc
+++ b/bin/proto-gen-go-grpc
@@ -1,0 +1,1 @@
+../scripts/run_proto-gen-go-grpc.sh

--- a/docs/tutorials/morpheusvm/5_testing.md
+++ b/docs/tutorials/morpheusvm/5_testing.md
@@ -44,10 +44,9 @@ source ../../scripts/common/utils.sh
 source ../../scripts/constants.sh
 
 rm_previous_cov_reports
-prepare_ginkgo
 
 # run with 3 embedded VMs
-ACK_GINKGO_RC=true ginkgo \
+ACK_GINKGO_RC=true ../../bin/ginkgo \
 run \
 -v \
 --fail-fast \

--- a/examples/morpheusvm/scripts/run.sh
+++ b/examples/morpheusvm/scripts/run.sh
@@ -32,9 +32,7 @@ go build -o "${AVALANCHEGO_PLUGIN_DIR}"/qCNyZHrs3rZX458wPJXPJJypPf6w423A84jnfbdP
 
 echo "building e2e.test"
 
-prepare_ginkgo
-
-ACK_GINKGO_RC=true ginkgo build ./tests/e2e
+ACK_GINKGO_RC=true ../../bin/ginkgo build ./tests/e2e
 ./tests/e2e/e2e.test --help
 
 args=(

--- a/examples/morpheusvm/scripts/stop.sh
+++ b/examples/morpheusvm/scripts/stop.sh
@@ -9,4 +9,4 @@ MORPHEUSVM_PATH=$(
   cd .. && pwd
 )
 
-ginkgo -v "$MORPHEUSVM_PATH"/tests/e2e/e2e.test -- --stop-network
+"$MORPHEUSVM_PATH"/../../bin/ginkgo -v "$MORPHEUSVM_PATH"/tests/e2e/e2e.test -- --stop-network

--- a/scripts/common/utils.sh
+++ b/scripts/common/utils.sh
@@ -2,26 +2,6 @@
 # Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 # See the file LICENSE for licensing terms.
 
-function check_command() {
-  if ! which "$1" &> /dev/null
-  then
-      echo -e "\033[0;31myour golang environment is misconfigued...please ensure the golang bin folder is in your PATH\033[0m"
-      echo -e "\033[0;31myou can set this for the current terminal session by running \"export PATH=\$PATH:\$(go env GOPATH)/bin\"\033[0m"
-      exit
-  fi
-}
-
-function install_if_not_exists() {
-  if ! command -v "$1" &> /dev/null
-  then
-    echo "$1 not found, installing..."
-    go install -v "$2"
-  fi
-
-  # alert the user if they do not have $GOPATH properly configured
-  check_command "$1"
-}
-
 # Function to check if the script is run from the repository root
 function check_repository_root() {
   if ! [[ "$0" =~ $1 ]]; then
@@ -30,19 +10,12 @@ function check_repository_root() {
   fi
 }
 
-function prepare_ginkgo() {
-  set -e
-
-  install_if_not_exists ginkgo github.com/onsi/ginkgo/v2/ginkgo@v2.13.1
-}
-
 function rm_previous_cov_reports() {
     rm -f integration.coverage.out
     rm -f integration.coverage.html
 }
 
 function add_license_headers() {
-  install_if_not_exists addlicense github.com/google/addlicense@latest
   local license_file="license-header.txt"
   if [[ ! -f "$license_file" ]]; then
     license_file="../../license-header.txt"
@@ -57,6 +30,9 @@ function add_license_headers() {
 
   echo "${action} license headers"
 
+  local repo_root
+  repo_root="$(cd "$( dirname "${BASH_SOURCE[0]}" )" || exit; cd ../.. && pwd )"
+
   # Find and process files with the specified extensions
-  find . -type f \( -name "*.go" -o -name "*.rs" -o -name "*.sh" \) -not -path "./target/*" -print0 | xargs -0 addlicense "${args[@]}"
+  find . -type f \( -name "*.go" -o -name "*.rs" -o -name "*.sh" \) -not -path "./target/*" -print0 | xargs -0 "${repo_root}"/bin/addlicense "${args[@]}"
 }

--- a/scripts/fix.lint.sh
+++ b/scripts/fix.lint.sh
@@ -19,9 +19,7 @@ source "${SCRIPT_DIR}/common/utils.sh"
 add_license_headers ""
 
 echo "gofumpt files"
-install_if_not_exists gofumpt mvdan.cc/gofumpt@latest
-gofumpt -l -w .
+./bin/gofumpt -l -w .
 
 echo "gci files"
-install_if_not_exists gci github.com/daixiang0/gci@v0.12.1
-gci write --skip-generated -s standard -s default -s blank -s dot -s "prefix(github.com/ava-labs/hypersdk)" -s alias --custom-order .
+./bin/gci write --skip-generated -s standard -s default -s blank -s dot -s "prefix(github.com/ava-labs/hypersdk)" -s alias --custom-order .

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -9,12 +9,9 @@ if ! [[ "$0" =~ scripts/lint.sh ]]; then
   exit 255
 fi
 
-# Default version of golangci-lint
-GOLANGCI_LINT_VERSION=${GOLANGCI_LINT_VERSION:-"v2.0.2"}
-
-SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd .. && pwd)
 # shellcheck source=/scripts/common/utils.sh
-source "$SCRIPT_DIR"/common/utils.sh
+source "${REPO_ROOT}"/scripts/common/utils.sh
 
 if [ "$#" -eq 0 ]; then
   # by default, check all source code
@@ -32,14 +29,14 @@ TESTS=${TESTS:-"golangci_lint gci"}
 
 # https://github.com/golangci/golangci-lint/releases
 function test_golangci_lint {
-  go install -v github.com/golangci/golangci-lint/v2/cmd/golangci-lint@"$GOLANGCI_LINT_VERSION"
-
-  golangci-lint run --config .golangci.yml
+  "${REPO_ROOT}"/bin/golangci-lint run --config .golangci.yml
 }
 
 function test_gci {
-  install_if_not_exists gci github.com/daixiang0/gci@v0.12.1
-  FILES=$(gci list --skip-generated -s standard -s default -s blank -s dot -s "prefix(github.com/ava-labs/hypersdk)" -s alias --custom-order .)
+  # Ensure gci is installed first to ensure installation output isn't confused for non-compliant files
+  "${REPO_ROOT}"/bin/gci --version
+
+  FILES=$("${REPO_ROOT}"/bin/gci list --skip-generated -s standard -s default -s blank -s dot -s "prefix(github.com/ava-labs/hypersdk)" -s alias --custom-order .)
   if [[ "${FILES}" ]]; then
     echo ""
     echo "Some files need to be gci-ed:"

--- a/scripts/protobuf_codegen.sh
+++ b/scripts/protobuf_codegen.sh
@@ -17,22 +17,9 @@ if [[ $(buf --version | cut -f2 -d' ') != "${BUF_VERSION}" ]]; then
   exit 255
 fi
 
-## install "protoc-gen-go"
-PROTOC_GEN_GO_VERSION='v1.33.0'
-go install -v google.golang.org/protobuf/cmd/protoc-gen-go@"${PROTOC_GEN_GO_VERSION}"
-if [[ $(protoc-gen-go --version | cut -f2 -d' ') != "${PROTOC_GEN_GO_VERSION}" ]]; then
-  # e.g., protoc-gen-go v1.28.1
-  echo "could not find protoc-gen-go ${PROTOC_GEN_GO_VERSION}, is it installed + in PATH?"
-  exit 255
-fi
-
-### install "protoc-gen-go-grpc"
-PROTOC_GEN_GO_GRPC_VERSION='1.3.0'
-go install -v google.golang.org/grpc/cmd/protoc-gen-go-grpc@v"${PROTOC_GEN_GO_GRPC_VERSION}"
-if [[ $(protoc-gen-go-grpc --version | cut -f2 -d' ') != "${PROTOC_GEN_GO_GRPC_VERSION}" ]]; then
-  # e.g., protoc-gen-go-grpc 1.3.0
-  echo "could not find protoc-gen-go-grpc ${PROTOC_GEN_GO_GRPC_VERSION}, is it installed + in PATH?"
-  exit 255
+# Ensure local binaries are in PATH
+if [[ ! "$PATH" =~ $PWD/bin ]]; then
+  export PATH=$PWD/bin:$PATH
 fi
 
 TARGET=$PWD/proto

--- a/scripts/run_actionlint.sh
+++ b/scripts/run_actionlint.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
+# See the file LICENSE for licensing terms.
+
+set -euo pipefail
+
+REPO_ROOT=$(cd "$( dirname "${BASH_SOURCE[0]}" )"; cd .. && pwd )
+"${REPO_ROOT}"/scripts/run_versioned_binary.sh github.com/rhysd/actionlint/cmd/actionlint v1.7.1 "${@}"

--- a/scripts/run_addlicense.sh
+++ b/scripts/run_addlicense.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
+# See the file LICENSE for licensing terms.
+
+set -euo pipefail
+
+REPO_ROOT=$(cd "$( dirname "${BASH_SOURCE[0]}" )"; cd .. && pwd )
+"${REPO_ROOT}"/scripts/run_versioned_binary.sh github.com/google/addlicense v1.1.1 "${@}"

--- a/scripts/run_avalanchego.sh
+++ b/scripts/run_avalanchego.sh
@@ -9,7 +9,6 @@ REPO_ROOT=$(cd "$( dirname "${BASH_SOURCE[0]}" )"; cd .. && pwd )
 # Set AVALANCHE_VERSION and ensure CGO is configured
 . "${REPO_ROOT}"/scripts/constants.sh
 
-. "${REPO_ROOT}"/scripts/install_versioned_binary.sh
-install_versioned_binary "${REPO_ROOT}" avalanchego github.com/ava-labs/avalanchego/main "${AVALANCHE_VERSION}"
-
-"${REPO_ROOT}"/build/avalanchego "${@}"
+# Need to set the binary name or the name will be 'main'
+GOLANG_BINARY_NAME=avalanchego \
+  "${REPO_ROOT}"/scripts/run_versioned_binary.sh github.com/ava-labs/avalanchego/main "${AVALANCHE_VERSION}" "${@}"

--- a/scripts/run_gci.sh
+++ b/scripts/run_gci.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
+# See the file LICENSE for licensing terms.
+
+set -euo pipefail
+
+REPO_ROOT=$(cd "$( dirname "${BASH_SOURCE[0]}" )"; cd .. && pwd )
+"${REPO_ROOT}"/scripts/run_versioned_binary.sh github.com/daixiang0/gci v0.12.1 "${@}"

--- a/scripts/run_ginkgo.sh
+++ b/scripts/run_ginkgo.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
+# See the file LICENSE for licensing terms.
+
+set -euo pipefail
+
+REPO_ROOT=$(cd "$( dirname "${BASH_SOURCE[0]}" )"; cd .. && pwd )
+"${REPO_ROOT}"/scripts/run_versioned_binary.sh github.com/onsi/ginkgo/v2/ginkgo v2.13.1 "${@}"

--- a/scripts/run_gofumpt.sh
+++ b/scripts/run_gofumpt.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
+# See the file LICENSE for licensing terms.
+
+set -euo pipefail
+
+REPO_ROOT=$(cd "$( dirname "${BASH_SOURCE[0]}" )"; cd .. && pwd )
+"${REPO_ROOT}"/scripts/run_versioned_binary.sh mvdan.cc/gofumpt v0.8.0 "${@}"

--- a/scripts/run_golangci-lint.sh
+++ b/scripts/run_golangci-lint.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
+# See the file LICENSE for licensing terms.
+
+set -euo pipefail
+
+REPO_ROOT=$(cd "$( dirname "${BASH_SOURCE[0]}" )"; cd .. && pwd )
+"${REPO_ROOT}"/scripts/run_versioned_binary.sh github.com/golangci/golangci-lint/v2/cmd/golangci-lint v2.0.2 "${@}"

--- a/scripts/run_proto-gen-go-grpc.sh
+++ b/scripts/run_proto-gen-go-grpc.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
+# See the file LICENSE for licensing terms.
+
+set -euo pipefail
+
+REPO_ROOT=$(cd "$( dirname "${BASH_SOURCE[0]}" )"; cd .. && pwd )
+"${REPO_ROOT}"/scripts/run_versioned_binary.sh google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.3.0 "${@}"

--- a/scripts/run_proto-gen-go.sh
+++ b/scripts/run_proto-gen-go.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
+# See the file LICENSE for licensing terms.
+
+set -euo pipefail
+
+REPO_ROOT=$(cd "$( dirname "${BASH_SOURCE[0]}" )"; cd .. && pwd )
+"${REPO_ROOT}"/scripts/run_versioned_binary.sh google.golang.org/protobuf/cmd/protoc-gen-go v1.33.0 "${@}"

--- a/scripts/run_tmpnetctl.sh
+++ b/scripts/run_tmpnetctl.sh
@@ -9,7 +9,4 @@ REPO_ROOT=$(cd "$( dirname "${BASH_SOURCE[0]}" )"; cd .. && pwd )
 # Set AVALANCHE_VERSION and ensure CGO is configured
 . "${REPO_ROOT}"/scripts/constants.sh
 
-. "${REPO_ROOT}"/scripts/install_versioned_binary.sh
-install_versioned_binary "${REPO_ROOT}" tmpnetctl github.com/ava-labs/avalanchego/tests/fixture/tmpnet/tmpnetctl "${AVALANCHE_VERSION}"
-
-"${REPO_ROOT}"/build/tmpnetctl "${@}"
+"${REPO_ROOT}"/scripts/run_versioned_binary.sh github.com/ava-labs/avalanchego/tests/fixture/tmpnet/tmpnetctl "${AVALANCHE_VERSION}" "${@}"

--- a/scripts/run_versioned_binary.sh
+++ b/scripts/run_versioned_binary.sh
@@ -4,6 +4,8 @@
 
 set -euo pipefail
 
+REPO_ROOT=$(cd "$( dirname "${BASH_SOURCE[0]}" )"; cd .. && pwd )
+
 function install_versioned_binary() {
   local repo_root="${1}"
   local binary_name="${2}"
@@ -33,3 +35,27 @@ function install_versioned_binary() {
   mkdir -p "${repo_root}/build"
   ln -sf "${binary_file}" "${repo_root}/build/${binary_name}"
 }
+
+# The first 2 arguments are for this script, the rest are for invoking binary
+BINARY_URL="${1}"
+VERSION="${2}"
+shift 2
+
+if [[ -z "${BINARY_URL}" ]]; then
+  echo "Usage: $0 <binary_url> <version> [<args>]"
+  echo "binary_url is required"
+  exit 1
+fi
+
+if [[ -z "${VERSION}" || "${VERSION}" == "latest" ]]; then
+  echo "Usage: $0 <binary_url> <version> [<args>]"
+  echo "version is required and cannot be 'latest'"
+  exit 1
+fi
+
+# The binary name is the last part of the URL, or can be overridden by the caller
+BINARY_NAME="${GOLANG_BINARY_NAME:-$(basename "${BINARY_URL}")}"
+
+install_versioned_binary "${REPO_ROOT}" "${BINARY_NAME}" "${BINARY_URL}" "${VERSION}"
+
+"${REPO_ROOT}/build/${BINARY_NAME}" "${@}"

--- a/scripts/tests.actionlint.sh
+++ b/scripts/tests.actionlint.sh
@@ -9,10 +9,4 @@ if ! [[ "$0" =~ scripts/tests.actionlint.sh ]]; then
   exit 255
 fi
 
-SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-# shellcheck source=/scripts/common/utils.sh
-source "$SCRIPT_DIR"/common/utils.sh
-
-install_if_not_exists actionlint github.com/rhysd/actionlint/cmd/actionlint@v1.7.1
-
-actionlint
+./bin/actionlint


### PR DESCRIPTION
As a follow-on to #2015, this PR updates the usage of all golang tooling to use the same strategy to ensure the correct version is used. This avoids `go install`ing to the gobal go bin path so that our repos always get the version of the dependency they want without conflicting with one another.

## TODO

- [x] Merge #2015 