### PR TITLE
feat(load): register tx latency metric

### DIFF
--- a/load/prometheus_tracker.go
+++ b/load/prometheus_tracker.go
@@ -58,6 +58,7 @@ func NewPrometheusTracker[T comparable](reg *prometheus.Registry) (*PrometheusTr
 
 	errs := wrappers.Errs{}
 	errs.Add(
+		reg.Register(prometheusTracker.txLatency),
 		reg.Register(prometheusTracker.txsIssuedCounter),
 		reg.Register(prometheusTracker.txsConfirmedCounter),
 		reg.Register(prometheusTracker.txsFailedCounter),


### PR DESCRIPTION
Load framework was missing latency metric. 

Fixes [this dashboard](https://grafana-poc.avax-dev.network/d/cejpdf8fl064ge/morpheusvm-performance?from=2025-04-29T22:14:46.745Z&to=now&timezone=Europe%2FBelgrade&var-datasource=P1809F7CD0C75ACF3&var-filter=network_uuid%7C%3D%7Ce5752fc2-63d1-4e6e-9fe1-0e0838e916a9&var-filter=is_ephemeral_node%7C%3D%7Cfalse&orgId=1&refresh=5s)