### PR TITLE
[context] Enforce Documentation Standard

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -235,8 +235,9 @@ linters:
       - legacy
       - std-error-handling
     rules:
-      - path-except: ^context/
-        text: "(ST1000|ST1020|ST1021|ST1022)"   
+      - linters:
+          - staticcheck
+        text: "(ST1000|ST1020|ST1021|ST1022)"
 
 issues:
   # Maximum issues count per one linter.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -166,6 +166,44 @@ linters:
         # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#useless-break
         - name: useless-break
           disabled: false
+        # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#exported
+        - name: exported
+          disabled: false
+          arguments:
+            - "checkPublicInterface"
+            - "sayRepetitiveInsteadOfStutters"
+          exclude:
+            - "**/abi/**/*.go"
+            - "**/api/**/*.go"
+            - "**/auth/**/*.go"
+            - "**/chain/**/*.go"
+            - "**/chainindex/**/*.go"
+            - "**/cli/**/*.go"
+            - "**/cmd/**/*.go"
+            - "**/codec/**/*.go"
+            - "**/consts/**/*.go"
+            - "**/crypto/**/*.go"
+            - "**/event/**/*.go"
+            - "**/examples/**/*.go"
+            - "**/extension/**/*.go"
+            - "**/fees/**/*.go"
+            - "**/genesis/**/*.go"
+            - "**/internal/**/*.go"
+            - "**/keys/**/*.go"
+            - "**/load/**/*.go"
+            - "**/proto/**/*.go"
+            - "**/pubsub/**/*.go"
+            - "**/requester/**/*.go"
+            - "**/snow/**/*.go"
+            - "**/state/**/*.go"
+            - "**/statesync/**/*.go"
+            - "**/storage/**/*.go"
+            - "**/tests/**/*.go"
+            - "**/throughput/**/*.go"
+            - "**/utils/**/*.go"
+            - "**/vm/**/*.go"
+            - "**/x/**/*.go"
+            - "TEST"
     spancheck:
       checks:
         - end
@@ -193,10 +231,13 @@ linters:
   exclusions:
     generated: lax
     presets:
-      - comments
       - common-false-positives
       - legacy
       - std-error-handling
+    rules:
+      - path-except: ^context/
+        text: "(ST1000|ST1020|ST1021|ST1022)"   
+
 issues:
   # Maximum issues count per one linter.
   # Set to 0 to disable.

--- a/context/config.go
+++ b/context/config.go
@@ -7,7 +7,7 @@ import "encoding/json"
 
 // Config represents a generic map-based configuration
 // Each value is stored as a raw JSON value, which can be used to unmarshal into
-// a specific type T
+// a specific config type T
 type Config map[string]json.RawMessage
 
 // NewEmptyConfig returns an empty config
@@ -49,7 +49,7 @@ func GetConfig[T any](c Config, key string, defaultConfig T) (T, error) {
 	return defaultConfig, nil
 }
 
-// SetConfig sets the value at key to value (which must be JSON serializable)
+// SetConfig sets the value at key to value (must be JSON serializable)
 func SetConfig[T any](c Config, key string, value T) error {
 	b, err := json.Marshal(value)
 	if err != nil {

--- a/context/config.go
+++ b/context/config.go
@@ -5,12 +5,18 @@ package context
 
 import "encoding/json"
 
+// Config represents a generic map-based configuration
+// Each value is stored as a raw JSON value, which can be used to unmarshal into
+// a specific type T
 type Config map[string]json.RawMessage
 
+// NewEmptyConfig returns an empty config
 func NewEmptyConfig() Config {
 	return make(Config)
 }
 
+// NewConfig returns a config derived from b
+// The contents of b are unmarshaled into the config
 func NewConfig(b []byte) (Config, error) {
 	c := Config{}
 	if len(b) > 0 {
@@ -21,10 +27,15 @@ func NewConfig(b []byte) (Config, error) {
 	return c, nil
 }
 
+// GetRawConfig returns the value stored at key
 func (c Config) GetRawConfig(key string) json.RawMessage {
 	return c[key]
 }
 
+// GetConfig attempts to read the config stored at key and unmarshal it into a
+// value of type T
+// If the key does not exist or if the value cannot be unmarshaled into a Config
+// value, the defaultConfig is returned
 func GetConfig[T any](c Config, key string, defaultConfig T) (T, error) {
 	val, ok := c[key]
 	if !ok {
@@ -38,6 +49,7 @@ func GetConfig[T any](c Config, key string, defaultConfig T) (T, error) {
 	return defaultConfig, nil
 }
 
+// SetConfig sets the value at key to value (which must be JSON serializable)
 func SetConfig[T any](c Config, key string, value T) error {
 	b, err := json.Marshal(value)
 	if err != nil {

--- a/context/doc.go
+++ b/context/doc.go
@@ -1,0 +1,14 @@
+// Copyright (C) 2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+// Package context provides a generic map-based configuration for storing
+// multiple configurations in a single value.
+//
+// As part of the [common.VM] interface, the Initialize method takes in a
+// config. With the introduction of the snow package, this config is now
+// shared between multiple packages, including the snow and vm packages.
+// [context] helps manage this shared config by allowing packages to define
+// their own sub-configurations within the main config.
+//
+// [common.VM]: https://github.com/ava-labs/avalanchego/blob/a353b45944904ce56b5eddf961bf83430892dc32/snow/engine/common/vm.go#L17
+package context

--- a/context/doc.go
+++ b/context/doc.go
@@ -4,11 +4,9 @@
 // Package context provides a generic map-based configuration for storing
 // multiple configurations in a single value.
 //
-// As part of the [common.VM] interface, the Initialize method takes in a
-// config. With the introduction of the snow package, this config is now
-// shared between multiple packages, including the snow and vm packages.
-// [context] helps manage this shared config by allowing packages to define
-// their own sub-configurations within the main config.
+// The config passed in during VM initialization is used by several packages,
+// including the snow and vm packages. The [context] package helps manage this
+// by allowing packages to define their own sub-configurations within the main config.
 //
 // [common.VM]: https://github.com/ava-labs/avalanchego/blob/a353b45944904ce56b5eddf961bf83430892dc32/snow/engine/common/vm.go#L17
 package context


### PR DESCRIPTION
This PR begins the commitment of properly documenting the HyperSDK public-facing API by adding documentation to the `context` package. The `context` package was chosen due to its small scope, which makes it ideal as a starter.

As part of this PR, `golangci-lint` has been updated to start enforcing documentation-related lint rules to the `context` packages. In future PRs, we can enforce documentation on other packages by removing their exemptions from the lint rules.