### PR TITLE
Remove GetTypeID From Actions

### DIFF
--- a/chain/dependencies.go
+++ b/chain/dependencies.go
@@ -107,7 +107,6 @@ type BalanceHandler interface {
 }
 
 type Action interface {
-	GetTypeID() uint8
 	// ValidRange is the timestamp range (in ms) that this [Action] is considered valid.
 	//
 	// -1 means no start/end

--- a/chain/transaction.go
+++ b/chain/transaction.go
@@ -258,10 +258,10 @@ func (t *Transaction) PreExecute(
 	for i, action := range t.Actions {
 		start, end := action.ValidRange(r)
 		if start >= 0 && timestamp < start {
-			return fmt.Errorf("%w: action type %d at index %d", ErrActionNotActivated, action.GetTypeID(), i)
+			return fmt.Errorf("%w: action type %T at index %d", ErrActionNotActivated, action, i)
 		}
 		if end >= 0 && timestamp > end {
-			return fmt.Errorf("%w: action type %d at index %d", ErrActionNotActivated, action.GetTypeID(), i)
+			return fmt.Errorf("%w: action type %T at index %d", ErrActionNotActivated, action, i)
 		}
 	}
 	start, end := t.Auth.ValidRange(r)

--- a/codec/type_parser.go
+++ b/codec/type_parser.go
@@ -9,19 +9,19 @@ import (
 	"github.com/ava-labs/hypersdk/consts"
 )
 
-type decoder[T Typed] struct {
+type decoder[T any] struct {
 	f func([]byte) (T, error)
 }
 
 // The number of types is limited to 255.
-type TypeParser[T Typed] struct {
+type TypeParser[T any] struct {
 	typeToIndex     map[string]uint8
 	indexToDecoder  map[uint8]*decoder[T]
 	registeredTypes []Typed
 }
 
 // NewTypeParser returns an instance of a Typeparser with generic type [T].
-func NewTypeParser[T Typed]() *TypeParser[T] {
+func NewTypeParser[T any]() *TypeParser[T] {
 	return &TypeParser[T]{
 		typeToIndex:     map[string]uint8{},
 		indexToDecoder:  map[uint8]*decoder[T]{},


### PR DESCRIPTION
This PR removes the `GetTypeID()` method from the `Action` interface. `GetTypeID()` is used only for the type parser; since this is a method irrelevant to the actual functionality of an action, we should remove it.